### PR TITLE
Improve TC wind performance with sinusoidal projection

### DIFF
--- a/climada/hazard/test/test_trop_cyclone.py
+++ b/climada/hazard/test/test_trop_cyclone.py
@@ -46,59 +46,64 @@ class TestReader(unittest.TestCase):
 
     def test_set_one_pass(self):
         """Test _tc_from_track function."""
+        intensity_idx = [0, 1, 2,  3,  80, 100, 120, 200, 220, 250, 260, 295]
+        intensity_values = {
+            "geosphere": [25.76590964, 27.08333002, 28.46008202, 25.70445069, 31.45216632,
+                          36.45564037, 21.22679800, 28.22022122, 32.92315537, 31.60115745, 0,
+                          40.62433745],
+            "equirect": [25.76575952, 27.08314419, 28.45984342, 25.70460801, 31.45171899,
+                         36.45003013, 21.22671287, 28.22016474, 32.92054837, 31.59980326, 0,
+                         40.62068325]
+        }
+        # the values for the two metrics should agree up to first digit at least
+        for i, val in enumerate(intensity_values["geosphere"]):
+            self.assertAlmostEqual(intensity_values["equirect"][i], val, 1)
+
         tc_track = TCTracks()
         tc_track.read_processed_ibtracs_csv(TEST_TRACK)
         tc_track.equal_timestep()
         tc_track.data = tc_track.data[:1]
-        tc_haz = TropCyclone()
-        tc_haz.set_from_tracks(tc_track, centroids=CENTR_TEST_BRB, model='H08',
-                               store_windfields=True)
 
-        self.assertEqual(tc_haz.tag.haz_type, 'TC')
-        self.assertEqual(tc_haz.tag.description, '')
-        self.assertEqual(tc_haz.tag.file_name, 'Name: 1951239N12334')
-        self.assertEqual(tc_haz.units, 'm/s')
-        self.assertEqual(tc_haz.centroids.size, 296)
-        self.assertEqual(tc_haz.event_id.size, 1)
-        self.assertEqual(tc_haz.date.size, 1)
-        self.assertEqual(dt.datetime.fromordinal(tc_haz.date[0]).year, 1951)
-        self.assertEqual(dt.datetime.fromordinal(tc_haz.date[0]).month, 8)
-        self.assertEqual(dt.datetime.fromordinal(tc_haz.date[0]).day, 27)
-        self.assertEqual(tc_haz.event_id[0], 1)
-        self.assertEqual(tc_haz.event_name, ['1951239N12334'])
-        self.assertTrue(np.array_equal(tc_haz.frequency, np.array([1])))
-        self.assertTrue(isinstance(tc_haz.fraction, sparse.csr.csr_matrix))
-        self.assertEqual(tc_haz.fraction.shape, (1, 296))
-        self.assertEqual(tc_haz.fraction[0, 100], 1)
-        self.assertEqual(tc_haz.fraction[0, 260], 0)
-        self.assertEqual(tc_haz.fraction.nonzero()[0].size, 280)
+        for metric in ["equirect", "geosphere"]:
+            tc_haz = TropCyclone()
+            tc_haz.set_from_tracks(tc_track, centroids=CENTR_TEST_BRB, model='H08',
+                                   store_windfields=True, metric=metric)
 
-        self.assertTrue(isinstance(tc_haz.intensity, sparse.csr.csr_matrix))
-        self.assertEqual(tc_haz.intensity.shape, (1, 296))
-        self.assertEqual(np.nonzero(tc_haz.intensity)[0].size, 280)
+            self.assertEqual(tc_haz.tag.haz_type, 'TC')
+            self.assertEqual(tc_haz.tag.description, '')
+            self.assertEqual(tc_haz.tag.file_name, 'Name: 1951239N12334')
+            self.assertEqual(tc_haz.units, 'm/s')
+            self.assertEqual(tc_haz.centroids.size, 296)
+            self.assertEqual(tc_haz.event_id.size, 1)
+            self.assertEqual(tc_haz.date.size, 1)
+            self.assertEqual(dt.datetime.fromordinal(tc_haz.date[0]).year, 1951)
+            self.assertEqual(dt.datetime.fromordinal(tc_haz.date[0]).month, 8)
+            self.assertEqual(dt.datetime.fromordinal(tc_haz.date[0]).day, 27)
+            self.assertEqual(tc_haz.event_id[0], 1)
+            self.assertEqual(tc_haz.event_name, ['1951239N12334'])
+            self.assertTrue(np.array_equal(tc_haz.frequency, np.array([1])))
+            self.assertTrue(isinstance(tc_haz.fraction, sparse.csr.csr_matrix))
+            self.assertEqual(tc_haz.fraction.shape, (1, 296))
+            self.assertEqual(tc_haz.fraction[0, 100], 1)
+            self.assertEqual(tc_haz.fraction[0, 260], 0)
+            self.assertEqual(tc_haz.fraction.nonzero()[0].size, 280)
 
-        self.assertEqual(tc_haz.intensity[0, 260], 0)
-        self.assertAlmostEqual(tc_haz.intensity[0, 1], 27.08333002)
-        self.assertAlmostEqual(tc_haz.intensity[0, 2], 28.46008202)
-        self.assertAlmostEqual(tc_haz.intensity[0, 3], 25.70445069)
-        self.assertAlmostEqual(tc_haz.intensity[0, 100], 36.45564037)
-        self.assertAlmostEqual(tc_haz.intensity[0, 250], 31.60115745)
-        self.assertAlmostEqual(tc_haz.intensity[0, 295], 40.62433745)
+            self.assertTrue(isinstance(tc_haz.intensity, sparse.csr.csr_matrix))
+            self.assertEqual(tc_haz.intensity.shape, (1, 296))
+            self.assertEqual(np.nonzero(tc_haz.intensity)[0].size, 280)
 
-        to_kn = (1.0 * ureg.meter / ureg.second).to(ureg.knot).magnitude
-        wind = tc_haz.intensity.toarray()[0,:]
-        self.assertAlmostEqual(wind[0] * to_kn, 50.08492156)
-        self.assertAlmostEqual(wind[80] * to_kn, 61.13812028)
-        self.assertAlmostEqual(wind[120] * to_kn, 41.26159439)
-        self.assertAlmostEqual(wind[200] * to_kn, 54.85572160)
-        self.assertAlmostEqual(wind[220] * to_kn, 63.99749424)
+            for idx, val in zip(intensity_idx, intensity_values[metric]):
+                if val == 0:
+                    self.assertEqual(tc_haz.intensity[0, idx], 0)
+                else:
+                    self.assertAlmostEqual(tc_haz.intensity[0, idx], val)
 
-        windfields = tc_haz.windfields[0].toarray()
-        windfields = windfields.reshape(windfields.shape[0], -1, 2)
-        windfield_norms = np.linalg.norm(windfields, axis=-1).max(axis=0)
-        intensity = tc_haz.intensity.toarray()[0, :]
-        msk = (intensity > 0)
-        self.assertTrue(np.allclose(windfield_norms[msk], intensity[msk]))
+            windfields = tc_haz.windfields[0].toarray()
+            windfields = windfields.reshape(windfields.shape[0], -1, 2)
+            windfield_norms = np.linalg.norm(windfields, axis=-1).max(axis=0)
+            intensity = tc_haz.intensity.toarray()[0, :]
+            msk = (intensity > 0)
+            self.assertTrue(np.allclose(windfield_norms[msk], intensity[msk]))
 
     def test_set_one_file_pass(self):
         """Test set function set_from_tracks with one input."""
@@ -245,7 +250,7 @@ class TestWindfieldHelpers(unittest.TestCase):
 
         self.assertEqual(v_trans.size, tc_track.data[0].time.size)
         self.assertEqual(v_trans[0], 0)
-        self.assertAlmostEqual(v_trans[1] * to_kn, 10.191466078221902)
+        self.assertAlmostEqual(v_trans[1] * to_kn, 10.191466246)
 
 
 class TestClimateSce(unittest.TestCase):

--- a/climada/hazard/trop_cyclone.py
+++ b/climada/hazard/trop_cyclone.py
@@ -37,7 +37,7 @@ from climada.hazard.tc_tracks import TCTracks, estimate_rmw
 from climada.hazard.tc_clim_change import get_knutson_criterion, calc_scale_knutson
 from climada.hazard.centroids.centr import Centroids
 from climada.util import ureg
-from climada.util.coordinates import dist_approx
+from climada.util.coordinates import dist_approx, lon_bounds, lon_normalize
 import climada.util.plot as u_plot
 
 LOGGER = logging.getLogger(__name__)
@@ -102,26 +102,37 @@ class TropCyclone(Hazard):
 
     def set_from_tracks(self, tracks, centroids=None, description='',
                         model='H08', ignore_distance_to_coast=False,
-                        store_windfields=False):
+                        store_windfields=False, metric="equirect"):
         """Clear and fill with windfields from specified tracks.
 
-        Parameters:
-            tracks (TCTracks): tracks of events
-            centroids (Centroids, optional): Centroids where to model TC.
-                Default: global centroids.
-            description (str, optional): description of the events
-            model (str, optional): model to compute gust. Default Holland2008.
-            ignore_distance_to_coast (boolean, optional): if True, centroids
-                far from coast are not ignored. Default False
-            store_windfields (boolean, optional): If True, the Hazard object
-                gets a list `windfields` of sparse matrices. For each track,
-                the full velocity vectors at each centroid and track position
-                are stored in a sparse matrix of shape
-                (npositions,  ncentroids * 2), that can be reshaped to a full
-                ndarray of shape (npositions, ncentroids, 2). Default: False.
+        Parameters
+        ----------
+        tracks : TCTracks
+            Tracks of storm events.
+        centroids : Centroids, optional
+            Centroids where to model TC. Default: global centroids at 360 arc-seconds resolution.
+        description : str, optional
+            Description of the event set. Default: "".
+        model : str, optional
+            Model to compute gust. Currently only 'H08' is supported for the one implemented in
+            `_stat_holland` according to Greg Holland. Default: "H08".
+        ignore_distance_to_coast : boolean, optional
+            If True, centroids far from coast are not ignored. Default: False.
+        store_windfields : boolean, optional
+            If True, the Hazard object gets a list `windfields` of sparse matrices. For each track,
+            the full velocity vectors at each centroid and track position are stored in a sparse
+            matrix of shape (npositions,  ncentroids * 2) that can be reshaped to a full ndarray
+            of shape (npositions, ncentroids, 2). Default: False.
+        metric : str, optional
+            Specify an approximation method to use for earth distances:
+            * "equirect": Distance according to sinusoidal projection. Fast, but inaccurate for
+              large distances and high latitudes.
+            * "geosphere": Exact spherical distance. Much more accurate at all distances, but slow.
+            Default: "equirect".
 
-        Raises:
-            ValueError
+        Raises
+        ------
+        ValueError
         """
         num_tracks = tracks.size
         if centroids is None:
@@ -150,6 +161,7 @@ class TropCyclone(Hazard):
                 itertools.repeat(coastal_idx, num_tracks),
                 itertools.repeat(model, num_tracks),
                 itertools.repeat(store_windfields, num_tracks),
+                itertools.repeat(metric, num_tracks),
                 chunksize=chunksize)
         else:
             last_perc = 0
@@ -161,8 +173,8 @@ class TropCyclone(Hazard):
                     last_perc = perc
                 tc_haz.append(
                     self._tc_from_track(track, centroids, coastal_idx,
-                                        model=model,
-                                        store_windfields=store_windfields))
+                                        model=model, store_windfields=store_windfields,
+                                        metric=metric))
         LOGGER.debug('Append events.')
         self.concatenate(tc_haz)
         LOGGER.debug('Compute frequency.')
@@ -283,22 +295,33 @@ class TropCyclone(Hazard):
         self.frequency = np.ones(self.event_id.size) / (year_delta * ens_size)
 
     def _tc_from_track(self, track, centroids, coastal_idx, model='H08',
-                       store_windfields=False):
+                       store_windfields=False, metric="equirect"):
         """Generate windfield hazard from a single track dataset
 
-        Parameters:
-            track (xr.Dataset): single tropical cyclone track.
-            centroids (Centroids): Centroids instance.
-            coastal_idx (np.array): Indices of centroids close to coast.
-            model (str, optional): Windfield model. Default: H08.
-            store_windfields (boolean, optional): If True, store windfields.
-                Default: False.
+        Parameters
+        ----------
+        track : xr.Dataset
+            Single tropical cyclone track.
+        centroids : Centroids
+            Centroids instance.
+        coastal_idx : np.array
+            Indices of centroids close to coast.
+        model : str, optional
+            Windfield model. Default: H08.
+        store_windfields : boolean, optional
+            If True, store windfields. Default: False.
+        metric : str, optional
+            Specify an approximation method to use for earth distances: "equirect" (faster) or
+            "geosphere" (more accurate). See `dist_approx` function in `climada.util.coordinates`.
+            Default: "equirect".
 
-        Raises:
-            ValueError, KeyError
+        Raises
+        ------
+        ValueError, KeyError
 
-        Returns:
-            TropCyclone
+        Returns
+        -------
+        haz : TropCyclone
         """
         try:
             mod_id = MODEL_VANG[model]
@@ -307,7 +330,8 @@ class TropCyclone(Hazard):
             raise ValueError
         ncentroids = centroids.coord.shape[0]
         coastal_centr = centroids.coord[coastal_idx]
-        windfields, reachable_centr_idx = compute_windfields(track, coastal_centr, mod_id)
+        windfields, reachable_centr_idx = compute_windfields(track, coastal_centr, mod_id,
+                                                             metric=metric)
         reachable_coastal_centr_idx = coastal_idx[reachable_centr_idx]
         npositions = windfields.shape[0]
         intensity = np.zeros(ncentroids)
@@ -369,7 +393,7 @@ class TropCyclone(Hazard):
                 setattr(haz_cc, chg['variable'], new_val)
         return haz_cc
 
-def compute_windfields(track, centroids, model):
+def compute_windfields(track, centroids, model, metric="equirect"):
     """Compute 1-minute sustained winds (in m/s) at 10 meters above ground
 
     In a first step, centroids within reach of the track are determined so that wind fields will
@@ -384,6 +408,10 @@ def compute_windfields(track, centroids, model):
         Centroids that are not within reach of the track are ignored.
     model : int
         Holland model selection according to MODEL_VANG.
+    metric : str, optional
+        Specify an approximation method to use for earth distances: "equirect" (faster) or
+        "geosphere" (more accurate). See `dist_approx` function in `climada.util.coordinates`.
+        Default: "equirect".
 
     Returns
     -------
@@ -410,12 +438,10 @@ def compute_windfields(track, centroids, model):
     if npositions < 2:
         return windfields, reachable_centr_idx
 
-    # never use longitudes at -180 degrees or below
-    t_lon[t_lon <= -180] += 360
-
-    # only use longitudes above 180, if 180 degree border is crossed
-    if t_lon.min() > 180:
-        t_lon -= 360
+    # normalize longitude values (improves performance of `dist_approx` and `_close_centroids`)
+    mid_lon = 0.5 * sum(lon_bounds(t_lon))
+    lon_normalize(t_lon, center=mid_lon)
+    lon_normalize(centroids[:,1], center=mid_lon)
 
     # restrict to centroids within rectangular bounding boxes around track positions
     track_centr_msk = _close_centroids(t_lat, t_lon, centroids)
@@ -427,7 +453,7 @@ def compute_windfields(track, centroids, model):
     # compute distances and vectors to all centroids
     [d_centr], [v_centr] = dist_approx(t_lat[None], t_lon[None],
                                        track_centr[None, :, 0], track_centr[None, :, 1],
-                                       log=True, method="geosphere")
+                                       log=True, normalize=False, method=metric)
 
     # exclude centroids that are too far from or too close to the eye
     close_centr_msk = (d_centr < CENTR_NODE_MAX_DIST_KM) & (d_centr > 1e-2)
@@ -444,7 +470,7 @@ def compute_windfields(track, centroids, model):
     t_rad[:] = estimate_rmw(t_rad, t_cen) * NM_TO_KM
 
     # translational speed of track at every node
-    v_trans = _vtrans(t_lat, t_lon, t_tstep)
+    v_trans = _vtrans(t_lat, t_lon, t_tstep, metric=metric)
     v_trans_norm = v_trans[0]
 
     # adjust pressure at previous track point
@@ -494,14 +520,21 @@ def compute_windfields(track, centroids, model):
     return windfields, reachable_centr_idx
 
 def _close_centroids(t_lat, t_lon, centroids, buffer=CENTR_NODE_MAX_DIST_DEG):
-    """Check whether centroids lay within rectangular buffer around track positions
+    """Check whether centroids lay within a rectangular buffer around track positions
+
+    The longitudinal coordinates are assumed to be normalized around a central longitude. This
+    makes sure that the buffered bounding box around the track doesn't cross the antimeridian.
+
+    The only hypothetical problem occurs when a TC track is travelling more than 349 degrees in
+    longitude because that's when adding a buffer of 5.5 degrees might cross the antimeridian.
+    Of course, this case is physically impossible.
 
     Parameters
     ----------
     t_lat : np.array of shape (npositions,)
         Latitudinal coordinates of track positions.
     t_lon : np.array of shape (npositions,)
-        Longitudinal coordinates of track positions.
+        Longitudinal coordinates of track positions, normalized around a central longitude.
     centroids : np.array of shape (ncentroids, 2)
         Coordinates of centroids, each row is a pair [lat, lon].
     buffer : float (optional)
@@ -515,25 +548,14 @@ def _close_centroids(t_lat, t_lon, centroids, buffer=CENTR_NODE_MAX_DIST_DEG):
     eye_bounds = np.c_[t_lon, t_lat, t_lon, t_lat]
     eye_bounds[:,:2] -= buffer
     eye_bounds[:,2:] += buffer
-
-    # rectangle crosses antimeridian:
-    eye_bounds[eye_bounds[:,0] <= -180,0] += 360
-    eye_bounds[eye_bounds[:,2] > 180,2] -= 360
-
     centr_lat, centr_lon = centroids[:, 0], centroids[:, 1]
-    msk_lat = ((eye_bounds[:,None,1] < centr_lat[None])
-               & (centr_lat[None] < eye_bounds[:,None,3]))
+    msk = (eye_bounds[:,None,1] < centr_lat[None])
+    msk &= (centr_lat[None] < eye_bounds[:,None,3])
+    msk &= (eye_bounds[:,None,0] < centr_lon[None])
+    msk &= (centr_lon[None] < eye_bounds[:,None,2])
+    return msk.any(axis=0)
 
-    # rectangle might cross antimeridian or not
-    msk_lon_crosses = (eye_bounds[:,2] < eye_bounds[:,0])
-    msk_lon_within = ~msk_lon_crosses
-    msk_lon = (eye_bounds[:,None,0] < centr_lon[None])
-    msk_lon_upper = (centr_lon[None] < eye_bounds[:,None,2])
-    msk_lon[msk_lon_crosses] |= msk_lon_upper[msk_lon_crosses]
-    msk_lon[msk_lon_within] &= msk_lon_upper[msk_lon_within]
-    return (msk_lat & msk_lon).any(axis=0)
-
-def _vtrans(t_lat, t_lon, t_tstep):
+def _vtrans(t_lat, t_lon, t_tstep, metric="equirect"):
     """Translational vector and velocity at each track node.
 
     Parameters
@@ -544,6 +566,10 @@ def _vtrans(t_lat, t_lon, t_tstep):
         track longitudes
     t_tstep : np.array
         track time steps
+    metric : str, optional
+        Specify an approximation method to use for earth distances: "equirect" (faster) or
+        "geosphere" (more accurate). See `dist_approx` function in `climada.util.coordinates`.
+        Default: "equirect".
 
     Returns
     -------
@@ -556,7 +582,7 @@ def _vtrans(t_lat, t_lon, t_tstep):
     v_trans_norm = np.zeros((t_lat.size,))
     norm, vec = dist_approx(t_lat[:-1, None], t_lon[:-1, None],
                             t_lat[1:, None], t_lon[1:, None],
-                            log=True, method="geosphere")
+                            log=True, normalize=False, method=metric)
     v_trans[1:, :] = vec[:, 0, 0]
     v_trans[1:, :] *= KMH_TO_MS / t_tstep[1:, None]
     v_trans_norm[1:] = norm[:, 0, 0]

--- a/climada/util/coordinates.py
+++ b/climada/util/coordinates.py
@@ -161,7 +161,7 @@ def lon_bounds(lon, buffer=0.0):
     Usually, an application of this function is followed by a renormalization of longitudinal
     values around the longitudinal middle value:
 
-    >>> bounds = latlon_bounds(lat, lon)
+    >>> bounds = lon_bounds(lon)
     >>> lon_mid = 0.5 * (bounds[0] + bounds[2])
     >>> lon = lon_normalize(lon, center=lon_mid)
     >>> np.all((bounds[0] <= lon) & (lon <= bounds[2]))
@@ -258,9 +258,11 @@ def dist_approx(lat1, lon1, lat2, lon2, log=False, normalize=True,
         Default: True
     method : str, optional
         Specify an approximation method to use:
-        * "equirect": equirectangular; very fast, good only at small distances.
-        * "geosphere": spherical approximation, slower, but much higher accuracy.
-        Default: "equirect".
+        * "equirect": Distance according to sinusoidal projection. Fast, but inaccurate for large
+          distances and high latitudes.
+        * "geosphere": Exact spherical distance. Much more accurate at all distances, but slow.
+        Note that ellipsoidal distances would be even more accurate, but are currently not
+        implemented. Default: "equirect".
     units : str, optional
         Specify a unit for the distance. One of:
         * "km": distance in km.
@@ -288,17 +290,18 @@ def dist_approx(lat1, lon1, lat2, lon2, log=False, normalize=True,
 
     if method == "equirect":
         if normalize:
-            lon_normalize(lon1)
-            lon_normalize(lon2)
-        d_lat = lat2[:, None] - lat1[:, :, None]
-        d_lon = lon2[:, None] - lon1[:, :, None]
-        fact1 = np.heaviside(d_lon - 180, 0)
-        fact2 = np.heaviside(-d_lon - 180, 0)
-        d_lon -= (fact1 - fact2) * 360
-        d_lon *= np.cos(np.radians(lat1[:, :, None]))
-        dist = np.sqrt(d_lon**2 + d_lat**2) * unit_factor
-        if log:
-            vtan = np.stack([d_lat, d_lon], axis=-1) * unit_factor
+            mid_lon = 0.5 * sum(lon_bounds(np.concatenate([lon1, lon2])))
+            lon_normalize(lon1, center=mid_lon)
+            lon_normalize(lon2, center=mid_lon)
+        vtan = np.stack([lat2[:, None] - lat1[:, :, None],
+                         lon2[:, None] - lon1[:, :, None]], axis=-1)
+        fact1 = np.heaviside(vtan[..., 1] - 180, 0)
+        fact2 = np.heaviside(-vtan[..., 1] - 180, 0)
+        vtan[..., 1] -= (fact1 - fact2) * 360
+        vtan[..., 1] *= np.cos(np.radians(lat1[:, :, None]))
+        vtan *= unit_factor
+        # faster version of `dist = np.linalg.norm(vtan, axis=-1)`
+        dist = np.sqrt(np.einsum("...l,...l->...", vtan, vtan))
     elif method == "geosphere":
         lat1, lon1, lat2, lon2 = map(np.radians, [lat1, lon1, lat2, lon2])
         dlat = 0.5 * (lat2[:, None] - lat1[:, :, None])

--- a/climada/util/test/test_coordinates.py
+++ b/climada/util/test/test_coordinates.py
@@ -121,10 +121,11 @@ class TestFunc(unittest.TestCase):
         """Test approximate distance functions"""
         data = np.array([
             # lat1, lon1, lat2, lon2, dist, dist_sph
-            [45.5, -32.2, 14, 56, 7709.827814738594, 8758.34146833],
-            [45.5, 147.8, 14, -124, 7709.827814738594, 8758.34146833],
-            [45.5, 507.8, 14, -124, 7709.827814738594, 8758.34146833],
-            [45.5, -212.2, 14, -124, 7709.827814738594, 8758.34146833],
+            [45.5, -32.1, 14, 56, 7702.88906574, 8750.64119051],
+            [45.5, 147.8, 14, -124, 7709.82781473, 8758.34146833],
+            [45.5, 507.9, 14, -124, 7702.88906574, 8750.64119051],
+            [45.5, -212.2, 14, -124, 7709.82781473, 8758.34146833],
+            [-3, -130.1, 4, -30.5, 11079.7217421, 11087.0352544],
         ])
         compute_dist = np.stack([
             dist_approx(data[:, None, 0], data[:, None, 1],
@@ -153,6 +154,8 @@ class TestFunc(unittest.TestCase):
                 self.assertAlmostEqual(d[0] * factor, cd[0])
                 self.assertAlmostEqual(d[1] * factor, cd[1])
 
+    def test_dist_approx_log_pass(self):
+        """Test log-functionality of approximate distance functions"""
         data = np.array([
             # lat1, lon1, lat2, lon2, dist, dist_sph
             [0, 0, 0, 1, 111.12, 111.12],

--- a/climada/util/test/test_coordinates.py
+++ b/climada/util/test/test_coordinates.py
@@ -72,11 +72,15 @@ class TestFunc(unittest.TestCase):
 
         # test in place operation
         lon_normalize(data)
-        self.assertTrue(np.allclose(data, [180, 20.1, -30, -170, 10]))
+        np.testing.assert_array_almost_equal(data, [180, 20.1, -30, -170, 10])
 
         # test with specific center and return value
         data = lon_normalize(data, center=-170)
-        self.assertTrue(np.allclose(data, [-180, -339.9, -30, -170, 10]))
+        np.testing.assert_array_almost_equal(data, [-180, -339.9, -30, -170, 10])
+
+        # test with center determined automatically (which is 280.05)
+        data = lon_normalize(data, center=None)
+        np.testing.assert_array_almost_equal(data, [180, 380.1, 330, 190, 370])
 
     def test_latlon_bounds(self):
         """Test latlon_bounds function"""


### PR DESCRIPTION
As discussed already in a video call, we can improve performance of TC wind field computation by returning to the sinusoidal distance computations (that were default in a legacy version of CLIMADA). The loss in accuracy is very small (compare the values in the tests).