### PR TITLE
fix test

### DIFF
--- a/climada/hazard/test/test_tc_tracks.py
+++ b/climada/hazard/test/test_tc_tracks.py
@@ -138,7 +138,8 @@ class TestIBTracs(unittest.TestCase):
         tc_track = tc.TCTracks()
         tc_track.read_ibtracs_netcdf(provider='usa', year_range=(1993, 1994),
                                      basin='EP', estimate_missing=True)
-        self.assertEqual(tc_track.size, 53)
+        self.assertEqual(tc_track.size, 52)
+        # actually 53, but dataset 46, PAT, is empty
 
     def test_ibtracs_correct_pass(self):
         """Check estimate_missing option"""

--- a/climada/hazard/test/test_tc_tracks.py
+++ b/climada/hazard/test/test_tc_tracks.py
@@ -139,7 +139,6 @@ class TestIBTracs(unittest.TestCase):
         tc_track.read_ibtracs_netcdf(provider='usa', year_range=(1993, 1994),
                                      basin='EP', estimate_missing=True)
         self.assertEqual(tc_track.size, 52)
-        # actually 53, but dataset 46, PAT, is empty
 
     def test_ibtracs_correct_pass(self):
         """Check estimate_missing option"""


### PR DESCRIPTION
with pull request #63 one of the datasets got filtered out in `TCTracks().read_ibtracs_netcdf(rovider='usa', year_range=(1993, 1994),basin='EP', estimate_missing=True)`:
```
Frozen(OrderedDict([('time_step', <xarray.Variable (time: 13)>
array([10800.00004045, 10800.        , 10800.        , 10800.        ,
       10800.        , 10800.        , 10800.        , 10800.        ,
       10800.        , 10800.        , 10800.        , 10800.        ,
       10800.        ])), ('radius_max_wind', <xarray.Variable (time: 13)>
array([0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.], dtype=float32)), ('radius_oci', <xarray.Variable (time: 13)>
array([0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.], dtype=float32)), ('max_sustained_wind', <xarray.Variable (time: 13)>
array([-1., -1., -1., -1., -1., -1., -1., -1., -1., -1., -1., -1., -1.],
      dtype=float32)), ('central_pressure', <xarray.Variable (time: 13)>
array([-1., -1., -1., -1., -1., -1., -1., -1., -1., -1., -1., -1., -1.],
      dtype=float32)), ('environmental_pressure', <xarray.Variable (time: 13)>
array([1005., 1005., 1005., 1005., 1005., 1005., 1005., 1005., 1005.,
       1005., 1005., 1010., 1010.])), ('time', <xarray.IndexVariable 'time' (time: 13)>
array(['1994-09-29T00:00:00.000000000', '1994-09-29T03:00:00.000000000',
       '1994-09-29T06:00:00.000000000', '1994-09-29T09:00:00.000000000',
       '1994-09-29T12:00:00.000000000', '1994-09-29T15:00:00.000000000',
       '1994-09-29T18:00:00.000000000', '1994-09-29T21:00:00.000000000',
       '1994-09-30T00:00:00.000000000', '1994-09-30T03:00:00.000000000',
       '1994-09-30T06:00:00.000000000', '1994-09-30T09:00:00.000000000',
       '1994-09-30T12:00:00.000000000'], dtype='datetime64[ns]')), ('lat', <xarray.Variable (time: 13)>
array([39.5     , 39.745296, 40.      , 40.275566, 40.5     , 40.498066,
       40.5     , 40.728046, 41.000004, 40.92378 , 41.      , 41.62489 ,
       42.5     ], dtype=float32)), ('lon', <xarray.Variable (time: 13)>
array([159.     , 160.34946, 162.     , 163.51527, 165.     , 166.505  ,
       168.     , 169.1625 , 171.     , 174.29718, 178.5    , 183.1068 ,
       188.     ], dtype=float32))]))
```

Accept this pull request if it makes sense to omit that dataset.\
If the dataset should not be filtered out - we have an issue.