### PR TITLE
Feature/knutson big tc

### DIFF
--- a/climada/hazard/trop_cyclone.py
+++ b/climada/hazard/trop_cyclone.py
@@ -412,7 +412,6 @@ class TropCyclone(Hazard):
                 else:
                     new_val[select] *= change
                 setattr(haz_cc, chg['variable'], new_val)
-                setattr(haz_cc, chg['variable'], new_val)
         return haz_cc
 
 def compute_windfields(track, centroids, model, metric="equirect"):

--- a/climada/hazard/trop_cyclone.py
+++ b/climada/hazard/trop_cyclone.py
@@ -408,13 +408,7 @@ class TropCyclone(Hazard):
                 #For sparse matrices *= is ineficient (slow, uses large memory)
                 #Instead use multiply and chunking
                 if isinstance(new_val, sparse.csr_matrix):
-                    chunk_size = 10
-                    n_chunks = int(len(select) / chunk_size)
-                    chunks = np.arange(0, n_chunks, chunk_size)
-                    chunks = np.append(chunks, n_chunks)
-                    for start, stop in zip(chunks[:-1], chunks[1:]):
-                        new_val[select[start:stop]] = \
-                            new_val[select[start:stop]].multiply(change)
+                    new_val = sparse.diags(np.where(select, change, 1)).dot(new_val)
                 else:
                     new_val[select] *= change
                 setattr(haz_cc, chg['variable'], new_val)

--- a/climada/hazard/trop_cyclone.py
+++ b/climada/hazard/trop_cyclone.py
@@ -405,8 +405,8 @@ class TropCyclone(Hazard):
                 change = chg['change'] * scale
             if select.any():
                 new_val = getattr(haz_cc, chg['variable'])
-                #For sparse matrices *= is ineficient (slow, uses large memory)
-                #Instead use multiply and chunking
+                # 1d-masks like `select` are inefficient for indexing sparse matrices since
+                # they are broadcasted densely in the second dimension
                 if isinstance(new_val, sparse.csr_matrix):
                     new_val = sparse.diags(np.where(select, change, 1)).dot(new_val)
                 else:

--- a/climada/hazard/trop_cyclone.py
+++ b/climada/hazard/trop_cyclone.py
@@ -415,7 +415,6 @@ class TropCyclone(Hazard):
                     for start, stop in zip(chunks[:-1], chunks[1:]):
                         new_val[select[start:stop]] = \
                             new_val[select[start:stop]].multiply(change)
-                        print(start, stop)
                 else:
                     new_val[select] *= change
                 setattr(haz_cc, chg['variable'], new_val)


### PR DESCRIPTION
This pull request is to fix a problem where `TropCyclone.set_climate_scenario_knu` would crash when a TC with a large number of tracks and centroids is used. 

Basically (as explained in a comment in the code), multiplying the intensity or frequency, which are sparse matrices, by a constant using `*=` is both slow and memory hungry. 

I solved it by detecting sparse matrices and then
a) replace `*=cst` by `csr_matrix.multiply(cst)
b) chunk the multiplication in small bits (very fast and memory-efficient in my testing)