### PR TITLE
Allow ~/.config/ as a location for climada.conf

### DIFF
--- a/climada/util/config.py
+++ b/climada/util/config.py
@@ -318,5 +318,6 @@ CONFIG_NAME = 'climada.conf'
 CONFIG = Config.from_dict(_fetch_conf([
     Path(SOURCE_DIR, 'climada', 'conf'),  # default config from the climada repository
     Path(Path.home(), 'climada', 'conf'),  # ~/climada/conf directory
+    Path(Path.home(), '.config'),  # ~/.config directory
     Path.cwd(),  # current working directory
 ], CONFIG_NAME))


### PR DESCRIPTION
With recent config-related changes (#114), CLIMADA uses a config file and, if I want to use a custom config file, it will create clutter in my $HOME because it's not a hidden file (`climada.conf` instead of `.climada.conf`). This PR solves this in a single changed line of code by adding `~/.config/` as a location to look for the `climada.conf` file.

See also #116 for discussions about alternative solutions. This PR is only about adding `~/.config/` to the list of allowed locations for the `climada.conf`. Please don't discuss alternative solutions in this PR.