### PR TITLE
TCTracks.equal_timestep: restrict to times within original bounds

### DIFF
--- a/climada/hazard/tc_tracks.py
+++ b/climada/hazard/tc_tracks.py
@@ -511,7 +511,6 @@ class TCTracks():
             st_penv = xr.apply_ufunc(basin_fun, track_ds.basin, vectorize=True)
 
             # set time_step in hours
-            track_ds.time.values[:1] = track_ds.time[:1].dt.floor('H')
             track_ds['time_step'] = xr.ones_like(track_ds.time, dtype=float)
             if track_ds.time.size > 1:
                 track_ds.time_step.values[1:] = (track_ds.time.diff(dim="date_time")
@@ -1293,6 +1292,9 @@ class TCTracks():
             track_int.attrs['category'] = set_category(
                 track_int.max_sustained_wind.values,
                 track_int.max_sustained_wind_unit)
+            # restrict to time steps within original bounds
+            track_int = track_int.sel(
+                time=(track.time[0] <= track_int.time) & (track_int.time <= track.time[-1]))
         else:
             LOGGER.warning('Track interpolation not done. '
                            'Not enough elements for %s', track.name)

--- a/climada/hazard/test/test_tc_tracks.py
+++ b/climada/hazard/test/test_tc_tracks.py
@@ -463,6 +463,7 @@ class TestFuncs(unittest.TestCase):
         self.assertEqual(np.max(tc_track.data[0].radius_max_wind), 0)
         self.assertEqual(np.min(tc_track.data[0].radius_max_wind), 0)
         self.assertEqual(tc_track.data[0].max_sustained_wind[21], 25)
+        self.assertTrue(np.isfinite(tc_track.data[0].central_pressure.values).all())
         self.assertAlmostEqual(tc_track.data[0].central_pressure.values[29], 1008, places=0)
         self.assertEqual(np.max(tc_track.data[0].environmental_pressure), 1010)
         self.assertEqual(np.min(tc_track.data[0].environmental_pressure), 1010)
@@ -480,18 +481,23 @@ class TestFuncs(unittest.TestCase):
 
         # test some "generic floats"
         for time_step_h in [0.6663545049172093, 2.509374054925788, 8.175754471661111]:
-            tc_track = tc.TCTracks()
-            tc_track.read_processed_ibtracs_csv(TEST_TRACK)
-            tc_track.equal_timestep(time_step_h=time_step_h)
-            self.assertTrue(np.all(tc_track.data[0].time_step == time_step_h))
+            # artifically create data that doesn't start at full hour
+            for loffset in [0, 22, 30]:
+                tc_track = tc.TCTracks()
+                tc_track.read_processed_ibtracs_csv(TEST_TRACK)
+                tc_track.data[0].time.values[:] += np.timedelta64(loffset, "m")
+                tc_track.equal_timestep(time_step_h=time_step_h)
+                np.testing.assert_array_equal(tc_track.data[0].time_step, time_step_h)
+                self.assertTrue(np.isfinite(tc_track.data[0].central_pressure.values).all())
 
         tc_track = tc.TCTracks()
         tc_track.read_processed_ibtracs_csv(TEST_TRACK)
         tc_track.equal_timestep(time_step_h=0.16667)
 
-        self.assertEqual(tc_track.data[0].time.size, 1333)
+        self.assertEqual(tc_track.data[0].time.size, 1332)
         self.assertTrue(np.all(tc_track.data[0].time_step == 0.16667))
-        self.assertAlmostEqual(tc_track.data[0].lon.values[66], -27.397636528537127)
+        self.assertTrue(np.isfinite(tc_track.data[0].central_pressure.values).all())
+        self.assertAlmostEqual(tc_track.data[0].lon.values[65], -27.397636528537127)
 
         for time_step_h in [0, -0.5, -1]:
             tc_track = tc.TCTracks()


### PR DESCRIPTION
Following up on #123 about improving the `TCTracks.read_ibtracs_netcdf` function, we found a little issue (#134) in the `TCTracks.equal_timestep` function that affects tracks for which the first time step is not rounded to full hours. More precisely, all tracks are affected for which the first time step is not a multiple of `time_step_h`.

For example, if `time_step_h=1` and the first time step of the track is `06:30:00`, then the output of `equal_timestep` will be a track that starts at `06:00:00` with NaN values. The following time steps (`07:00:00` and so on) will be okay.

Another, more general, example: If `time_step_h=0.75` and the first time step of the track is `02:00:00`, then the output of `equal_timestep` will be a track that starts at `01:30:00` with NaN values. The following time steps (`02:15:00`, `03:00:00` and so on) will be okay.

This PR restricts the output of `equal_timestep` to times within the time bounds of the original track so that no additional NaNs are produced.