### PR TITLE
Add cfgrib to requirements

### DIFF
--- a/requirements/env_climada.yml
+++ b/requirements/env_climada.yml
@@ -5,6 +5,7 @@ dependencies:
   - blas=1.0
   - bottleneck=1.3.2
   - cartopy=0.17.0
+  - conda-forge::cfgrib=0.9.7.7
   - curl=7.65.3
   - cython=0.29.7
   - dask=1.2.2


### PR DESCRIPTION
Add cfgrib from conda-forge to requirements for dealing with grib and bufr files. Also install ECMWFs eccodes.
Grip files are the standart file format for storing weather forecasts. The ECMWF produces eccodes to deal with this file format and suggest to use cfgrib in python (engine for xarray) to open grip files in python. That is why it is important for my work to somehow read grib files. Is cfgrib compatible with our environment? I was able to install it on windows with Anaconda without any problem.