### PR TITLE
Don't replace NaNs by -1 when estimating TC track parameters

### DIFF
--- a/climada/hazard/tc_tracks.py
+++ b/climada/hazard/tc_tracks.py
@@ -956,42 +956,104 @@ def _dist_since_lf(track):
     return dist_since_lf
 
 def _estimate_pressure(cen_pres, lat, lon, v_max):
-    """Replace missing pressure values with statistical estimate."""
+    """Replace missing pressure values with statistical estimate.
+
+    In addition to NaNs, negative values and zeros in `cen_pres` are interpreted as missing values.
+
+    See function `ibtracs_fit_param` for more details about the statistical estimation:
+
+    >>> ibtracs_fit_param('pres', ['lat', 'lon', 'wind'], year_range=(1980, 2019))
+    >>> r^2: 0.8746154487335112
+
+    Parameters
+    ----------
+    cen_pres : array-like
+        Central pressure values along track in hPa (mbar).
+    lat : array-like
+        Latitudinal coordinates of eye location.
+    lon : array-like
+        Longitudinal coordinates of eye location.
+    v_max : array-like
+        Maximum wind speed along track in knots.
+
+    Returns
+    -------
+    cen_pres_estimated : np.array
+        Estimated central pressure values in hPa (mbar).
+    """
     cen_pres = np.where(np.isnan(cen_pres), -1, cen_pres)
     v_max = np.where(np.isnan(v_max), -1, v_max)
     lat, lon = [np.where(np.isnan(ar), -999, ar) for ar in [lat, lon]]
     msk = (cen_pres <= 0) & (v_max > 0) & (lat > -999) & (lon > -999)
-    # ibtracs_fit_param('pres', ['lat', 'lon', 'wind'], year_range=(1980, 2019))
-    # r^2: 0.8746154487335112
     c_const, c_lat, c_lon, c_vmax = 1024.392, 0.0620, -0.0335, -0.737
     cen_pres[msk] = c_const + c_lat * lat[msk] \
                             + c_lon * lon[msk] \
                             + c_vmax * v_max[msk]
-    return cen_pres
+    return np.where(cen_pres <= 0, np.nan, cen_pres)
 
 def _estimate_vmax(v_max, lat, lon, cen_pres):
-    """Replace missing wind speed values with statistical estimate."""
+    """Replace missing wind speed values with a statistical estimate.
+
+    In addition to NaNs, negative values and zeros in `v_max` are interpreted as missing values.
+
+    See function `ibtracs_fit_param` for more details about the statistical estimation:
+
+    >>> ibtracs_fit_param('wind', ['lat', 'lon', 'pres'], year_range=(1980, 2019))
+    >>> r^2: 0.8717153945288457
+
+    Parameters
+    ----------
+    v_max : array-like
+        Maximum wind speed along track in knots.
+    lat : array-like
+        Latitudinal coordinates of eye location.
+    lon : array-like
+        Longitudinal coordinates of eye location.
+    cen_pres : array-like
+        Central pressure values along track in hPa (mbar).
+
+    Returns
+    -------
+    v_max_estimated : np.array
+        Estimated maximum wind speed values in knots.
+    """
     v_max = np.where(np.isnan(v_max), -1, v_max)
     cen_pres = np.where(np.isnan(cen_pres), -1, cen_pres)
     lat, lon = [np.where(np.isnan(ar), -999, ar) for ar in [lat, lon]]
     msk = (v_max <= 0) & (cen_pres > 0) & (lat > -999) & (lon > -999)
-    # ibtracs_fit_param('wind', ['lat', 'lon', 'pres'], year_range=(1980, 2019))
-    # r^2: 0.8717153945288457
     c_const, c_lat, c_lon, c_pres = 1216.823, 0.0852, -0.0398, -1.182
     v_max[msk] = c_const + c_lat * lat[msk] \
                          + c_lon * lon[msk] \
                          + c_pres * cen_pres[msk]
-    return v_max
+    return np.where(v_max <= 0, np.nan, v_max)
 
 def estimate_roci(roci, cen_pres):
-    """Replace missing radius values with statistical estimate."""
+    """Replace missing radius (ROCI) values with statistical estimate.
+
+    In addition to NaNs, negative values and zeros in `roci` are interpreted as missing values.
+
+    See function `ibtracs_fit_param` for more details about the statistical estimation:
+
+    >>> ibtracs_fit_param('roci', ['pres'],
+    ...                   order=[(872, 950, 985, 1005, 1021)],
+    ...                   year_range=(1980, 2019))
+    >>> r^2: 0.9148320406675339
+
+    Parameters
+    ----------
+    roci : array-like
+        ROCI values along track in km.
+    cen_pres : array-like
+        Central pressure values along track in hPa (mbar).
+
+    Returns
+    -------
+    roci_estimated : np.array
+        Estimated ROCI values in km.
+    """
     roci = np.where(np.isnan(roci), -1, roci)
     cen_pres = np.where(np.isnan(cen_pres), -1, cen_pres)
     msk = (roci <= 0) & (cen_pres > 0)
-    # ibtracs_fit_param('roci', ['pres'],
-    #                   order=[(872, 950, 985, 1005, 1021)],
-    #                   year_range=(1980, 2019))
-    # r^2: 0.9148320406675339
     pres_l = [872, 950, 985, 1005, 1021]
     roci_l = [210.711487, 215.897110, 198.261520, 159.589508, 90.900116]
     roci[msk] = 0
@@ -1000,15 +1062,33 @@ def estimate_roci(roci, cen_pres):
         slope_1 = 1. / (pres_l[i + 1] - pres_l_i) if i + 1 < len(pres_l) else 0
         roci[msk] += roci_l[i] * np.fmax(0, (1 - slope_0 * np.fmax(0, pres_l_i - cen_pres[msk])
                                              - slope_1 * np.fmax(0, cen_pres[msk] - pres_l_i)))
-    return roci
+    return np.where(roci <= 0, np.nan, roci)
 
 def estimate_rmw(rmw, cen_pres):
-    """Replace missing radius values with statistical estimate."""
+    """Replace missing radius (RMW) values with statistical estimate.
+
+    In addition to NaNs, negative values and zeros in `rmw` are interpreted as missing values.
+
+    See function `ibtracs_fit_param` for more details about the statistical estimation:
+
+    >>> ibtracs_fit_param('rmw', ['pres'], order=[(872, 940, 980, 1021)], year_range=(1980, 2019))
+    >>> r^2: 0.7905970811843872
+
+    Parameters
+    ----------
+    rmw : array-like
+        RMW values along track in km.
+    cen_pres : array-like
+        Central pressure values along track in hPa (mbar).
+
+    Returns
+    -------
+    rmw : np.array
+        Estimated RMW values in km.
+    """
     rmw = np.where(np.isnan(rmw), -1, rmw)
     cen_pres = np.where(np.isnan(cen_pres), -1, cen_pres)
     msk = (rmw <= 0) & (cen_pres > 0)
-    # ibtracs_fit_param('rmw', ['pres'], order=[(872, 940, 980, 1021)], year_range=(1980, 2019))
-    # r^2: 0.7905970811843872
     pres_l = [872, 940, 980, 1021]
     rmw_l = [14.907318, 15.726927, 25.742142, 56.856522]
     rmw[msk] = 0
@@ -1017,7 +1097,7 @@ def estimate_rmw(rmw, cen_pres):
         slope_1 = 1. / (pres_l[i + 1] - pres_l_i) if i + 1 < len(pres_l) else 0
         rmw[msk] += rmw_l[i] * np.fmax(0, (1 - slope_0 * np.fmax(0, pres_l_i - cen_pres[msk])
                                            - slope_1 * np.fmax(0, cen_pres[msk] - pres_l_i)))
-    return rmw
+    return np.where(rmw <= 0, np.nan, rmw)
 
 def ibtracs_fit_param(explained, explanatory, year_range=(1980, 2019), order=1):
     """Statistically fit an ibtracs parameter to other ibtracs variables

--- a/climada/hazard/test/test_tc_tracks.py
+++ b/climada/hazard/test/test_tc_tracks.py
@@ -481,31 +481,35 @@ class TestFuncs(unittest.TestCase):
         cat = tc.set_category(max_sus_wind, max_sus_wind_unit)
         self.assertEqual(4, cat)
 
-    def test_estimate_pres_pass(self):
-        """Test central pressure estimation function."""
-        cen_pres = np.array([
-            -999, -999, -999, -999, -999, -999, -999, -999, -999, 992, -999,
-            -999, 993, -999, -999, 1004
-        ], dtype=float)
-        v_max = np.array([
-            45, 50, 50, 55, 60, 65, 70, 80, 75, 70, 70, 70, 70, 65, 55, 45
-        ], dtype=float)
-        lat = np.array([
-            13.8, 13.9, 14, 14.1, 14.1, 14.1, 14.1, 14.2, 14.2, 14.3, 14.4,
-            14.6, 14.8, 15, 15.1, 15.1
-        ])
-        lon = np.array([
-            -51.1, -52.8, -54.4, -56, -57.3, -58.4, -59.7, -61.1, -62.7, -64.3,
-            -65.8, -67.4, -69.4, -71.4, -73, -74.2
-        ])
+    def test_estimate_params_pass(self):
+        """Test track parameter estimation functions."""
+        cen_pres = np.array([-999, 993, np.nan, -1, 0, 1004, np.nan])
+        v_max = np.array([45, np.nan, 50, 55, 0, 60, 75])
+        lat = np.array([13.8, 13.9, 14, 14.1, 14.1, np.nan, -999])
+        lon = np.array([np.nan, -52.8, -54.4, -56, -58.4, -59.7, -61.1])
+        ref_pres = np.array([np.nan, 993, 990.2324, 986.6072, np.nan, 1004, np.nan])
         out_pres = tc._estimate_pressure(cen_pres, lat, lon, v_max)
+        self.assertTrue(np.allclose(ref_pres, out_pres, equal_nan=True))
 
-        ref_res = np.array([
-            993.79445, 990.1726, 990.2324, 986.6072, 982.96575, 979.3176,
-            975.67615, 968.35925, 972.09785, 992., 975.8991, 975.9651, 993.,
-            979.8089, 987.2387, 1004.
-        ])
-        self.assertTrue(np.allclose(ref_res, out_pres))
+        v_max = np.array([45, np.nan, 50, 55, 0, 60, 75])
+        cen_pres = np.array([-999, 993, np.nan, -1, 0, 1004, np.nan])
+        lat = np.array([13.8, 13.9, 14, 14.1, 14.1, np.nan, -999])
+        lon = np.array([np.nan, -52.8, -54.4, -56, -58.4, -59.7, -61.1])
+        ref_vmax = np.array([45, 46.38272, 50, 55, np.nan, 60, 75])
+        out_vmax = tc._estimate_vmax(v_max, lat, lon, cen_pres)
+        self.assertTrue(np.allclose(ref_vmax, out_vmax, equal_nan=True))
+
+        roci = np.array([np.nan, -1, 145, 170, 180, 0, -5])
+        cen_pres = np.array([-999, 993, np.nan, -1, 0, 1004, np.nan])
+        ref_roci = np.array([np.nan, 182.792715, 145, 170, 180, 161.5231086, np.nan])
+        out_roci = tc.estimate_roci(roci, cen_pres)
+        self.assertTrue(np.allclose(ref_roci, out_roci, equal_nan=True))
+
+        rmw = np.array([17, 33, -1, 25, np.nan, -5, 13])
+        cen_pres = np.array([-999, 993, np.nan, -1, 0, 1004, np.nan])
+        ref_rmw = np.array([17, 33, np.nan, 25, np.nan, 43.95543761, 13])
+        out_rmw = tc.estimate_rmw(rmw, cen_pres)
+        self.assertTrue(np.allclose(ref_rmw, out_rmw, equal_nan=True))
 
     def test_estimate_rmw_pass(self):
         """Test estimate_rmw function."""


### PR DESCRIPTION
This is a fix for #62. I took the opportunity to add docstrings and unit tests for all the parameter estimation functions.

I would suggest @bguillod as a reviewer because he's already familiar with the problem, but somehow I can't select him (?).