### PR TITLE
Feature/scipy_16_update

### DIFF
--- a/climada/entity/exposures/black_marble.py
+++ b/climada/entity/exposures/black_marble.py
@@ -455,7 +455,7 @@ def _resample_land(geom, nightlight, lat, lon, res_fact, on_land):
     nightlight_res, lat_res, lon_res = nightlight, lat, lon
     if res_fact != 1.0:
         sum_val = nightlight.sum()
-        nightlight_res = ndimage.zoom(nightlight, res_fact, mode='constant', cval=0.0)
+        nightlight_res = ndimage.zoom(nightlight, res_fact, mode='nearest')
         nightlight_res[nightlight_res < 0.0] = 0.0
 
         lat_res, lon_res = np.mgrid[

--- a/climada/entity/exposures/black_marble.py
+++ b/climada/entity/exposures/black_marble.py
@@ -455,7 +455,7 @@ def _resample_land(geom, nightlight, lat, lon, res_fact, on_land):
     nightlight_res, lat_res, lon_res = nightlight, lat, lon
     if res_fact != 1.0:
         sum_val = nightlight.sum()
-        nightlight_res = ndimage.zoom(nightlight, res_fact, mode='nearest')
+        nightlight_res = ndimage.zoom(nightlight, res_fact, mode='constant', cval=0.0)
         nightlight_res[nightlight_res < 0.0] = 0.0
 
         lat_res, lon_res = np.mgrid[

--- a/climada/entity/exposures/test/test_black_marble.py
+++ b/climada/entity/exposures/test/test_black_marble.py
@@ -250,8 +250,8 @@ class TestNightLight(unittest.TestCase):
 
         self.assertTrue(np.allclose(lat_ref[on_ref], lat_res))
         self.assertTrue(np.allclose(lon_ref[on_ref], lon_res))
-        self.assertAlmostEqual(nightlight_res[0], 0.1410256410256411)
-        self.assertAlmostEqual(nightlight_res[1], 0.3589743589743589)
+        self.assertAlmostEqual(nightlight_res[0], 0.1683201638775818)
+        self.assertAlmostEqual(nightlight_res[1], 0.33167983612241814)
 
 class TestEconIndices(unittest.TestCase):
     """Test functions to get economic indices."""


### PR DESCRIPTION
the zoom `mode='constant'` with `cval=0.0` reproduces the former `mode='nearest'` results.
those are the default values of the respective parameters of `zoom`.

This pull request fixes the `climada.entity.exposures.test.test_black_marble.TestNightLight.test_cut_country_brb_2km_pass` failure that was introduced on February 8, 2020.