### PR TITLE
TCTracks: interpolate with arbitrary resolution

### DIFF
--- a/climada/hazard/tc_tracks.py
+++ b/climada/hazard/tc_tracks.py
@@ -887,15 +887,18 @@ class TCTracks():
             LOGGER.info("Progress: 100%")
 
     def equal_timestep(self, time_step_h=1, land_params=False):
-        """Generate interpolated track values to time steps of min_time_step.
-        Parameters:
-            time_step_h (float, optional): time step in hours to which to
-                interpolate. Default: 1.
-            land_params (bool, optional): compute on_land and dist_since_lf at
-                each node. Default: False.
+        """Generate interpolated track values to time steps of time_step_h.
+
+        Parameters
+        ----------
+        time_step_h : float or int, optional
+            Temporal resolution in hours (positive, may be non-integer-valued). Default: 1.
+        land_params : bool, optional
+            If True, recompute `on_land` and `dist_since_lf` at each node. Default: False.
         """
-        LOGGER.info('Interpolating %s tracks to %sh time steps.', self.size,
-                    time_step_h)
+        if time_step_h <= 0:
+            raise ValueError("time_step_h is not a positive number: %s", time_step_h)
+        LOGGER.info('Interpolating %s tracks to %sh time steps.', self.size, time_step_h)
 
         if land_params:
             extent = self.get_extent()
@@ -1112,11 +1115,18 @@ class TCTracks():
     def _one_interp_data(track, time_step_h, land_geom=None):
         """Interpolate values of one track.
 
-        Parameters:
-            track (xr.Dataset): track data
+        Parameters
+        ----------
+        track : xr.Dataset
+            Track data.
+        time_step_h : int or float
+            Desired temporal resolution in hours (may be non-integer-valued).
+        land_geom : shapely.geometry.multipolygon.MultiPolygon, optional
+            Land geometry. If given, recompute `dist_since_lf` and `on_land` property.
 
-        Returns:
-            xr.Dataset
+        Returns
+        -------
+        track_int : xr.Dataset
         """
         if track.time.size >= 2:
             method = ['linear', 'quadratic', 'cubic'][min(2, track.time.size - 2)]
@@ -1127,7 +1137,7 @@ class TCTracks():
                 # crosses 180 degrees east/west -> use positive degrees east
                 lon[lon < 0] += 360
 
-            time_step = '{}H'.format(time_step_h)
+            time_step = pd.tseries.frequencies.to_offset(pd.Timedelta(hours=time_step_h))
             track_int = track.resample(time=time_step, keep_attrs=True, skipna=True)\
                              .interpolate('linear')
             track_int['time_step'][:] = time_step_h

--- a/climada/hazard/test/test_tc_tracks.py
+++ b/climada/hazard/test/test_tc_tracks.py
@@ -412,6 +412,28 @@ class TestFuncs(unittest.TestCase):
         self.assertEqual(tc_track.data[0].id_no, 1951239012334)
         self.assertEqual(tc_track.data[0].category, 1)
 
+        # test some "generic floats"
+        for time_step_h in [0.6663545049172093, 2.509374054925788, 8.175754471661111]:
+            tc_track = tc.TCTracks()
+            tc_track.read_processed_ibtracs_csv(TEST_TRACK)
+            tc_track.equal_timestep(time_step_h=time_step_h)
+            self.assertTrue(np.all(tc_track.data[0].time_step == time_step_h))
+
+        tc_track = tc.TCTracks()
+        tc_track.read_processed_ibtracs_csv(TEST_TRACK)
+        tc_track.equal_timestep(time_step_h=0.16667)
+
+        self.assertEqual(tc_track.data[0].time.size, 1333)
+        self.assertTrue(np.all(tc_track.data[0].time_step == 0.16667))
+        self.assertAlmostEqual(tc_track.data[0].lon.values[66], -27.397636528537127)
+
+        for time_step_h in [0, -0.5, -1]:
+            tc_track = tc.TCTracks()
+            tc_track.read_processed_ibtracs_csv(TEST_TRACK)
+            msg = f"time_step_h is not a positive number: {time_step_h}"
+            with self.assertRaises(ValueError, msg=msg) as cm:
+                tc_track.equal_timestep(time_step_h=time_step_h)
+
     def test_interp_origin_pass(self):
         """Interpolate track to min_time_step crossing lat origin"""
         tc_track = tc.TCTracks()


### PR DESCRIPTION
The function `TCTracks.equal_timestep` is currently limited to hourly resolution time steps. I don't think that we have to support arbitrary small time steps, but minute resolution might be useful for some case studies. Since supporting minute resolution is a very easy change and 100% backward compatible, I quickly created a PR for this (with unit test).

While I was at it, I updated the docstrings to NumPy format.

EDIT: Many sub-hour offsets (like 1/360 or 5/60) work well already without this PR. However, this PR now introduces support for arbitrary resolutions.