### PR TITLE
Impact._build_exp_event: avoid unnecessary sparse-dense conversion

### DIFF
--- a/climada/engine/impact.py
+++ b/climada/engine/impact.py
@@ -913,7 +913,7 @@ class Impact():
         """
         return Exposures(
             data={
-                'value': self.imp_mat.toarray()[event_id - 1, :],
+                'value': self.imp_mat[event_id - 1].toarray().ravel(),
                 'latitude': self.coord_exp[:, 0],
                 'longitude': self.coord_exp[:, 1],
             },


### PR DESCRIPTION
This fixes #82 (see explanation given there). It's a one-liner.