### PR TITLE
Bugfix/exposure.assign centroids/coord.dtype

### DIFF
--- a/climada/entity/exposures/base.py
+++ b/climada/entity/exposures/base.py
@@ -301,8 +301,8 @@ class Exposures():
             assigned[(x_i < 0) | (x_i >= hazard.centroids.meta['width'])] = -1
             assigned[(y_i < 0) | (y_i >= hazard.centroids.meta['height'])] = -1
         else:
-            coord = np.stack([self.gdf.latitude.values, self.gdf.longitude.values], axis=1)
-            haz_coord = hazard.centroids.coord
+            coord = np.stack([self.gdf.latitude.values, self.gdf.longitude.values], axis=1).astype('float64')
+            haz_coord = hazard.centroids.coord.astype('float64')
 
             if np.array_equal(coord, haz_coord):
                 assigned = np.arange(self.gdf.shape[0])

--- a/climada/entity/exposures/test/test_base.py
+++ b/climada/entity/exposures/test/test_base.py
@@ -62,7 +62,9 @@ class TestFuncs(unittest.TestCase):
         haz.set_raster([HAZ_DEMO_FL], window=Window(10, 20, 50, 60))
         haz.raster_to_vector()
         ncentroids = haz.centroids.size
-
+        haz.centroids.lat = haz.centroids.lat.astype('float32')
+        haz.centroids.lon = haz.centroids.lon.astype('float32')
+        
         exp = Exposures()
         exp.gdf.crs = haz.centroids.crs
 

--- a/climada/entity/exposures/test/test_base.py
+++ b/climada/entity/exposures/test/test_base.py
@@ -62,9 +62,7 @@ class TestFuncs(unittest.TestCase):
         haz.set_raster([HAZ_DEMO_FL], window=Window(10, 20, 50, 60))
         haz.raster_to_vector()
         ncentroids = haz.centroids.size
-        haz.centroids.lat = haz.centroids.lat.astype('float32')
-        haz.centroids.lon = haz.centroids.lon.astype('float32')
-        
+
         exp = Exposures()
         exp.gdf.crs = haz.centroids.crs
 
@@ -75,9 +73,13 @@ class TestFuncs(unittest.TestCase):
             haz.centroids.lat, haz.centroids.lat + 0.001 * (-0.5 + np_rand.rand(ncentroids))])
         expected_result = np.concatenate([np.arange(ncentroids), np.arange(ncentroids)])
 
-        exp.assign_centroids(haz)
-        self.assertEqual(exp.gdf.shape[0], len(exp.gdf[INDICATOR_CENTR + 'FL']))
-        np.testing.assert_array_equal(exp.gdf[INDICATOR_CENTR + 'FL'].values, expected_result)
+        # make sure that it works for both float32 and float64
+        for test_dtype in [np.float64, np.float32]:
+            haz.centroids.lat = haz.centroids.lat.astype(test_dtype)
+            haz.centroids.lon = haz.centroids.lon.astype(test_dtype)
+            exp.assign_centroids(haz)
+            self.assertEqual(exp.gdf.shape[0], len(exp.gdf[INDICATOR_CENTR + 'FL']))
+            np.testing.assert_array_equal(exp.gdf[INDICATOR_CENTR + 'FL'].values, expected_result)
 
     def test_read_raster_pass(self):
         """set_from_raster"""


### PR DESCRIPTION
Fixes #175 
I changed a test so the hazard.centroids.lat and lon are in float32 which produced an error and then fixed the error as suggested in the issue.