### PR TITLE
Feature/rc add scenario rcp26

### DIFF
--- a/climada/hazard/relative_cropyield.py
+++ b/climada/hazard/relative_cropyield.py
@@ -172,7 +172,8 @@ class RelativeCropyield(Hazard):
             ag_model, cl_model, _, _, soc, co2, crop_prop, *_ = filename.split('_')
             _, crop, irr = crop_prop.split('-')
             filename = os.path.join(input_dir, filename)
-        elif '_%i_%i.nc' %(YEARCHUNKS[scenario]['startyear'], YEARCHUNKS[scenario]['endyear']) in filename:
+        elif '_%i_%i.nc' %(YEARCHUNKS[scenario]['startyear'], YEARCHUNKS[scenario]['endyear']) \
+            in filename:
             yearchunk = YEARCHUNKS[scenario]
             (_, _, _, _, _, _, crop_irr, *_) = filename.split('_')
             _, crop, irr = crop_irr.split('-')
@@ -521,9 +522,10 @@ def generate_full_hazard_set(input_dir=INPUT_DIR, output_dir=OUTPUT_DIR, bbox=BB
                                       YEARCHUNKS[scenario]['startyear'],
                                       YEARCHUNKS[scenario]['endyear'])
 
-                if os.path.isfile(os.path.join(input_dir, fut_file)): # if true, calculate and save future hazard set:
+                if os.path.isfile(os.path.join(input_dir, fut_file)):
+                    # if true, calculate and save future hazard set:
                     haz_fut, filename = calc_fut_haz(his_file, scenario, file_props, hist_mean,
-                                                 input_dir, bbox, fut_file=fut_file)
+                                                     input_dir, bbox, fut_file=fut_file)
                     filename_list.append(filename)
                     output_list.append(haz_fut)
                 if scenario == 'rcp26': # also test for extended
@@ -540,9 +542,10 @@ def generate_full_hazard_set(input_dir=INPUT_DIR, output_dir=OUTPUT_DIR, bbox=BB
                                           YEARCHUNKS['rcp26-2']['startyear'],
                                           YEARCHUNKS['rcp26-2']['endyear'])
 
-                    if os.path.isfile(os.path.join(input_dir, fut_file)): # if true, calculate and save future hazard set:
+                    if os.path.isfile(os.path.join(input_dir, fut_file)):
+                        # if true, calculate and save future hazard set:
                         haz_fut, filename = calc_fut_haz(his_file, scenario, file_props, hist_mean,
-                                                     input_dir, bbox, fut_file=fut_file)
+                                                         input_dir, bbox, fut_file=fut_file)
                         filename_list.append(filename)
                         output_list.append(haz_fut)
     # calculate mean hist_mean for each crop-irrigation combination and save as hdf5 in output_dir
@@ -722,7 +725,8 @@ def calc_his_haz(his_file, file_props, input_dir=INPUT_DIR, bbox=BBOX, yearrange
 
     return haz_his, filename, hist_mean
 
-def calc_fut_haz(his_file, scenario, file_props, hist_mean, input_dir=INPUT_DIR, bbox=BBOX, fut_file=None):
+def calc_fut_haz(his_file, scenario, file_props, hist_mean, input_dir=INPUT_DIR, bbox=BBOX,
+                 fut_file=None):
 
     """Create future hazard.
 

--- a/climada/hazard/relative_cropyield.py
+++ b/climada/hazard/relative_cropyield.py
@@ -69,7 +69,12 @@ YEARCHUNKS['historical'] = {'yearrange': np.array([1976, 2005]), 'startyear': 18
 
 YEARCHUNKS['rcp26'] = dict()
 YEARCHUNKS['rcp26'] = {'yearrange': np.array([2006, 2099]), 'startyear': 2006,
-                       'endyear': 2099} # not yet implemented for RCP2.6 runs from 2100 to 2299.
+                       'endyear': 2099}
+
+YEARCHUNKS['rcp26-2'] = dict() # future extended (rcp26, 2100-2299) works for set_from_single_run, 
+                               # but not yet implemented for generate_full_hazard_set
+YEARCHUNKS['rcp26-2'] = {'yearrange': np.array([2100, 2299]), 'startyear': 2006,
+                       'endyear': 2299}
 YEARCHUNKS['rcp60'] = dict()
 YEARCHUNKS['rcp60'] = {'yearrange': np.array([2006, 2099]), 'startyear': 2006,
                        'endyear': 2099}
@@ -168,14 +173,18 @@ class RelativeCropyield(Hazard):
             ag_model, cl_model, _, _, soc, co2, crop_prop, *_ = filename.split('_')
             _, crop, irr = crop_prop.split('-')
             filename = os.path.join(input_dir, filename)
-        else:
+        elif '_%i_%i.nc' %(YEARCHUNKS[scenario]['startyear'], YEARCHUNKS[scenario]['endyear']) in filename:
             yearchunk = YEARCHUNKS[scenario]
             (_, _, _, _, _, _, crop_irr, *_) = filename.split('_')
             _, crop, irr = crop_irr.split('-')
             filename = os.path.join(input_dir, filename)
-
-
-
+        else: # backup: get yearchunk from filename
+            (_, _, _, _, _, _, crop_irr, _, _, year1, year2) = filename.split('_')
+            yearchunk = {'yearrange': np.array([int(year1), int(year2.split('.')[0])]),
+                         'startyear': int(year1),
+                         'endyear': int(year2.split('.')[0])}
+            _, crop, irr = crop_irr.split('-')
+            filename = os.path.join(input_dir, filename)
 
         # define indexes of the netcdf-bands to be extracted, and the
         # corresponding event names and dates

--- a/climada/hazard/relative_cropyield.py
+++ b/climada/hazard/relative_cropyield.py
@@ -73,7 +73,7 @@ YEARCHUNKS['rcp26'] = {'yearrange': np.array([2006, 2099]), 'startyear': 2006,
 
 YEARCHUNKS['rcp26-2'] = dict()
 YEARCHUNKS['rcp26-2'] = {'yearrange': np.array([2100, 2299]), 'startyear': 2100,
-                       'endyear': 2299}
+                         'endyear': 2299}
 YEARCHUNKS['rcp60'] = dict()
 YEARCHUNKS['rcp60'] = {'yearrange': np.array([2006, 2099]), 'startyear': 2006,
                        'endyear': 2099}
@@ -662,7 +662,8 @@ def init_hazard_set(filenames, input_dir=INPUT_DIR, bbox=BBOX, isimip_run='ISIMI
     # ensure that all files are assigned to the corresponding crop-irr combination
     hist_mean_per_crop = dict()
     for crop_irr in crop_list:
-        amount_crop_irr = sum(crop_irr in s for s in his_file_list)
+        crop, irr = crop_irr.split('-')
+        amount_crop_irr = sum((crop in s) and (irr in s) for s in his_file_list)
         hist_mean_per_crop[crop_irr] = dict()
         hist_mean_per_crop[crop_irr] = {
             'value': np.zeros([amount_crop_irr, haz_dummy.intensity.shape[1]]),


### PR DESCRIPTION
Before, RelativeCropyield could only be initiated for RCP6.0 and historical data (ISIMIP2b) as well as ISIMIP2a runs.
This feature enables the integration of RCP2.6, RCP8.0, as well as RCP2.6 extended (2100-2299) runs from ISIMIP2b as well.

Some workarounds were required to differentiate between the yearchunks for the two RCP2.6 file types.