### PR TITLE
Improve performance of wind field computation

### DIFF
--- a/climada/hazard/tc_tracks.py
+++ b/climada/hazard/tc_tracks.py
@@ -669,9 +669,10 @@ class TCTracks():
             last_perc = 0
             new_data = []
             for track in self.data:
+                # progress indicator
                 perc = 100 * len(new_data) / len(self.data)
                 if perc - last_perc >= 10:
-                    LOGGER.info("Progress: %d%%", perc)
+                    LOGGER.debug("Progress: %d%%", perc)
                     last_perc = perc
                 new_data.append(
                     self._one_interp_data(track, time_step_h, land_geom))

--- a/climada/hazard/tc_tracks.py
+++ b/climada/hazard/tc_tracks.py
@@ -515,7 +515,7 @@ class TCTracks():
                     hours[i_track, valid_idx[reference_idx]],)
                 datetimes = [reference_date + dt.timedelta(hours=int(step * i))
                              for i in range(nnodes)]
-            datetimes = np.array(datetimes)
+            datetimes = np.array(datetimes, dtype=np.datetime64)
 
             max_sustained_wind = tc_maxwind[i_track, valid_idx]
             max_sustained_wind_unit = 'kn'
@@ -666,10 +666,15 @@ class TCTracks():
                                       itertools.repeat(land_geom, self.size),
                                       chunksize=chunksize)
         else:
-            new_data = list()
+            last_perc = 0
+            new_data = []
             for track in self.data:
-                new_data.append(self._one_interp_data(track, time_step_h,
-                                                      land_geom))
+                perc = 100 * len(new_data) / len(self.data)
+                if perc - last_perc >= 10:
+                    LOGGER.info("Progress: %d%%", perc)
+                    last_perc = perc
+                new_data.append(
+                    self._one_interp_data(track, time_step_h, land_geom))
             self.data = new_data
 
     def calc_random_walk(self, **kwargs):

--- a/climada/hazard/test/test_trop_cyclone.py
+++ b/climada/hazard/test/test_trop_cyclone.py
@@ -156,8 +156,26 @@ class TestReader(unittest.TestCase):
         self.assertEqual(tc_haz.fraction.nonzero()[0].size, 0)
         self.assertEqual(tc_haz.intensity.nonzero()[0].size, 0)
 
-class TestModel(unittest.TestCase):
-    """Test modelling of tropical cyclone"""
+class TestWindfieldHelpers(unittest.TestCase):
+    """Test helper functions of TC wind field model"""
+
+    def test_close_centroids_pass(self):
+        """Test _close_centroids function."""
+        t_lat = np.array([0, 0, 0])
+        t_lon = np.array([1, 2, 3])
+        centroids = np.array([[0, 0], [0, 0.9], [-0.9, 1.2], [1, 2.1], [0, 4], [0.5, 3.8]])
+        test_mask = np.array([False, True, True, False, False, True])
+        mask = tc._close_centroids(t_lat, t_lon, centroids, buffer=1)
+        np.testing.assert_equal(mask, test_mask)
+
+        # example where antimeridian is crossed
+        t_lat = np.linspace(-10, 10, 11)
+        t_lon = np.linspace(170, 200, 11)
+        t_lon[t_lon > 180] -= 360
+        centroids = np.array([[-11, 169], [-7, 176], [4, -170], [10, 170], [-10, -160]])
+        test_mask = np.array([True, True, True, False, False])
+        mask = tc._close_centroids(t_lat, t_lon, centroids, buffer=5)
+        np.testing.assert_equal(mask, test_mask)
 
     def test_bs_hol08_pass(self):
         """Test _bs_hol08 function. Compare to MATLAB reference."""
@@ -311,6 +329,6 @@ class TestClimateSce(unittest.TestCase):
 
 if __name__ == "__main__":
     TESTS = unittest.TestLoader().loadTestsFromTestCase(TestReader)
-    TESTS.addTests(unittest.TestLoader().loadTestsFromTestCase(TestModel))
+    TESTS.addTests(unittest.TestLoader().loadTestsFromTestCase(TestWindfieldHelpers))
     TESTS.addTests(unittest.TestLoader().loadTestsFromTestCase(TestClimateSce))
     unittest.TextTestRunner(verbosity=2).run(TESTS)

--- a/climada/hazard/trop_cyclone.py
+++ b/climada/hazard/trop_cyclone.py
@@ -387,8 +387,8 @@ def compute_windfields(track, centroids, model):
 
     Returns
     -------
-    windfield : np.array of shape (npositions, nreachable, 2)
-        A directional wind field for each track position on those centroids within reach
+    windfields : np.array of shape (npositions, nreachable, 2)
+        Directional wind fields for each track position on those centroids within reach
         of the TC track.
     reachable_centr_idx : np.array of shape (nreachable,)
         List of indices of input centroids within reach of the TC track.
@@ -400,6 +400,16 @@ def compute_windfields(track, centroids, model):
                                            'environmental_pressure', 'central_pressure']
     ]
 
+    # start with the assumption that no centroids are within reach
+    npositions = t_lat.shape[0]
+    reachable_centr_idx = np.zeros((0,), dtype=np.int64)
+    windfields = np.zeros((npositions, 0, 2), dtype=np.float64)
+
+    # the wind field model requires at least two track positions because translational speed
+    # as well as the change in pressure are required
+    if npositions < 2:
+        return windfields, reachable_centr_idx
+
     # never use longitudes at -180 degrees or below
     t_lon[t_lon <= -180] += 360
 
@@ -407,35 +417,24 @@ def compute_windfields(track, centroids, model):
     if t_lon.min() > 180:
         t_lon -= 360
 
-    # restrict to centroids in rectangular bounding box around track
+    # restrict to centroids within rectangular bounding boxes around track positions
     track_centr_msk = _close_centroids(t_lat, t_lon, centroids)
     track_centr = centroids[track_centr_msk]
-
     nreachable = track_centr.shape[0]
-    npositions = t_lat.shape[0]
-    windfields = np.zeros((npositions, nreachable, 2))
-    [reachable_centr_idx] = track_centr_msk.nonzero()
-
-    # the wind field model requires at least two track positions because translational speed
-    # as well as the change in pressure are required
-    if t_lon.size < 2:
-        return windfields, reachable_centr_idx
-
-    if track_centr.shape[0] == 0:
+    if nreachable == 0:
         return windfields, reachable_centr_idx
 
     # compute distances and vectors to all centroids
-    d_centr, v_centr = [ar[0] for ar in dist_approx(
-        t_lat[None], t_lon[None],
-        track_centr[None, :, 0], track_centr[None, :, 1],
-        log=True, method="geosphere")]
+    [d_centr], [v_centr] = dist_approx(t_lat[None], t_lon[None],
+                                       track_centr[None, :, 0], track_centr[None, :, 1],
+                                       log=True, method="geosphere")
 
     # exclude centroids that are too far from or too close to the eye
-    close_centr = (d_centr < CENTR_NODE_MAX_DIST_KM) & (d_centr > 1e-2)
-    if not np.any(close_centr):
+    close_centr_msk = (d_centr < CENTR_NODE_MAX_DIST_KM) & (d_centr > 1e-2)
+    if not np.any(close_centr_msk):
         return windfields, reachable_centr_idx
     v_centr_normed = np.zeros_like(v_centr)
-    v_centr_normed[close_centr] = v_centr[close_centr] / d_centr[close_centr, None]
+    v_centr_normed[close_centr_msk] = v_centr[close_centr_msk] / d_centr[close_centr_msk, None]
 
     # make sure that central pressure never exceeds environmental pressure
     pres_exceed_msk = (t_cen > t_env)
@@ -462,15 +461,15 @@ def compute_windfields(track, centroids, model):
 
     # derive angular velocity
     v_ang_norm = _stat_holland(d_centr[1:], t_rad[1:], hol_b, t_env[1:],
-                               t_cen[1:], t_lat[1:], close_centr[1:])
+                               t_cen[1:], t_lat[1:], close_centr_msk[1:])
     hemisphere = 'N'
     if np.count_nonzero(t_lat < 0) > np.count_nonzero(t_lat > 0):
         hemisphere = 'S'
     v_ang_rotate = [1.0, -1.0] if hemisphere == 'N' else [-1.0, 1.0]
     v_ang_dir = np.array(v_ang_rotate)[..., :] * v_centr_normed[1:, :, ::-1]
     v_ang = np.zeros_like(v_ang_dir)
-    v_ang[close_centr[1:]] = v_ang_norm[close_centr[1:], None] \
-                             * v_ang_dir[close_centr[1:]]
+    v_ang[close_centr_msk[1:]] = v_ang_norm[close_centr_msk[1:], None] \
+                                 * v_ang_dir[close_centr_msk[1:]]
 
     # Influence of translational speed decreases with distance from eye.
     # The "absorbing factor" is according to the following paper (see Fig. 7):
@@ -482,45 +481,57 @@ def compute_windfields(track, centroids, model):
     #
     t_rad_bc = np.broadcast_arrays(t_rad[:, None], d_centr)[0]
     v_trans_corr = np.zeros_like(d_centr)
-    v_trans_corr[close_centr] = np.fmin(1, t_rad_bc[close_centr] / d_centr[close_centr])
+    v_trans_corr[close_centr_msk] = np.fmin(
+        1, t_rad_bc[close_centr_msk] / d_centr[close_centr_msk])
 
     # add angular and corrected translational velocity vectors
     v_full = v_trans[1][1:, None, :] * v_trans_corr[1:, :, None] + v_ang
     v_full[np.isnan(v_full)] = 0
 
+    windfields = np.zeros((npositions, nreachable, 2), dtype=np.float64)
     windfields[1:, :, :] = v_full
+    [reachable_centr_idx] = track_centr_msk.nonzero()
     return windfields, reachable_centr_idx
 
-def _close_centroids(t_lat, t_lon, centroids):
-    """Choose centroids within padded rectangular region around track
+def _close_centroids(t_lat, t_lon, centroids, buffer=CENTR_NODE_MAX_DIST_DEG):
+    """Check whether centroids lay within rectangular buffer around track positions
 
-    Parameters:
-        t_lat (np.array): latitudinal coordinates of track points
-        t_lon (np.array): longitudinal coordinates of track points
-        centroids (np.array): coordinates of centroids to check
+    Parameters
+    ----------
+    t_lat : np.array of shape (npositions,)
+        Latitudinal coordinates of track positions.
+    t_lon : np.array of shape (npositions,)
+        Longitudinal coordinates of track positions.
+    centroids : np.array of shape (ncentroids, 2)
+        Coordinates of centroids, each row is a pair [lat, lon].
+    buffer : float (optional)
+        Size of the buffer. Default: CENTR_NODE_MAX_DIST_DEG.
 
-    Returns:
-        np.array (mask)
+    Returns
+    -------
+    mask : np.array of shape (ncentroids,)
+        Mask that is True for close centroids and False for other centroids.
     """
-    if (t_lon < -170).any() and (t_lon > 170).any():
-        # crosses 180 degrees east/west -> use positive degrees east
-        t_lon[t_lon < 0] += 360
+    eye_bounds = np.c_[t_lon, t_lat, t_lon, t_lat]
+    eye_bounds[:,:2] -= buffer
+    eye_bounds[:,2:] += buffer
 
-    track_bounds = np.array([t_lon.min(), t_lat.min(), t_lon.max(), t_lat.max()])
-    track_bounds[:2] -= CENTR_NODE_MAX_DIST_DEG
-    track_bounds[2:] += CENTR_NODE_MAX_DIST_DEG
-    if track_bounds[2] > 180:
-        # crosses 180 degrees East/West
-        track_bounds[2] -= 360
+    # rectangle crosses antimeridian:
+    eye_bounds[eye_bounds[:,0] <= -180,0] += 360
+    eye_bounds[eye_bounds[:,2] > 180,2] -= 360
 
     centr_lat, centr_lon = centroids[:, 0], centroids[:, 1]
-    msk_lat = (track_bounds[1] < centr_lat) & (centr_lat < track_bounds[3])
-    if track_bounds[2] < track_bounds[0]:
-        # crosses 180 degrees East/West
-        msk_lon = (track_bounds[0] < centr_lon) | (centr_lon < track_bounds[2])
-    else:
-        msk_lon = (track_bounds[0] < centr_lon) & (centr_lon < track_bounds[2])
-    return msk_lat & msk_lon
+    msk_lat = ((eye_bounds[:,None,1] < centr_lat[None])
+               & (centr_lat[None] < eye_bounds[:,None,3]))
+
+    # rectangle might cross antimeridian or not
+    msk_lon_crosses = (eye_bounds[:,2] < eye_bounds[:,0])
+    msk_lon_within = ~msk_lon_crosses
+    msk_lon = (eye_bounds[:,None,0] < centr_lon[None])
+    msk_lon_upper = (centr_lon[None] < eye_bounds[:,None,2])
+    msk_lon[msk_lon_crosses] |= msk_lon_upper[msk_lon_crosses]
+    msk_lon[msk_lon_within] &= msk_lon_upper[msk_lon_within]
+    return (msk_lat & msk_lon).any(axis=0)
 
 def _vtrans(t_lat, t_lon, t_tstep):
     """Translational vector and velocity at each track node.


### PR DESCRIPTION
*Statement of the problem that this PR is trying to solve:* If the number of centroids is very large (e.g. if it is a global grid of comparably high resolution), the current wind field computation requires prohibitive amounts of memory. This is because, for each track, a dense windfield array is allocated covering all centroids - even those that are far away from the TC track: https://github.com/CLIMADA-project/climada_python/blob/6c27a6120815dde71fe0995ab5f8c963d33398bc/climada/hazard/trop_cyclone.py#L390

*Solution proposed by this PR:* We make sure that only those centroids in the direct vicinity of each TC track (the "reachable" centroids) are regarded in the wind field computation so that computational performance will only depend on the *resolution* of the centroids and not on the *total area covered* by the centroids:
https://github.com/CLIMADA-project/climada_python/blob/26ceaa3600fe693ecc961c7d312fd6eba8f0e049/climada/hazard/trop_cyclone.py#L409-L416

This does not change the API function `TropCyclone.set_from_track`, neither its structure nor its output, but only its overall performance. The changes do not affect performance of regional studies where centroids cover a comparably small area of the globe.

*Changes unrelated to the main topic of this PR:* While testing this functionality, I noticed that `TCTracks.equal_timestep` can take quite some time and decided to add a progress indicator for the convenience of CLIMADA users.