### PR TITLE
read_ibtracs_netcdf: fix for tracks crossing antimeridian

### DIFF
--- a/climada/hazard/test/test_tc_tracks.py
+++ b/climada/hazard/test/test_tc_tracks.py
@@ -142,6 +142,18 @@ class TestIbtracs(unittest.TestCase):
         self.assertAlmostEqual(track_ds.lat.values[-1], 31.40, places=5)
         self.assertAlmostEqual(track_ds.central_pressure.values[-1], 980, places=5)
 
+    def test_read_antimeridian(self):
+        """Read a track that crosses the antimeridian and make sure that lon is consistent"""
+        tc_track = tc.TCTracks()
+        storm_id = '2013224N12220'
+
+        # the officially responsible agencies 'usa' and 'tokyo' use different signs in lon, but we
+        # have to `estimate_missing` because both have gaps in reported values
+        tc_track.read_ibtracs_netcdf(storm_id=storm_id, provider=['official_3h'],
+                                     estimate_missing=True)
+        track_ds = tc_track.get_track()
+        np.testing.assert_array_less(0, track_ds.lon)
+
     def test_read_estimate_missing(self):
         """Read a tropical cyclone and estimate missing values."""
         tc_track = tc.TCTracks()


### PR DESCRIPTION
Usually, if an agency reports about a track that crosses the antimeridian, the longitude is always chosen positive within IBTrACS. However, it can happen that the TC crosses the antimeridian according to one agency, but not according to another. When mixing agency data, this can yield inconsistent sign changes in longitude. When using the `interpolate_missing` option, this will lead to wrong interpolated values.

According to my analysis, this only affects a single storm in IBTrACS with the default settings: [2013224N12220](http://ibtracs.unca.edu/index.php?name=v04r00-2013224N12220). However, you never know what might change in the future in IBTrACS. Furthermore, this PR also makes sure that no longitude values are less than -180 (which can happen for some agencies).