### PR TITLE
Coerce user-supplied Centroid lat-lon data to np.arrays

### DIFF
--- a/climada/hazard/centroids/centr.py
+++ b/climada/hazard/centroids/centr.py
@@ -325,7 +325,7 @@ class Centroids():
             CRS. Default: DEF_CRS
         """
         self.__init__()
-        self.lat, self.lon, self.geometry = np.array(lat), np.array(lon), gpd.GeoSeries(crs=crs)
+        self.lat, self.lon, self.geometry = np.asarray(lat), np.asarray(lon), gpd.GeoSeries(crs=crs)
 
     def set_raster_file(self, file_name, band=[1], src_crs=None, window=False,
                         geometry=False, dst_crs=False, transform=None, width=None,

--- a/climada/hazard/centroids/centr.py
+++ b/climada/hazard/centroids/centr.py
@@ -325,7 +325,7 @@ class Centroids():
             CRS. Default: DEF_CRS
         """
         self.__init__()
-        self.lat, self.lon, self.geometry = lat, lon, gpd.GeoSeries(crs=crs)
+        self.lat, self.lon, self.geometry = np.array(lat), np.array(lon), gpd.GeoSeries(crs=crs)
 
     def set_raster_file(self, file_name, band=[1], src_crs=None, window=False,
                         geometry=False, dst_crs=False, transform=None, width=None,


### PR DESCRIPTION
This is a small edit to the Centroid class to coerce `Centroid.lat` and `Centroid.lon` to `np.array` objects when they're directly supplied by the user.

Previously a `Centroid` class with user-supplied lat and lon arrays (via `Centroid.set_lat_lon`) preserves the classes of whatever lat/lon data is passed to it. This is fine in most cases, but if it's given a `pandas.Series` (for example, when setting centroids from the lat/lon columns of an `Exposure.gdf`), then the `TropCyclone.set_from_tracks()` method falls  over because it's unable to use `np.nonzero()` on a Series.

Code to reproduce the bug:
```
from climada.hazard import TropCyclone, TCTracks, Centroids
from climada.entity.exposures import LitPop

exp_litpop = LitPop()
exp_litpop.set_country('Puerto Rico', res_arcsec=300)

cent = Centroids()
cent.set_lat_lon(exp_litpop.gdf.latitude, exp_litpop.gdf.longitude)

track = TCTracks()
track.read_ibtracs_netcdf(storm_id='2017260N12310')

haz = TropCyclone()
haz.set_from_tracks(track, cent) # Error here
```
