### PR TITLE
Update antimeridian handling util.plot.geo_scatter_from_array

### DIFF
--- a/climada/util/plot.py
+++ b/climada/util/plot.py
@@ -137,7 +137,7 @@ def geo_scatter_from_array(array_sub, geo_coord, var_name, title,
         extend border colorbar with arrows.
         [ 'neither' | 'both' | 'min' | 'max' ], by default 'neither'
     proj : ccrs, optional
-        coordinate reference system if the given data, by default ccrs.PlateCarree()
+        coordinate reference system of the given data, by default ccrs.PlateCarree()
     shapes : bool, optional
         Overlay Earth's countries coastlines to matplotlib.pyplot axis.
         The default is True

--- a/climada/util/plot.py
+++ b/climada/util/plot.py
@@ -248,7 +248,7 @@ def geo_scatter_from_array(array_sub, geo_coord, var_name, title,
         if pop_name:
             add_populated_places(axis, extent, proj)
 
-        hex_bin = axis.scatter(coord[:, 1], coord[:, 0], c=array_im,
+        scatter = axis.scatter(coord[:, 1], coord[:, 0], c=array_im,
                                transform=proj, **kwargs)
         
         # Create colorbar in this axis
@@ -256,7 +256,7 @@ def geo_scatter_from_array(array_sub, geo_coord, var_name, title,
                                                      size="6.5%", 
                                                      pad=0.1,
                                                      axes_class=plt.Axes)
-        cbar = plt.colorbar(hex_bin, cax=cbax, orientation='vertical',
+        cbar = plt.colorbar(scatter, cax=cbax, orientation='vertical',
                             extend=extend)
         cbar.set_label(name)
         axis.set_title(tit)

--- a/climada/util/plot.py
+++ b/climada/util/plot.py
@@ -408,7 +408,7 @@ def geo_scatter_categorical(array_sub, geo_coord, var_name, title,
     kwargs['vmax'] = array_sub_n - 0.5
 
     # #create the axes
-    axes = geo_scatter_from_array(array_sub_cat, geo_coord, var_name,
+    axes = _plot_scattered_data("scatter", array_sub_cat, geo_coord, var_name,
                                   title, **kwargs)
 
     #add colorbar labels


### PR DESCRIPTION
This pull request adds the antimeridian handling to the `util.plot.geo_scatter_from_array` plotting function. The code is copied from `util.geo_bin_from_array`.

As a consequence, the two above functions are identical up to the following lines:
In `geo_bin_from_array` we use `plt.hexbin()`:
```
        if 'gridsize' not in kwargs:
            kwargs['gridsize'] = min(int(array_im.size / 2), MAX_BINS)
        hex_bin = axis.hexbin(coord[:, 1], coord[:, 0], C=array_im,
                              transform=proj, **kwargs)
```
In `geo_scatter_from_array` we use `plt.scatter()`:
```
        scatter = axis.scatter(coord[:, 1], coord[:, 0], c=array_im,
                               transform=proj, **kwargs)
```

