### PR TITLE
Feature/fix plot rp intensity

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -16,3 +16,4 @@ Mannie Kam
 Simona Meiler
 Alessio Ciullo
 Thomas Vogt
+Chahan Kropf

--- a/climada/hazard/base.py
+++ b/climada/hazard/base.py
@@ -685,7 +685,7 @@ class Hazard():
         title = list()
         for ret in return_periods:
             title.append('Return period: ' + str(ret) + ' years')
-        _, axis = u_plot.geo_im_from_array(inten_stats, self.centroids.coord,
+        axis = u_plot.geo_im_from_array(inten_stats, self.centroids.coord,
                                            colbar_name, title, smooth=smooth,
                                            axes=axis, **kwargs)
         return axis, inten_stats


### PR DESCRIPTION
This is a simple fix for issue #74 . Now the function hazard.plot_rp_intensity returns the full set of subplots. There is no more unpacking to be done, and hence one can specify a single return period.