### PR TITLE
Fix exception for missing geometry

### DIFF
--- a/climada/hazard/tc_tracks.py
+++ b/climada/hazard/tc_tracks.py
@@ -247,6 +247,10 @@ class TCTracks():
 
         if buffer <= 0.0:
             raise ValueError(f"buffer={buffer} is invalid, must be above zero.")
+        try:  
+            exposure.geometry
+        except AttributeError:
+            exposure.set_geometry_points()
 
         exp_buffer = exposure.buffer(distance=buffer, resolution=0)
         exp_buffer = exp_buffer.unary_union


### PR DESCRIPTION
Fix `TCTracks.tracks_in_exp(exposure)` to catch exception when `exposure.geometry` is not defined.