### PR TITLE
Exposures: error message on item access

### DIFF
--- a/climada/entity/exposures/base.py
+++ b/climada/entity/exposures/base.py
@@ -224,6 +224,14 @@ class Exposures():
             [f"crs: {self.crs}", "data:", str(self.gdf)]
         )
 
+    def _access_item(self, *args):
+        raise TypeError("Since CLIMADA 2.0, Exposures objects are not subscriptable. Data "
+                        "fields of Exposures objects are accessed using the `gdf` attribute. "
+                        "For example, `expo['value']` is replaced by `expo.gdf['value']`.")
+    __getitem__ = _access_item
+    __setitem__ = _access_item
+    __delitem__ = _access_item
+
     def check(self):
         """Check Exposures consistency.
 

--- a/climada/entity/exposures/test/test_base.py
+++ b/climada/entity/exposures/test/test_base.py
@@ -385,13 +385,21 @@ class TestGeoDFFuncs(unittest.TestCase):
         self.assertEqual(exp_tr.tag.file_name, '')
 
     def test_constructor_pass(self):
-        """Test initialization with input GeiDataFrame"""
+        """Test initialization with input GeoDataFrame"""
         in_gpd = gpd.GeoDataFrame()
         in_gpd['value'] = np.zeros(10)
         in_gpd.ref_year = 2015
         in_exp = Exposures(in_gpd, ref_year=2015)
         self.assertEqual(in_exp.ref_year, 2015)
         self.assertTrue(np.array_equal(in_exp.gdf.value, np.zeros(10)))
+
+    def test_error_on_access_item(self):
+        """Test error output when trying to access items as in CLIMADA 1.x"""
+        expo = good_exposures()
+        with self.assertRaises(TypeError) as err:
+            expo['value'] = 3
+        self.assertIn("CLIMADA 2", str(err.exception))
+        self.assertIn("gdf", str(err.exception))
 
 # Execute Tests
 if __name__ == "__main__":


### PR DESCRIPTION
Before this pull request, old CLIMADA-based code that still accesses data fields of Exposures objects directly would yield this error message:
```
>>> from climada.entity import Exposures
>>> expo = Exposures()
>>> expo['value']
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: 'Exposures' object is not subscriptable
```

This pull request adds a more helpful error message for users coming from CLIMADA 1.x:
```
>>> expo['value']
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "./climada/entity/exposures/base.py", line 228, in _access_item
    raise TypeError("Since CLIMADA 2.0, Exposures objects are not subscriptable. Data "
TypeError: Since CLIMADA 2.0, Exposures objects are not subscriptable. Data fields of Exposures objects are accessed using the `gdf` attribute. For example, `expo['value']` is replaced by `expo.gdf['value']`.
```

The type of error (`TypeError`) and the formulation are taken from the default type and message for this kind of exception.
