### PR TITLE
Feature/antimeridian centroids select

### DIFF
--- a/climada/hazard/centroids/centr.py
+++ b/climada/hazard/centroids/centr.py
@@ -772,8 +772,10 @@ class Centroids():
                 lon_min, lon_max, lat_min, lat_max = extent
                 lon_max += 360 if lon_min > lon_max else 0
                 lon_normalized = lon_normalize(self.lon.copy(), center=0.5 * (lon_min + lon_max))
-                sel_cen &= ((lon_min <= lon_normalized) & (lon_normalized <= lon_max)
-                            & (lat_min <= self.lat) & (self.lat <= lat_max))
+                sel_cen &= (
+                  (lon_normalized >= lon_min) & (lon_normalized <= lon_max) &
+                  (self.lat >= lat_min) & (self.lat <= lat_max)
+                )
 
 
         if not self.lat.size or not self.lon.size:

--- a/climada/hazard/centroids/centr.py
+++ b/climada/hazard/centroids/centr.py
@@ -751,6 +751,9 @@ class Centroids():
             region to filter according to region_id values
         extent : tuple
             Format (min_lon, max_lon, min_lat, max_lat) tuple.
+            If min_lon > lon_max, the extend crosses the antimeridian and is
+            [lon_max, 180] + [-180, lon_min]
+            Borders are inclusive.
         sel_cen : np.array
             1-dim mask, overrides reg_id and extent
 
@@ -761,7 +764,7 @@ class Centroids():
         """
 
         if sel_cen is None:
-            sel_cen = np.ones_like(self.region_id, dtype=bool)
+            sel_cen = np.ones_like(self.lat, dtype=bool)
             if reg_id:
                 sel_cen &= np.isin(self.region_id, reg_id)
             if extent:
@@ -778,11 +781,11 @@ class Centroids():
 
                 sel_cen &= (        
                     (
-                        ((self.lon > lon_min ) & (self.lon < mid_lon_min)) | 
-                        ((self.lon > mid_lon_max) & (self.lon < lon_max))
+                        ((self.lon >= lon_min ) & (self.lon <= mid_lon_min)) | 
+                        ((self.lon >= mid_lon_max) & (self.lon <= lon_max))
                     ) &
                     (
-                        (lat_min < self.lat) & (lat_max > self.lat)
+                        (self.lat >= lat_min) & (self.lat <= lat_max)
                     )
                     )
                     

--- a/climada/hazard/centroids/test/test_vec_ras.py
+++ b/climada/hazard/centroids/test/test_vec_ras.py
@@ -730,12 +730,33 @@ class TestCentroidsFuncs(unittest.TestCase):
         self.assertEqual(fil_centr.lon[0], VEC_LON[100])
         self.assertEqual(fil_centr.lon[1], VEC_LON[200])
         self.assertTrue(np.array_equal(fil_centr.region_id, np.ones(2) * 10))
+        
+    def test_select_extent_pass(self):
+        """Test select extent"""
+        centr = Centroids()
+        centr.set_lat_lon(np.array([-5, -3, 0, 3, 5]),
+                          np.array([-180, -175, -170, 170, 175]))
+        centr.check()
+        centr.region_id = np.zeros(len(centr.lat))
+        ext_centr = centr.select(extent=[-175, -170, -5, 5])
+        self.assertTrue(np.array_equal(ext_centr.lon, np.array([-175, -170])))
+        self.assertTrue(np.array_equal(ext_centr.lat, np.array([-3, 0])))
+        # Cross antimeridian
+        ext_centr = centr.select(extent=[170, -175, -5, 5])
+        self.assertTrue(np.array_equal(ext_centr.lon,
+                                       np.array([-180, -175, 170, 175])
+                                       )
+                        )
+        self.assertTrue(np.array_equal(ext_centr.lat,
+                                       np.array([-5, -3, 3, 5])
+                                       )
+                        )
 
 # Execute Tests
 if __name__ == "__main__":
     TESTS = unittest.TestLoader().loadTestsFromTestCase(TestRaster)
-    TESTS.addTests(unittest.TestLoader().loadTestsFromTestCase(TestVector))
-    TESTS.addTests(unittest.TestLoader().loadTestsFromTestCase(TestCentroids))
-    TESTS.addTests(unittest.TestLoader().loadTestsFromTestCase(TestReader))
+    # TESTS.addTests(unittest.TestLoader().loadTestsFromTestCase(TestVector))
+    # TESTS.addTests(unittest.TestLoader().loadTestsFromTestCase(TestCentroids))
+    # TESTS.addTests(unittest.TestLoader().loadTestsFromTestCase(TestReader))
     TESTS.addTests(unittest.TestLoader().loadTestsFromTestCase(TestCentroidsFuncs))
     unittest.TextTestRunner(verbosity=2).run(TESTS)

--- a/climada/hazard/centroids/test/test_vec_ras.py
+++ b/climada/hazard/centroids/test/test_vec_ras.py
@@ -730,7 +730,7 @@ class TestCentroidsFuncs(unittest.TestCase):
         self.assertEqual(fil_centr.lon[0], VEC_LON[100])
         self.assertEqual(fil_centr.lon[1], VEC_LON[200])
         self.assertTrue(np.array_equal(fil_centr.region_id, np.ones(2) * 10))
-        
+
     def test_select_extent_pass(self):
         """Test select extent"""
         centr = Centroids()
@@ -739,18 +739,18 @@ class TestCentroidsFuncs(unittest.TestCase):
         centr.check()
         centr.region_id = np.zeros(len(centr.lat))
         ext_centr = centr.select(extent=[-175, -170, -5, 5])
-        self.assertTrue(np.array_equal(ext_centr.lon, np.array([-175, -170])))
-        self.assertTrue(np.array_equal(ext_centr.lat, np.array([-3, 0])))
-        # Cross antimeridian
+        np.testing.assert_array_equal(ext_centr.lon, np.array([-175, -170]))
+        np.testing.assert_array_equal(ext_centr.lat, np.array([-3, 0]))
+
+        # Cross antimeridian, version 1
         ext_centr = centr.select(extent=[170, -175, -5, 5])
-        self.assertTrue(np.array_equal(ext_centr.lon,
-                                       np.array([-180, -175, 170, 175])
-                                       )
-                        )
-        self.assertTrue(np.array_equal(ext_centr.lat,
-                                       np.array([-5, -3, 3, 5])
-                                       )
-                        )
+        np.testing.assert_array_equal(ext_centr.lon, np.array([-180, -175, 170, 175]))
+        np.testing.assert_array_equal(ext_centr.lat, np.array([-5, -3, 3, 5]))
+
+        # Cross antimeridian, version 2
+        ext_centr = centr.select(extent=[170, 185, -5, 5])
+        np.testing.assert_array_equal(ext_centr.lon, np.array([-180, -175, 170, 175]))
+        np.testing.assert_array_equal(ext_centr.lat, np.array([-5, -3, 3, 5]))
 
 # Execute Tests
 if __name__ == "__main__":

--- a/climada/hazard/centroids/test/test_vec_ras.py
+++ b/climada/hazard/centroids/test/test_vec_ras.py
@@ -755,8 +755,8 @@ class TestCentroidsFuncs(unittest.TestCase):
 # Execute Tests
 if __name__ == "__main__":
     TESTS = unittest.TestLoader().loadTestsFromTestCase(TestRaster)
-    # TESTS.addTests(unittest.TestLoader().loadTestsFromTestCase(TestVector))
-    # TESTS.addTests(unittest.TestLoader().loadTestsFromTestCase(TestCentroids))
-    # TESTS.addTests(unittest.TestLoader().loadTestsFromTestCase(TestReader))
+    TESTS.addTests(unittest.TestLoader().loadTestsFromTestCase(TestVector))
+    TESTS.addTests(unittest.TestLoader().loadTestsFromTestCase(TestCentroids))
+    TESTS.addTests(unittest.TestLoader().loadTestsFromTestCase(TestReader))
     TESTS.addTests(unittest.TestLoader().loadTestsFromTestCase(TestCentroidsFuncs))
     unittest.TextTestRunner(verbosity=2).run(TESTS)


### PR DESCRIPTION
Proposal: modify `centroids.select(extent=[min_lon, max_lon, min_lat, max_lat]` to accept values `min_lon > max_lon`. This allows to select a window of centroids accross the antimeridian. 

The idea is to cut the extent into two windows centered around the middle longitude if min_lon < max_lon, and centered around -180/180 if min_lon > max_lon.

lon_min < lon_max:  lon_min ... mid and mid ... lon_max
lon_min > lon_max:  -180 ... lon_max and lon_min ... 180