### PR TITLE
Improve TropCyclone memory efficiency for large centroid sets

### DIFF
--- a/climada/engine/impact.py
+++ b/climada/engine/impact.py
@@ -44,7 +44,7 @@ from climada.entity.exposures.base import INDICATOR_IF, INDICATOR_CENTR
 import climada.util.plot as u_plot
 from climada import CONFIG
 from climada.util.constants import DEF_CRS
-import climada.util.dates_times as util_dt
+import climada.util.dates_times as u_dt
 from climada.util.select import get_attributes_with_matching_dimension
 
 LOGGER = logging.getLogger(__name__)
@@ -1106,8 +1106,8 @@ class Impact():
             mask_dt = np.ones(nb_events, dtype=bool)
             date_ini, date_end = dates
             if isinstance(date_ini, str):
-                date_ini = util_dt.str_to_date(date_ini)
-                date_end = util_dt.str_to_date(date_end)
+                date_ini = u_dt.str_to_date(date_ini)
+                date_end = u_dt.str_to_date(date_end)
             mask_dt &= (date_ini <= self.date)
             mask_dt &= (self.date <= date_end)
             if not np.any(mask_dt):

--- a/climada/entity/disc_rates/base.py
+++ b/climada/entity/disc_rates/base.py
@@ -29,7 +29,7 @@ import pandas as pd
 import matplotlib.pyplot as plt
 import xlsxwriter
 
-import climada.util.checker as check
+import climada.util.checker as u_check
 from climada.entity.tag import Tag
 import climada.util.finance as u_fin
 import climada.util.hdf5_handler as hdf5
@@ -91,7 +91,7 @@ class DiscRates():
         Raises:
             ValueError
         """
-        check.size(len(self.years), self.rates, 'DiscRates.rates')
+        u_check.size(len(self.years), self.rates, 'DiscRates.rates')
 
     def select(self, year_range):
         """Select discount rates in given years.

--- a/climada/entity/exposures/crop_production.py
+++ b/climada/entity/exposures/crop_production.py
@@ -27,9 +27,10 @@ import pandas as pd
 import h5py
 from matplotlib import pyplot as plt
 from iso3166 import countries as iso_cntry
+
 from climada.entity.exposures.base import Exposures
 from climada.entity.tag import Tag
-import climada.util.coordinates as coord
+import climada.util.coordinates as u_coord
 from climada.util.constants import DEF_CRS
 from climada.util.coordinates import pts_to_raster_meta, get_resolution
 from climada import CONFIG
@@ -223,7 +224,7 @@ class CropProduction(Exposures):
         lon, lat = np.meshgrid(data.lon.values, data.lat.values)
         self['latitude'] = lat.flatten()
         self['longitude'] = lon.flatten()
-        self['region_id'] = coord.get_country_code(self.latitude, self.longitude)
+        self['region_id'] = u_coord.get_country_code(self.latitude, self.longitude)
 
         # The indeces of the yearrange to be extracted are determined
         time_idx = (int(yearrange[0] - yearchunk['startyear']),
@@ -486,7 +487,7 @@ class CropProduction(Exposures):
         fao['year'] = fao['file'].Year.values
         fao['price'] = fao['file'].Value.values
 
-        fao_country = coord.country_faocode2iso(getattr(fao['file'], 'Area Code').values)
+        fao_country = u_coord.country_faocode2iso(getattr(fao['file'], 'Area Code').values)
 
         # create a list of the countries contained in the exposure
         iso3alpha = list()
@@ -675,7 +676,7 @@ def normalize_with_fao_cp(exp_firr, exp_noirr, input_dir=None,
     fao_values = fao.Value.values
     fao_code = getattr(fao, 'Area Code').values
 
-    fao_country = coord.country_iso2faocode(country_list)
+    fao_country = u_coord.country_iso2faocode(country_list)
 
     fao_crop_production = np.zeros(len(country_list))
     ratio = np.ones(len(country_list))

--- a/climada/entity/impact_funcs/base.py
+++ b/climada/entity/impact_funcs/base.py
@@ -25,7 +25,7 @@ import logging
 import numpy as np
 import matplotlib.pyplot as plt
 
-import climada.util.checker as check
+import climada.util.checker as u_check
 
 LOGGER = logging.getLogger(__name__)
 
@@ -104,8 +104,8 @@ class ImpactFunc():
             ValueError
         """
         num_exp = len(self.intensity)
-        check.size(num_exp, self.mdd, 'ImpactFunc.mdd')
-        check.size(num_exp, self.paa, 'ImpactFunc.paa')
+        u_check.size(num_exp, self.mdd, 'ImpactFunc.mdd')
+        u_check.size(num_exp, self.paa, 'ImpactFunc.paa')
 
         if num_exp == 0:
             LOGGER.warning("%s impact function with name '%s' (id=%s) has empty"

--- a/climada/entity/measures/base.py
+++ b/climada/entity/measures/base.py
@@ -28,7 +28,7 @@ import numpy as np
 import pandas as pd
 
 from climada.entity.exposures.base import Exposures, INDICATOR_IF, INDICATOR_CENTR
-import climada.util.checker as check
+import climada.util.checker as u_check
 
 LOGGER = logging.getLogger(__name__)
 
@@ -101,12 +101,12 @@ class Measure():
             ValueError
         """
         try:
-            check.size(3, self.color_rgb, 'Measure.color_rgb')
+            u_check.size(3, self.color_rgb, 'Measure.color_rgb')
         except ValueError:
-            check.size(4, self.color_rgb, 'Measure.color_rgb')
-        check.size(2, self.hazard_inten_imp, 'Measure.hazard_inten_imp')
-        check.size(2, self.mdd_impact, 'Measure.mdd_impact')
-        check.size(2, self.paa_impact, 'Measure.paa_impact')
+            u_check.size(4, self.color_rgb, 'Measure.color_rgb')
+        u_check.size(2, self.hazard_inten_imp, 'Measure.hazard_inten_imp')
+        u_check.size(2, self.mdd_impact, 'Measure.mdd_impact')
+        u_check.size(2, self.paa_impact, 'Measure.paa_impact')
 
     def calc_impact(self, exposures, imp_fun_set, hazard):
         """Apply measure and compute impact and risk transfer of measure

--- a/climada/hazard/base.py
+++ b/climada/hazard/base.py
@@ -40,11 +40,11 @@ from pathos.pools import ProcessPool as Pool
 from climada.hazard.tag import Tag as TagHazard
 from climada.hazard.centroids.centr import Centroids
 import climada.util.plot as u_plot
-import climada.util.checker as check
+import climada.util.checker as u_check
 import climada.util.dates_times as u_dt
 from climada import CONFIG
 import climada.util.hdf5_handler as hdf5
-import climada.util.coordinates as co
+import climada.util.coordinates as u_coord
 
 LOGGER = logging.getLogger(__name__)
 
@@ -458,7 +458,7 @@ class Hazard():
             else:
                 points_df[inten_name] = np.asarray(self.fraction[i_ev - self.size, :].toarray()).\
                 reshape(-1)
-        raster, meta = co.points_to_raster(points_df, val_names, scheduler=scheduler)
+        raster, meta = u_coord.points_to_raster(points_df, val_names, scheduler=scheduler)
         self.intensity = sparse.csr_matrix(raster[:self.size, :, :].reshape(self.size, -1))
         self.fraction = sparse.csr_matrix(raster[self.size:, :, :].reshape(self.size, -1))
         self.centroids = Centroids()
@@ -956,7 +956,7 @@ class Hazard():
         if not intensity:
             variable = self.fraction
         if self.centroids.meta:
-            co.write_raster(file_name, variable.toarray(), self.centroids.meta)
+            u_coord.write_raster(file_name, variable.toarray(), self.centroids.meta)
         else:
             pixel_geom = self.centroids.calc_pixels_polygons()
             profile = self.centroids.meta
@@ -1234,15 +1234,15 @@ class Hazard():
             LOGGER.error("There are events with the same identifier.")
             raise ValueError
 
-        check.check_oligatories(self.__dict__, self.vars_oblig, 'Hazard.',
+        u_check.check_oligatories(self.__dict__, self.vars_oblig, 'Hazard.',
                                 num_ev, num_ev, num_cen)
-        check.check_optionals(self.__dict__, self.vars_opt, 'Hazard.', num_ev)
-        self.event_name = check.array_default(num_ev, self.event_name,
+        u_check.check_optionals(self.__dict__, self.vars_opt, 'Hazard.', num_ev)
+        self.event_name = u_check.array_default(num_ev, self.event_name,
                                               'Hazard.event_name',
                                               list(self.event_id))
-        self.date = check.array_default(num_ev, self.date, 'Hazard.date',
+        self.date = u_check.array_default(num_ev, self.date, 'Hazard.date',
                                         np.ones(self.event_id.shape, dtype=int))
-        self.orig = check.array_default(num_ev, self.orig, 'Hazard.orig',
+        self.orig = u_check.array_default(num_ev, self.orig, 'Hazard.orig',
                                         np.zeros(self.event_id.shape, dtype=bool))
         if len(self._events_set()) != num_ev:
             LOGGER.error("There are events with same date and name.")

--- a/climada/hazard/tc_surge_bathtub.py
+++ b/climada/hazard/tc_surge_bathtub.py
@@ -29,7 +29,7 @@ import rasterio.warp
 import scipy.sparse as sp
 
 from climada.hazard.base import Hazard
-import climada.util.coordinates as coord_util
+import climada.util.coordinates as u_coord
 
 LOGGER = logging.getLogger(__name__)
 
@@ -85,7 +85,7 @@ class TCSurgeBathtub(Hazard):
         coastal_msk &= (np.abs(centroids.lat) <= MAX_LATITUDE)
 
         # Load elevation at coastal centroids
-        coastal_centroids_h = coord_util.read_raster_sample(
+        coastal_centroids_h = u_coord.read_raster_sample(
             topo_path, centroids.lat[coastal_msk], centroids.lon[coastal_msk])
 
         # Update selected coastal centroids to exclude high-lying locations
@@ -170,12 +170,12 @@ def _fraction_on_land(centroids, topo_path):
         shape = centroids.shape
         cen_trans = centroids.meta['transform']
     else:
-        shape[0], shape[1], cen_trans = coord_util.pts_to_raster_meta(
-            bounds, min(coord_util.get_resolution(centroids.lat, centroids.lon)))
+        shape[0], shape[1], cen_trans = u_coord.pts_to_raster_meta(
+            bounds, min(u_coord.get_resolution(centroids.lat, centroids.lon)))
 
     read_raster_buffer = 0.5 * max(np.abs(cen_trans[0]), np.abs(cen_trans[4]))
     bounds += read_raster_buffer * np.array([-1., -1., 1., 1.])
-    on_land, dem_trans = coord_util.read_raster_bounds(topo_path, bounds)
+    on_land, dem_trans = u_coord.read_raster_bounds(topo_path, bounds)
     on_land = (on_land > 0).astype(np.float64)
 
     with rasterio.open(topo_path, 'r') as src:

--- a/climada/hazard/tc_tracks.py
+++ b/climada/hazard/tc_tracks.py
@@ -49,7 +49,7 @@ import xarray as xr
 
 # climada dependencies
 from climada.util import ureg
-import climada.util.coordinates as coord_util
+import climada.util.coordinates as u_coord
 from climada.util.constants import EARTH_RADIUS_KM, SYSTEM_DIR
 from climada.util.files_handler import get_file_names, download_ftp
 import climada.util.plot as u_plot
@@ -246,7 +246,7 @@ class TCTracks():
 
         if buffer <= 0.0:
             raise ValueError(f"buffer={buffer} is invalid, must be above zero.")
-        try:  
+        try:
             exposure.geometry
         except AttributeError:
             exposure.set_geometry_points()
@@ -935,7 +935,7 @@ class TCTracks():
 
         if land_params:
             extent = self.get_extent()
-            land_geom = coord_util.get_land_geometry(extent, resolution=10)
+            land_geom = u_coord.get_land_geometry(extent, resolution=10)
         else:
             land_geom = None
 
@@ -987,7 +987,7 @@ class TCTracks():
         -------
         bounds : tuple (lon_min, lat_min, lon_max, lat_max)
         """
-        bounds = coord_util.latlon_bounds(
+        bounds = u_coord.latlon_bounds(
             np.concatenate([t.lat.values for t in self.data]),
             np.concatenate([t.lon.values for t in self.data]),
             buffer=deg_buffer)
@@ -1055,7 +1055,7 @@ class TCTracks():
         norm = BoundaryNorm([0] + SAFFIR_SIM_CAT, len(SAFFIR_SIM_CAT))
         for track in self.data:
             lonlat = np.stack([track.lon.values, track.lat.values], axis=-1)
-            lonlat[:, 0] = coord_util.lon_normalize(lonlat[:, 0], center=mid_lon)
+            lonlat[:, 0] = u_coord.lon_normalize(lonlat[:, 0], center=mid_lon)
             segments = np.stack([lonlat[:-1], lonlat[1:]], axis=1)
             # remove segments which cross 180 degree longitude boundary
             segments = segments[segments[:, 0, 0] * segments[:, 1, 0] >= 0, :, :]
@@ -1273,7 +1273,7 @@ def track_land_params(track, land_geom):
         land geometry
     """
     track['on_land'] = ('time',
-                        coord_util.coord_on_land(track.lat.values, track.lon.values, land_geom))
+                        u_coord.coord_on_land(track.lat.values, track.lon.values, land_geom))
     track['dist_since_lf'] = ('time', _dist_since_lf(track))
 
 def _dist_since_lf(track):

--- a/climada/hazard/trop_cyclone.py
+++ b/climada/hazard/trop_cyclone.py
@@ -37,7 +37,7 @@ from climada.hazard.tc_tracks import TCTracks, estimate_rmw
 from climada.hazard.tc_clim_change import get_knutson_criterion, calc_scale_knutson
 from climada.hazard.centroids.centr import Centroids
 from climada.util import ureg
-from climada.util.coordinates import dist_approx, lon_bounds, lon_normalize
+import climada.util.coordinates as coord_util
 import climada.util.plot as u_plot
 
 LOGGER = logging.getLogger(__name__)
@@ -151,7 +151,17 @@ class TropCyclone(Hazard):
             coastal_idx = ((centroids.dist_coast < INLAND_MAX_DIST_KM * 1000)
                            & (np.abs(centroids.lat) < 61)).nonzero()[0]
 
-        LOGGER.info('Mapping %s tracks to %s centroids.', str(tracks.size),
+        # Restrict to coastal centroids within reach of any of the tracks
+        t_bounds = tracks.get_bounds(deg_buffer=CENTR_NODE_MAX_DIST_DEG)
+        t_mid_lon = 0.5 * (t_bounds[0] + t_bounds[2])
+        coastal_centroids = centroids.coord[coastal_idx]
+        coord_util.lon_normalize(coastal_centroids[:, 1], center=t_mid_lon)
+        coastal_idx = coastal_idx[((t_bounds[0] <= coastal_centroids[:, 1])
+                                   & (coastal_centroids[:, 1] <= t_bounds[2])
+                                   & (t_bounds[1] <= coastal_centroids[:, 0])
+                                   & (coastal_centroids[:, 0] <= t_bounds[3]))]
+
+        LOGGER.info('Mapping %s tracks to %s coastal centroids.', str(tracks.size),
                     str(coastal_idx.size))
         if self.pool:
             chunksize = min(num_tracks // self.pool.ncpus, 1000)
@@ -175,6 +185,8 @@ class TropCyclone(Hazard):
                     self._tc_from_track(track, centroids, coastal_idx,
                                         model=model, store_windfields=store_windfields,
                                         metric=metric))
+            if last_perc < 100:
+                LOGGER.info("Progress: 100%")
         LOGGER.debug('Append events.')
         self.concatenate(tc_haz)
         LOGGER.debug('Compute frequency.')
@@ -334,14 +346,17 @@ class TropCyclone(Hazard):
                                                              metric=metric)
         reachable_coastal_centr_idx = coastal_idx[reachable_centr_idx]
         npositions = windfields.shape[0]
-        intensity = np.zeros(ncentroids)
-        intensity[reachable_coastal_centr_idx] = np.linalg.norm(windfields, axis=-1)\
-                                                          .max(axis=0)
+
+        intensity = np.linalg.norm(windfields, axis=-1).max(axis=0)
         intensity[intensity < self.intensity_thres] = 0
+        intensity = sparse.csr_matrix(
+            (intensity, reachable_coastal_centr_idx, [0, intensity.size]),
+            shape=(1, ncentroids))
+        intensity.eliminate_zeros()
 
         new_haz = TropCyclone()
         new_haz.tag = TagHazard(HAZ_TYPE, 'Name: ' + track.name)
-        new_haz.intensity = sparse.csr_matrix(intensity.reshape(1, -1))
+        new_haz.intensity = intensity
         if store_windfields:
             wf_full = np.zeros((npositions, ncentroids, 2))
             wf_full[:, reachable_coastal_centr_idx, :] = windfields
@@ -439,9 +454,9 @@ def compute_windfields(track, centroids, model, metric="equirect"):
         return windfields, reachable_centr_idx
 
     # normalize longitude values (improves performance of `dist_approx` and `_close_centroids`)
-    mid_lon = 0.5 * sum(lon_bounds(t_lon))
-    lon_normalize(t_lon, center=mid_lon)
-    lon_normalize(centroids[:,1], center=mid_lon)
+    mid_lon = 0.5 * sum(coord_util.lon_bounds(t_lon))
+    coord_util.lon_normalize(t_lon, center=mid_lon)
+    coord_util.lon_normalize(centroids[:, 1], center=mid_lon)
 
     # restrict to centroids within rectangular bounding boxes around track positions
     track_centr_msk = _close_centroids(t_lat, t_lon, centroids)
@@ -451,9 +466,9 @@ def compute_windfields(track, centroids, model, metric="equirect"):
         return windfields, reachable_centr_idx
 
     # compute distances and vectors to all centroids
-    [d_centr], [v_centr] = dist_approx(t_lat[None], t_lon[None],
-                                       track_centr[None, :, 0], track_centr[None, :, 1],
-                                       log=True, normalize=False, method=metric)
+    [d_centr], [v_centr] = coord_util.dist_approx(t_lat[None], t_lon[None],
+                                                  track_centr[None, :, 0], track_centr[None, :, 1],
+                                                  log=True, normalize=False, method=metric)
 
     # exclude centroids that are too far from or too close to the eye
     close_centr_msk = (d_centr < CENTR_NODE_MAX_DIST_KM) & (d_centr > 1e-2)
@@ -546,14 +561,14 @@ def _close_centroids(t_lat, t_lon, centroids, buffer=CENTR_NODE_MAX_DIST_DEG):
         Mask that is True for close centroids and False for other centroids.
     """
     eye_bounds = np.c_[t_lon, t_lat, t_lon, t_lat]
-    eye_bounds[:,:2] -= buffer
-    eye_bounds[:,2:] += buffer
+    eye_bounds[:, :2] -= buffer
+    eye_bounds[:, 2:] += buffer
     centr_lat, centr_lon = centroids[:, 0], centroids[:, 1]
-    msk = (eye_bounds[:,None,1] < centr_lat[None])
-    msk &= (centr_lat[None] < eye_bounds[:,None,3])
-    msk &= (eye_bounds[:,None,0] < centr_lon[None])
-    msk &= (centr_lon[None] < eye_bounds[:,None,2])
-    return msk.any(axis=0)
+    mask = ((eye_bounds[:, None, 1] < centr_lat[None])
+            & (centr_lat[None] < eye_bounds[:, None, 3])
+            & (eye_bounds[:, None, 0] < centr_lon[None])
+            & (centr_lon[None] < eye_bounds[:, None, 2]))
+    return mask.any(axis=0)
 
 def _vtrans(t_lat, t_lon, t_tstep, metric="equirect"):
     """Translational vector and velocity at each track node.
@@ -580,9 +595,9 @@ def _vtrans(t_lat, t_lon, t_tstep, metric="equirect"):
     """
     v_trans = np.zeros((t_lat.size, 2))
     v_trans_norm = np.zeros((t_lat.size,))
-    norm, vec = dist_approx(t_lat[:-1, None], t_lon[:-1, None],
-                            t_lat[1:, None], t_lon[1:, None],
-                            log=True, normalize=False, method=metric)
+    norm, vec = coord_util.dist_approx(t_lat[:-1, None], t_lon[:-1, None],
+                                       t_lat[1:, None], t_lon[1:, None],
+                                       log=True, normalize=False, method=metric)
     v_trans[1:, :] = vec[:, 0, 0]
     v_trans[1:, :] *= KMH_TO_MS / t_tstep[1:, None]
     v_trans_norm[1:] = norm[:, 0, 0]

--- a/climada/util/test/test_interpolation.py
+++ b/climada/util/test/test_interpolation.py
@@ -21,7 +21,7 @@ Test interpolation module.
 import unittest
 import numpy as np
 
-import climada.util.interpolation as interp
+import climada.util.interpolation as u_interp
 from climada.util.constants import ONE_LAT_KM
 
 def def_input_values():
@@ -117,7 +117,7 @@ class TestDistance(unittest.TestCase):
         lats2 = 14
         lons2 = 56
         self.assertAlmostEqual(7709.827814738594,
-                               interp.dist_approx(lats1, lons1, cos_lats1, lats2, lons2))
+                               u_interp.dist_approx(lats1, lons1, cos_lats1, lats2, lons2))
 
     def test_dist_sqr_approx_pass(self):
         """Test against matlab reference."""
@@ -128,7 +128,7 @@ class TestDistance(unittest.TestCase):
         lons2 = 56
         self.assertAlmostEqual(
             7709.827814738594,
-            np.sqrt(interp.dist_sqr_approx(lats1, lons1, cos_lats1, lats2, lons2)) * ONE_LAT_KM)
+            np.sqrt(u_interp.dist_sqr_approx(lats1, lons1, cos_lats1, lats2, lons2)) * ONE_LAT_KM)
 
 class TestInterpIndex(unittest.TestCase):
     """Test interpol_index function's interface"""
@@ -136,41 +136,41 @@ class TestInterpIndex(unittest.TestCase):
     def test_wrong_method_fail(self):
         """Check exception is thrown when wrong method is given"""
         with self.assertLogs('climada.util.interpolation', level='ERROR') as cm:
-            interp.interpol_index(np.ones((10, 2)), np.ones((7, 2)), 'method')
+            u_interp.interpol_index(np.ones((10, 2)), np.ones((7, 2)), 'method')
         self.assertIn('Interpolation using method with distance haversine is not supported.',
                       cm.output[0])
 
     def test_wrong_distance_fail(self):
         """Check exception is thrown when wrong distance is given"""
         with self.assertLogs('climada.util.interpolation', level='ERROR') as cm:
-            interp.interpol_index(np.ones((10, 2)), np.ones((7, 2)),
-                                  distance='distance')
+            u_interp.interpol_index(np.ones((10, 2)), np.ones((7, 2)),
+                                    distance='distance')
         self.assertIn('Interpolation using NN with distance distance is not supported.',
                       cm.output[0])
 
     def test_wrong_centroid_fail(self):
         """Check exception is thrown when centroids missing one dimension"""
         with self.assertRaises(IndexError):
-            interp.interpol_index(np.ones((10, 1)), np.ones((7, 2)),
-                                  distance='approx')
+            u_interp.interpol_index(np.ones((10, 1)), np.ones((7, 2)),
+                                    distance='approx')
         with self.assertRaises(ValueError):
-            interp.interpol_index(np.ones((10, 1)), np.ones((7, 2)),
-                                  distance='haversine')
+            u_interp.interpol_index(np.ones((10, 1)), np.ones((7, 2)),
+                                    distance='haversine')
 
     def test_wrong_coord_fail(self):
         """Check exception is thrown when coordinates missing one dimension"""
         with self.assertRaises(IndexError):
-            interp.interpol_index(np.ones((10, 2)), np.ones((7, 1)),
-                                  distance='approx')
+            u_interp.interpol_index(np.ones((10, 2)), np.ones((7, 1)),
+                                    distance='approx')
         with self.assertRaises(ValueError):
-            interp.interpol_index(np.ones((10, 2)), np.ones((7, 1)),
-                                  distance='haversine')
+            u_interp.interpol_index(np.ones((10, 2)), np.ones((7, 1)),
+                                    distance='haversine')
 
 class TestNN(unittest.TestCase):
     """Test interpolator neareast neighbor with approximate distance"""
 
     def tearDown(self):
-        interp.THRESHOLD = 100
+        u_interp.THRESHOLD = 100
 
     def normal_pass(self, dist):
         """Checking result against matlab climada_demo_step_by_step"""
@@ -178,8 +178,8 @@ class TestNN(unittest.TestCase):
         exposures, centroids = def_input_values()
 
         # Interpolate with default threshold
-        neighbors = interp.interpol_index(centroids, exposures,
-                                          'NN', dist)
+        neighbors = u_interp.interpol_index(centroids, exposures,
+                                            'NN', dist)
         # Reference output
         ref_neighbors = def_ref()
         # Check results
@@ -195,8 +195,8 @@ class TestNN(unittest.TestCase):
         # Interpolate with lower threshold to raise warnings
         threshold = 50
         with self.assertLogs('climada.util.interpolation', level='INFO') as cm:
-            neighbors = interp.interpol_index(centroids, exposures, 'NN',
-                                              dist, threshold=threshold)
+            neighbors = u_interp.interpol_index(centroids, exposures, 'NN',
+                                                dist, threshold=threshold)
         self.assertIn("Distance to closest centroid", cm.output[0])
 
         ref_neighbors = def_ref_50()
@@ -213,7 +213,7 @@ class TestNN(unittest.TestCase):
         exposures[2, :] = exposures[0, :]
 
         # Interpolate with default threshold
-        neighbors = interp.interpol_index(centroids, exposures, 'NN', dist)
+        neighbors = u_interp.interpol_index(centroids, exposures, 'NN', dist)
 
         # Check output neighbors have same size as coordinates
         self.assertEqual(len(neighbors), exposures.shape[0])


### PR DESCRIPTION
When computing wind fields from TCTracks and a Centroids object, this PR improves memory efficiency by filtering out centroids early on that are not within reach of any of the TC tracks.

Previously to this PR, filtering was done for coastal centroids, but the reachability was only checked on a track-by-track basis. This would allocate a lot of unnecessary memory when there are many centroids that are never reached by any of the TC tracks.