### PR TITLE
Hazard.select: accept general array-likes as date parameter

### DIFF
--- a/climada/hazard/base.py
+++ b/climada/hazard/base.py
@@ -527,23 +527,29 @@ class Hazard():
             raise var_err
 
     def select(self, event_names=None, date=None, orig=None, reg_id=None, reset_frequency=False):
-        """Select events within provided date and/or (historical or synthetical)
-        and/or region. Frequency of the events may need to be recomputed!
+        """Select events matching provided criteria
 
-        Parameters:
-            event_names (list(str), optional): names of event
-            date (tuple(str or int), optional): (initial date, final date) in
-                string ISO format ('2011-01-02') or datetime ordinal integer
-            orig (bool, optional): select only historical (True) or only
-                synthetic (False)
-            reg_id (int, optional): region identifier of the centroids's
-                region_id attibute
-            reset_frequency (boolean): change frequency of events proportional to
-                difference between first and last year (old and new)
-                default = False
+        The frequency of events may need to be recomputed (see `reset_frequency`)!
 
-        Returns:
-            Hazard or children
+        Parameters
+        ----------
+        event_names : list of str, optional
+            Names of events.
+        date : array-like of length 2 containing str or int, optional
+            (initial date, final date) in string ISO format ('2011-01-02') or datetime
+            ordinal integer.
+        orig : bool, optional
+            Select only historical (True) or only synthetic (False) events.
+        reg_id : int, optional
+            Region identifier of the centroids' region_id attibute.
+        reset_frequency : bool, optional
+            Change frequency of events proportional to difference between first and last
+            year (old and new). Default: False.
+
+        Returns
+        -------
+        haz : Hazard or None
+            If no event matching the specified criteria is found, None is returned.
         """
         if type(self) is Hazard:
             haz = Hazard(self.tag.haz_type)
@@ -553,8 +559,8 @@ class Hazard():
         sel_cen = np.ones(self.centroids.size, dtype=bool)
 
         # filter events by date
-        if isinstance(date, tuple):
-            date_ini, date_end = date[0], date[1]
+        if date is not None:
+            date_ini, date_end = date
             if isinstance(date_ini, str):
                 date_ini = u_dt.str_to_date(date[0])
                 date_end = u_dt.str_to_date(date[1])

--- a/climada/hazard/test/test_base.py
+++ b/climada/hazard/test/test_base.py
@@ -425,6 +425,28 @@ class TestSelect(unittest.TestCase):
         sel_haz = haz.select(date=(6, 8), orig=False)
         self.assertEqual(sel_haz, None)
 
+    def test_select_date_invalid_pass(self):
+        """Test select with invalid date values"""
+        haz = dummy_hazard()
+
+        # lists and numpy arrays should work just like tuples
+        sel_haz = haz.select(date=['0001-01-02', '0001-01-03'])
+        self.assertTrue(np.array_equal(sel_haz.date, np.array([2, 3])))
+        sel_haz = haz.select(date=np.array([2, 4]))
+        self.assertTrue(np.array_equal(sel_haz.date, np.array([2, 3, 4])))
+
+        # iterables of length not exactly 2 are invalid
+        with self.assertRaises(ValueError) as context:
+            haz.select(date=(3,))
+        self.assertTrue("not enough values to unpack" in str(context.exception))
+        with self.assertRaises(ValueError) as context:
+            haz.select(date=(1, 2, 3))
+        self.assertTrue("too many values to unpack" in str(context.exception))
+
+        # only strings and numbers are valid
+        with self.assertRaises(TypeError) as context:
+            haz.select(date=({}, {}))
+
     def test_select_reg_id_pass(self):
         """Test select region of centroids."""
         haz = dummy_hazard()


### PR DESCRIPTION
I ran into a problem where I wanted to filter hazard events by date and my filtering criterion was silently (!) ignored. This is because the `date` parameter in `Hazard.select` was ignored unless it was a `tuple` object. Passing a list `[date_ini, date_end]` did not work!

This pull request changes this behaviour and adds unit tests to make sure that valid inputs aren't ignored and invalid inputs raise exceptions. Furthermore, it updates the docstring of `Hazard.select`.

All unit tests on Jenkins are successful (see https://ied-wcr-jenkins.ethz.ch/job/climada_branches/job/feature%252Fhazard_select_date_invalid/).