### PR TITLE
u_coord.points_to_raster: fix for antimeridian

### DIFF
--- a/climada/entity/exposures/base.py
+++ b/climada/entity/exposures/base.py
@@ -266,7 +266,7 @@ class Exposures():
             haz_coord = hazard.centroids.coord
 
             if np.array_equal(coord, haz_coord):
-                assigned = np.arange(self.shape[0])
+                assigned = np.arange(self.gdf.shape[0])
             else:
                 # pairs of floats can be sorted (lexicographically) in NumPy
                 coord_view = coord.view(dtype='float64,float64').reshape(-1)
@@ -462,23 +462,26 @@ class Exposures():
             ras_tiff.write(raster.astype(np.float32), 1)
             ras_tiff.close()
         # make plot
-        crs_epsg, _ = u_plot.get_transformation(self.crs)
-        if isinstance(crs_epsg, ccrs.PlateCarree):
+        proj_data, _ = u_plot.get_transformation(self.crs)
+        proj_plot = proj_data
+        if isinstance(proj_data, ccrs.PlateCarree):
+            # use different projections for plot and data to shift the central lon in the plot
             xmin, ymin, xmax, ymax = u_coord.latlon_bounds(
                 self.gdf.latitude.values, self.gdf.longitude.values)
-            mid_lon = 0.5 * (xmin + xmax)
-            crs_epsg = ccrs.PlateCarree(central_longitude=mid_lon)
+            proj_plot = ccrs.PlateCarree(central_longitude=0.5 * (xmin + xmax))
         else:
             xmin, ymin, xmax, ymax = (self.gdf.longitude.min(), self.gdf.latitude.min(),
                                       self.gdf.longitude.max(), self.gdf.latitude.max())
+
         if not axis:
-            _, axis = u_plot.make_map(proj=crs_epsg)
+            _, axis = u_plot.make_map(proj=proj_plot)
+
         cbar_ax = make_axes_locatable(axis).append_axes('right', size="6.5%",
                                                         pad=0.1, axes_class=plt.Axes)
-        axis.set_extent((xmin, xmax, ymin, ymax), crs_epsg)
+        axis.set_extent((xmin, xmax, ymin, ymax), crs=proj_data)
         u_plot.add_shapes(axis)
         imag = axis.imshow(raster_f(raster), **kwargs, origin='upper',
-                           extent=(xmin, xmax, ymin, ymax), transform=crs_epsg)
+                           extent=(xmin, xmax, ymin, ymax), transform=proj_data)
         plt.colorbar(imag, cax=cbar_ax, label=label)
         plt.draw()
         return axis

--- a/climada/hazard/centroids/centr.py
+++ b/climada/hazard/centroids/centr.py
@@ -24,6 +24,7 @@ import copy
 import logging
 from pathlib import Path
 
+import cartopy.crs as ccrs
 import geopandas as gpd
 import h5py
 import numpy as np
@@ -36,19 +37,8 @@ from shapely.geometry.point import Point
 from climada.util.constants import (DEF_CRS,
                                     ONE_LAT_KM,
                                     NATEARTH_CENTROIDS)
-from climada.util.coordinates import (coord_on_land,
-                                      dist_to_coast,
-                                      dist_to_coast_nasa,
-                                      equal_crs,
-                                      get_country_code,
-                                      get_resolution,
-                                      pts_to_raster_meta,
-                                      raster_to_meshgrid,
-                                      read_raster,
-                                      read_raster_sample,
-                                      read_vector,
-                                      lon_normalize,
-                                      NE_CRS)
+
+import climada.util.coordinates as u_coord
 import climada.util.hdf5_handler as u_hdf5
 import climada.util.plot as u_plot
 
@@ -166,15 +156,15 @@ class Centroids():
         eq : bool
         """
         if self.meta and centr.meta:
-            return equal_crs(self.meta['crs'], centr.meta['crs']) \
-                and self.meta['height'] == centr.meta['height'] \
-                and self.meta['width'] == centr.meta['width'] \
-                and self.meta['transform'] == centr.meta['transform']
-        return equal_crs(self.geometry.crs, centr.geometry.crs) \
-            and self.lat.shape == centr.lat.shape \
-            and self.lon.shape == centr.lon.shape \
-            and np.allclose(self.lat, centr.lat) \
-            and np.allclose(self.lon, centr.lon)
+            return (u_coord.equal_crs(self.meta['crs'], centr.meta['crs'])
+                    and self.meta['height'] == centr.meta['height']
+                    and self.meta['width'] == centr.meta['width']
+                    and self.meta['transform'] == centr.meta['transform'])
+        return (equal_crs(self.geometry.crs, centr.geometry.crs)
+                and self.lat.shape == centr.lat.shape
+                and self.lon.shape == centr.lon.shape
+                and np.allclose(self.lat, centr.lat)
+                and np.allclose(self.lon, centr.lon))
 
     @staticmethod
     def from_base_grid(land=False, res_as=360, base_file=None):
@@ -313,7 +303,7 @@ class Centroids():
             CRS. Default: DEF_CRS
         """
         self.__init__()
-        rows, cols, ras_trans = pts_to_raster_meta(points_bounds, (res, -res))
+        rows, cols, ras_trans = u_coord.pts_to_raster_meta(points_bounds, (res, -res))
         self.meta = {
             'width': cols,
             'height': rows,
@@ -377,17 +367,18 @@ class Centroids():
             Each row is an event.
         """
         if not self.meta:
-            self.meta, inten = read_raster(file_name, band, src_crs, window,
-                                           geometry, dst_crs, transform, width,
-                                           height, resampling)
+            self.meta, inten = u_coord.read_raster(
+                file_name, band, src_crs, window, geometry, dst_crs,
+                transform, width, height, resampling)
             return sparse.csr_matrix(inten)
 
-        tmp_meta, inten = read_raster(file_name, band, src_crs, window, geometry,
-                                      dst_crs, transform, width, height, resampling)
-        if (tmp_meta['crs'] != self.meta['crs']) \
-           or (tmp_meta['transform'] != self.meta['transform']) \
-           or (tmp_meta['height'] != self.meta['height']) \
-           or (tmp_meta['width'] != self.meta['width']):
+        tmp_meta, inten = u_coord.read_raster(
+            file_name, band, src_crs, window, geometry, dst_crs,
+            transform, width, height, resampling)
+        if (tmp_meta['crs'] != self.meta['crs']
+                or tmp_meta['transform'] != self.meta['transform']
+                or tmp_meta['height'] != self.meta['height']
+                or tmp_meta['width'] != self.meta['width']):
             LOGGER.error('Raster data is inconsistent with contained raster.')
             raise ValueError
         return sparse.csr_matrix(inten)
@@ -412,12 +403,14 @@ class Centroids():
             Sparse intensity array of shape (len(inten_name), len(geometry)).
         """
         if not self.geometry.crs:
-            self.lat, self.lon, self.geometry, inten = read_vector(file_name, inten_name, dst_crs)
+            self.lat, self.lon, self.geometry, inten = u_coord.read_vector(
+                file_name, inten_name, dst_crs)
             return sparse.csr_matrix(inten)
-        tmp_lat, tmp_lon, tmp_geometry, inten = read_vector(file_name, inten_name, dst_crs)
-        if not equal_crs(tmp_geometry.crs, self.geometry.crs) or \
-        not np.allclose(tmp_lat, self.lat) or\
-        not np.allclose(tmp_lon, self.lon):
+        tmp_lat, tmp_lon, tmp_geometry, inten = u_coord.read_vector(
+            file_name, inten_name, dst_crs)
+        if not (equal_crs(tmp_geometry.crs, self.geometry.crs)
+                and np.allclose(tmp_lat, self.lat)
+                and np.allclose(tmp_lon, self.lon)):
             LOGGER.error('Vector data inconsistent with contained vector.')
             raise ValueError
         return sparse.csr_matrix(inten)
@@ -540,7 +533,7 @@ class Centroids():
             self.lat, self.lon = np.array([]), np.array([])
         else:
             LOGGER.debug('Appending points')
-            if not equal_crs(centr.geometry.crs, self.geometry.crs):
+            if not u_coord.equal_crs(centr.geometry.crs, self.geometry.crs):
                 LOGGER.error('Different CRS not accepted.')
                 raise ValueError
             self.lat = np.append(self.lat, centr.lat)
@@ -598,8 +591,8 @@ class Centroids():
         """
         ne_geom = self._ne_crs_geom(scheduler)
         LOGGER.debug('Setting region_id %s points.', str(self.lat.size))
-        self.region_id = get_country_code(ne_geom.geometry[:].y.values,
-                                          ne_geom.geometry[:].x.values)
+        self.region_id = u_coord.get_country_code(
+            ne_geom.geometry[:].y.values, ne_geom.geometry[:].x.values)
 
     def set_area_pixel(self, min_resol=1.0e-8, scheduler=None):
         """Set `area_pixel` attribute for every pixel or point (area in m*m).
@@ -623,14 +616,14 @@ class Centroids():
                 raise ValueError
             res = self.meta['transform'].a
         else:
-            res = get_resolution(self.lat, self.lon, min_resol=min_resol)
+            res = u_coord.get_resolution(self.lat, self.lon, min_resol=min_resol)
             res = np.abs(res).min()
         self.set_geometry_points(scheduler)
         LOGGER.debug('Setting area_pixel %s points.', str(self.lat.size))
         xy_pixels = self.geometry.buffer(res / 2).envelope
         is_cea = ('units' in self.geometry.crs
                   and self.geometry.crs['units'] in ['m', 'metre', 'meter']
-                  or equal_crs(self.geometry.crs, {'proj': 'cea'}))
+                  or u_coord.equal_crs(self.geometry.crs, {'proj': 'cea'}))
         if is_cea:
             self.area_pixel = xy_pixels.area.values
         else:
@@ -659,13 +652,13 @@ class Centroids():
             lon_unique_len = self.meta['width']
             res_lat = abs(res_lat)
         else:
-            res_lat, res_lon = np.abs(get_resolution(self.lat, self.lon,
-                                                     min_resol=min_resol))
+            res_lat, res_lon = np.abs(
+                u_coord.get_resolution(self.lat, self.lon, min_resol=min_resol))
             lat_unique = np.array(np.unique(self.lat))
             lon_unique_len = len(np.unique(self.lon))
             is_cea = ('units' in self.geometry.crs
                       and self.geometry.crs['units'] in ['m', 'metre', 'meter']
-                      or equal_crs(self.geometry.crs, {'proj': 'cea'}))
+                      or u_coord.equal_crs(self.geometry.crs, {'proj': 'cea'}))
             if is_cea:
                 self.area_pixel = np.repeat(res_lat * res_lon, lon_unique_len)
                 return
@@ -690,7 +683,7 @@ class Centroids():
         """
         if not self.coord.size:
             self.set_meta_to_lat_lon()
-        self.elevation = read_raster_sample(topo_path, self.lat, self.lon)
+        self.elevation = u_coord.read_raster_sample(topo_path, self.lat, self.lon)
 
     def set_dist_coast(self, signed=False, precomputed=False, scheduler=None):
         """Set dist_coast attribute for every pixel or point in meters.
@@ -707,11 +700,12 @@ class Centroids():
         if precomputed:
             if not self.lat.size or not self.lon.size:
                 self.set_meta_to_lat_lon()
-            self.dist_coast = dist_to_coast_nasa(self.lat, self.lon, highres=True, signed=signed)
+            self.dist_coast = u_coord.dist_to_coast_nasa(
+                self.lat, self.lon, highres=True, signed=signed)
         else:
             ne_geom = self._ne_crs_geom(scheduler)
             LOGGER.debug('Computing distance to coast for %s centroids.', str(self.lat.size))
-            self.dist_coast = dist_to_coast(ne_geom, signed=signed)
+            self.dist_coast = u_coord.dist_to_coast(ne_geom, signed=signed)
 
     def set_on_land(self, scheduler=None):
         """Set on_land attribute for every pixel or point.
@@ -723,7 +717,8 @@ class Centroids():
         """
         ne_geom = self._ne_crs_geom(scheduler)
         LOGGER.debug('Setting on_land %s points.', str(self.lat.size))
-        self.on_land = coord_on_land(ne_geom.geometry[:].y.values, ne_geom.geometry[:].x.values)
+        self.on_land = u_coord.coord_on_land(
+            ne_geom.geometry[:].y.values, ne_geom.geometry[:].x.values)
 
     def remove_duplicate_points(self, scheduler=None):
         """Return Centroids with removed duplicated points
@@ -771,7 +766,8 @@ class Centroids():
             if extent:
                 lon_min, lon_max, lat_min, lat_max = extent
                 lon_max += 360 if lon_min > lon_max else 0
-                lon_normalized = lon_normalize(self.lon.copy(), center=0.5 * (lon_min + lon_max))
+                lon_normalized = u_coord.lon_normalize(
+                    self.lon.copy(), center=0.5 * (lon_min + lon_max))
                 sel_cen &= (
                   (lon_normalized >= lon_min) & (lon_normalized <= lon_max) &
                   (self.lat >= lat_min) & (self.lat <= lat_max)
@@ -801,8 +797,8 @@ class Centroids():
         min_resol : float, optional
             Minimum centroids resolution to use in the raster. Default: 1.0e-8.
         """
-        res = get_resolution(self.lon, self.lat, min_resol=min_resol)
-        rows, cols, ras_trans = pts_to_raster_meta(self.total_bounds, res)
+        res = u_coord.get_resolution(self.lon, self.lat, min_resol=min_resol)
+        rows, cols, ras_trans = u_coord.pts_to_raster_meta(self.total_bounds, res)
         LOGGER.debug('Resolution points: %s', str(res))
         self.meta = {
             'width': cols,
@@ -813,9 +809,8 @@ class Centroids():
 
     def set_meta_to_lat_lon(self):
         """Compute lat and lon of every pixel center from meta raster."""
-        xgrid, ygrid = raster_to_meshgrid(self.meta['transform'],
-                                          self.meta['width'],
-                                          self.meta['height'])
+        xgrid, ygrid = u_coord.raster_to_meshgrid(
+            self.meta['transform'], self.meta['width'], self.meta['height'])
         self.lon = xgrid.flatten()
         self.lat = ygrid.flatten()
         self.geometry = gpd.GeoSeries(crs=self.meta['crs'])
@@ -834,12 +829,26 @@ class Centroids():
         -------
         axis : matplotlib.axes._subplots.AxesSubplot
         """
-        if not axis:
-            _, axis = u_plot.make_map()
-        u_plot.add_shapes(axis)
         if self.meta and not self.coord.size:
             self.set_meta_to_lat_lon()
-        axis.scatter(self.lon, self.lat, **kwargs)
+        pad = np.abs(u_coord.get_resolution(self.lat, self.lon)).min()
+
+        proj_data, _ = u_plot.get_transformation(self.crs)
+        proj_plot = proj_data
+        if isinstance(proj_data, ccrs.PlateCarree):
+            # use different projections for plot and data to shift the central lon in the plot
+            xmin, ymin, xmax, ymax = u_coord.latlon_bounds(self.lat, self.lon, buffer=pad)
+            proj_plot = ccrs.PlateCarree(central_longitude=0.5 * (xmin + xmax))
+        else:
+            xmin, ymin, xmax, ymax = (self.lon.min() - pad, self.lat.min() - pad,
+                                      self.lon.max() + pad, self.lat.max() + pad)
+
+        if not axis:
+            _, axis = u_plot.make_map(proj=proj_plot)
+
+        axis.set_extent((xmin, xmax, ymin, ymax), crs=proj_data)
+        u_plot.add_shapes(axis)
+        axis.scatter(self.lon, self.lat, transform=proj_data, **kwargs)
         return axis
 
     def calc_pixels_polygons(self, scheduler=None):
@@ -1024,10 +1033,10 @@ class Centroids():
         """
         if not self.lat.size or not self.lon.size:
             self.set_meta_to_lat_lon()
-        if equal_crs(self.geometry.crs, NE_CRS) and self.geometry.size:
+        if u_coord.equal_crs(self.geometry.crs, u_coord.NE_CRS) and self.geometry.size:
             return self.geometry
         self.set_geometry_points(scheduler)
-        return self.geometry.to_crs(NE_CRS)
+        return self.geometry.to_crs(u_coord.NE_CRS)
 
     def __deepcopy__(self, memo):
         """Avoid error deep copy in gpd.GeoSeries by setting only the crs."""
@@ -1066,7 +1075,7 @@ def generate_nat_earth_centroids(res_as=360, path=None, dist_coast=False):
     lat_dim = np.arange(-90 + res_deg, 90, res_deg)
     lon_dim = np.arange(-180 + res_deg, 180 + res_deg, res_deg)
     lon, lat = [ar.ravel() for ar in np.meshgrid(lon_dim, lat_dim)]
-    natids = np.uint16(get_country_code(lat, lon, gridded=False))
+    natids = np.uint16(u_coord.get_country_code(lat, lon, gridded=False))
 
     cen = Centroids()
     cen.set_lat_lon(lat, lon)

--- a/climada/util/coordinates.py
+++ b/climada/util/coordinates.py
@@ -1333,33 +1333,27 @@ def read_raster_bounds(path, bounds, res=None, bands=None):
         width, height = bounds[2] - bounds[0], bounds[3] - bounds[1]
         shape = (int(np.ceil(height / res[1]) + 1),
                  int(np.ceil(width / res[0]) + 1))
+
+        # make sure that the extent of pixel centers covers the specified regions
         extra = (0.5 * ((shape[1] - 1) * res[0] - width),
                  0.5 * ((shape[0] - 1) * res[1] - height))
         bounds = (bounds[0] - extra[0] - 0.5 * res[0], bounds[1] - extra[1] - 0.5 * res[1],
                   bounds[2] + extra[0] + 0.5 * res[0], bounds[3] + extra[1] + 0.5 * res[1])
 
-        if bounds[0] > 180:
-            bounds = (bounds[0] - 360, bounds[1], bounds[2] - 360, bounds[3])
-
-        window = src.window(*bounds)
-        w_transform = src.window_transform(window)
-        transform = rasterio.Affine(np.sign(w_transform[0]) * res[0], 0, w_transform[2],
-                                    0, np.sign(w_transform[4]) * res[1], w_transform[5])
-
-        if bounds[2] <= 180:
-            data = src.read(bands, out_shape=shape, window=window,
-                            resampling=resampling)
-        else:
-            # split up at antimeridian
-            bounds_sub = [(bounds[0], bounds[1], 180, bounds[3]),
-                          (-180, bounds[1], bounds[2] - 360, bounds[3])]
-            ratio_left = (bounds_sub[0][2] - bounds_sub[0][0]) / (bounds[2] - bounds[0])
-            shapes_sub = [(shape[0], int(shape[1] * ratio_left))]
-            shapes_sub.append((shape[0], shape[1] - shapes_sub[0][1]))
-            windows_sub = [src.window(*bds) for bds in bounds_sub]
-            data = [src.read(bands, out_shape=shp, window=win, resampling=resampling)
-                    for shp, win in zip(shapes_sub, windows_sub)]
-            data = np.concatenate(data, axis=2)
+        data = np.zeros((len(bands),) + shape, dtype=src.dtypes[0])
+        res = (np.sign(src.transform[0]) * res[0], np.sign(src.transform[4]) * res[1])
+        transform = rasterio.Affine(res[0], 0, bounds[0] if res[0] > 0 else bounds[2],
+                                    0, res[1], bounds[1] if res[1] > 0 else bounds[3])
+        crs = DEF_CRS if src.crs is None else src.crs
+        for iband, band in enumerate(bands):
+            rasterio.warp.reproject(
+                source=rasterio.band(src, band),
+                destination=data[iband],
+                src_transform=src.transform,
+                src_crs=src.crs,
+                dst_transform=transform,
+                dst_crs=crs,
+                resampling=resampling)
     return data, transform
 
 def read_raster_sample(path, lat, lon, intermediate_res=None, method='linear', fill_value=None):
@@ -1609,7 +1603,7 @@ def points_to_raster(points_df, val_names=None, res=0.0, raster_res=0.0, schedul
         return df_exp.apply(fun, axis=1)
 
     LOGGER.info('Raster from resolution %s to %s.', res, raster_res)
-    df_poly = points_df[val_names]
+    df_poly = gpd.GeoDataFrame(points_df[val_names])
     if not scheduler:
         df_poly['geometry'] = apply_box(points_df)
     else:
@@ -1617,9 +1611,19 @@ def points_to_raster(points_df, val_names=None, res=0.0, raster_res=0.0, schedul
                                npartitions=cpu_count())
         df_poly['geometry'] = ddata.map_partitions(apply_box, meta=Polygon) \
                                    .compute(scheduler=scheduler)
+    df_poly.crs = points_df.crs
+
+    # renormalize longitude if necessary
+    if df_poly.crs == DEF_CRS:
+        xmin, ymin, xmax, ymax = latlon_bounds(points_df.latitude.values,
+                                               points_df.longitude.values)
+        x_mid = 0.5 * (xmin + xmax)
+        df_poly = df_poly.to_crs({"proj": "longlat", "lon_wrap": x_mid})
+    else:
+        xmin, ymin, xmax, ymax = (points_df.longitude.min(), points_df.latitude.min(),
+                                  points_df.longitude.max(), points_df.latitude.max())
+
     # construct raster
-    xmin, ymin, xmax, ymax = (points_df.longitude.min(), points_df.latitude.min(),
-                              points_df.longitude.max(), points_df.latitude.max())
     rows, cols, ras_trans = pts_to_raster_meta((xmin, ymin, xmax, ymax),
                                                (raster_res, -raster_res))
     raster_out = np.zeros((len(val_names), rows, cols))

--- a/climada/util/plot.py
+++ b/climada/util/plot.py
@@ -40,7 +40,7 @@ from rasterio.crs import CRS
 import requests
 
 from climada.util.files_handler import to_list
-from climada.util.coordinates import grid_is_regular
+import climada.util.coordinates as u_coord
 
 LOGGER = logging.getLogger(__name__)
 
@@ -75,7 +75,7 @@ def geo_bin_from_array(array_sub, geo_coord, var_name, title, pop_name=True,
         buffer (float, optional): border to add to coordinates
         extend (str, optional): extend border colorbar with arrows.
             [ 'neither' | 'both' | 'min' | 'max' ]
-        proj (ccrs): coordinate reference system used in coordinates
+        proj (ccrs): coordinate reference system of the given data
         kwargs (optional): arguments for hexbin matplotlib function
 
     Returns:
@@ -92,8 +92,15 @@ def geo_bin_from_array(array_sub, geo_coord, var_name, title, pop_name=True,
 
     if 'cmap' not in kwargs:
         kwargs['cmap'] = 'Wistia'
+
     if axes is None:
-        _, axes = make_map(num_im, proj=proj)
+        proj_plot = proj
+        if isinstance(proj, ccrs.PlateCarree):
+            # use different projections for plot and data to shift the central lon in the plot
+            xmin, xmax = u_coord.lon_bounds(np.concatenate([c[:, 1] for c in list_coord]))
+            proj_plot = ccrs.PlateCarree(central_longitude=0.5 * (xmin + xmax))
+        _, axes = make_map(num_im, proj=proj_plot)
+
     if not isinstance(axes, np.ndarray):
         axes_iter = np.array([[axes]])
 
@@ -104,8 +111,13 @@ def geo_bin_from_array(array_sub, geo_coord, var_name, title, pop_name=True,
             raise ValueError("Size mismatch in input array: %s != %s." %
                              (coord.shape[0], array_im.size))
 
+
         # Binned image with coastlines
-        extent = _get_borders(coord, buffer=buffer, proj_limits=proj.x_limits + proj.y_limits)
+        if isinstance(proj, ccrs.PlateCarree):
+            xmin, ymin, xmax, ymax = u_coord.latlon_bounds(coord[:, 0], coord[:, 1], buffer=buffer)
+            extent = (xmin, xmax, ymin, ymax)
+        else:
+            extent = _get_borders(coord, buffer=buffer, proj_limits=proj.x_limits + proj.y_limits)
         axis.set_extent((extent), proj)
         add_shapes(axis)
         if pop_name:
@@ -226,7 +238,7 @@ def geo_im_from_array(array_sub, coord, var_name, title,
     list_tit = to_list(num_im, title, 'title')
     list_name = to_list(num_im, var_name, 'var_name')
 
-    is_reg, height, width = grid_is_regular(coord)
+    is_reg, height, width = u_coord.grid_is_regular(coord)
     extent = _get_borders(coord, proj_limits=(-360, 360, -90, 90))
     mid_lon = 0
     if not proj:
@@ -305,7 +317,7 @@ def make_map(num_sub=1, figsize=(9, 13), proj=ccrs.PlateCarree()):
     for axis in axes_iter.flatten():
         try:
             grid = axis.gridlines(draw_labels=True, alpha=0.2, transform=proj)
-            grid.xlabels_top = grid.ylabels_right = False
+            grid.top_labels = grid.right_labels = False
             grid.xformatter = LONGITUDE_FORMATTER
             grid.yformatter = LATITUDE_FORMATTER
         except TypeError:
@@ -495,7 +507,7 @@ def multibar_plot(ax, data, colors=None, total_width=0.8, single_width=1, legend
         }
         fig, ax = plt.subplots()
         multibar_plot(ax, data, xticklabels=["a", "b", "c"])
-        
+
 
     colors : array-like, optional
         A list of colors which are used for the bars. If None, the colors
@@ -512,12 +524,12 @@ def multibar_plot(ax, data, colors=None, total_width=0.8, single_width=1, legend
 
     legend: bool, optional, default: True
         If this is set to true, a legend will be added to the axis.
-        
+
     ticklabels: list, optional, default: None
         labels of the xticks (yticks if invert_axis=True)
-        
+
     invert_axis: boolean, default: False
-        Invert the x and y axis. By default, the bars are vertical. 
+        Invert the x and y axis. By default, the bars are vertical.
         invert_axis=True gives horizontal bars.
     """
 
@@ -548,7 +560,7 @@ def multibar_plot(ax, data, colors=None, total_width=0.8, single_width=1, legend
 
         # Add a handle to the last drawn bar, which we'll need for the legend
         bars.append(bar[0])
-           
+
     if ticklabels:
         if invert_axis:
             plt.setp(ax, yticks=range(len(data)), yticklabels=ticklabels);

--- a/climada/util/test/test_coordinates.py
+++ b/climada/util/test/test_coordinates.py
@@ -556,6 +556,23 @@ class TestRasterMeta(unittest.TestCase):
         self.assertEqual(meta['height'], 21)
         self.assertEqual(meta['width'], 5)
 
+        # test for values crossing antimeridian
+        df_val = gpd.GeoDataFrame(crs=DEF_CRS)
+        df_val['latitude'] = [1, 0, 1, 0]
+        df_val['longitude'] = [178, -179.0, 181, -180]
+        df_val['value'] = np.arange(4)
+        r_data, meta = points_to_raster(df_val, val_names=['value'], res=0.5, raster_res=1.0)
+        self.assertTrue(equal_crs(meta['crs'], df_val.crs))
+        self.assertAlmostEqual(meta['transform'][0], 1.0)
+        self.assertAlmostEqual(meta['transform'][1], 0)
+        self.assertAlmostEqual(meta['transform'][2], 177.5)
+        self.assertAlmostEqual(meta['transform'][3], 0)
+        self.assertAlmostEqual(meta['transform'][4], -1.0)
+        self.assertAlmostEqual(meta['transform'][5], 1.5)
+        self.assertEqual(meta['height'], 2)
+        self.assertEqual(meta['width'], 4)
+        np.testing.assert_array_equal(r_data[0], [[0, 0, 0, 2], [0, 0, 3, 1]])
+
 class TestRasterIO(unittest.TestCase):
     def test_write_raster_pass(self):
         """Test write_raster function."""


### PR DESCRIPTION
Following the discussion in #139, this PR fixes `climada.util.coordinates.points_to_raster` to correctly handle points that lie in an area crossing the antimeridian.

While I'm at it, I simplified the code of `climada.util.coordinates.read_raster_bounds` which was more complicated than necessary when the given bounds cross the antimeridian.

Similarly, I fixed `Centroids.plot` as well as `Exposures.plot_raster` and `Exposures.plot_hexbin` to correctly handle plot data crossing the antimeridian.