### PR TITLE
Use pycountry instead of iso3166 for country code lookup

### DIFF
--- a/climada/engine/forecast.py
+++ b/climada/engine/forecast.py
@@ -36,13 +36,13 @@ import pyproj
 import shapely
 from cartopy.io import shapereader
 from mpl_toolkits.axes_grid1 import make_axes_locatable
-from iso3166 import countries as iso_cntry
 
 from climada.engine import Impact
 import climada.util.plot as u_plot
 from climada.util.config import CONFIG
 from climada.util.files_handler import to_list
 from climada.util.coordinates import coord_on_land as u_coord_on_land
+from climada.util.coordinates import country_to_iso
 from climada.util.value_representation import \
     value_to_monetary_unit as u_value_to_monetary_unit
 
@@ -171,7 +171,7 @@ class Forecast():
         self.exposure = exposure
         if exposure_name is None:
             try:
-                self.exposure_name = iso_cntry.get(exposure.gdf.region_id.unique()[0]).name
+                self.exposure_name = country_to_iso(exposure.gdf.region_id.unique()[0], "name")
             except (KeyError, AttributeError):
                 self.exposure_name = 'custom'
         else:

--- a/climada/engine/forecast.py
+++ b/climada/engine/forecast.py
@@ -41,8 +41,7 @@ from climada.engine import Impact
 import climada.util.plot as u_plot
 from climada.util.config import CONFIG
 from climada.util.files_handler import to_list
-from climada.util.coordinates import coord_on_land as u_coord_on_land
-from climada.util.coordinates import country_to_iso
+import climada.util.coordinates as u_coord
 from climada.util.value_representation import \
     value_to_monetary_unit as u_value_to_monetary_unit
 
@@ -171,7 +170,8 @@ class Forecast():
         self.exposure = exposure
         if exposure_name is None:
             try:
-                self.exposure_name = country_to_iso(exposure.gdf.region_id.unique()[0], "name")
+                self.exposure_name = u_coord.country_to_iso(
+                    exposure.gdf.region_id.unique()[0], "name")
             except (KeyError, AttributeError):
                 self.exposure_name = 'custom'
         else:
@@ -921,9 +921,9 @@ class Forecast():
 
         for geometry, _ in zip(shp.geometries(), shp.records()):
             geom2 = shapely.ops.transform(transformer.transform, geometry)
-            in_geom = u_coord_on_land(lat=self._impact[haz_ind].coord_exp[:, 0],
-                                      lon=self._impact[haz_ind].coord_exp[:, 1],
-                                      land_geom=geom2)
+            in_geom = u_coord.coord_on_land(lat=self._impact[haz_ind].coord_exp[:, 0],
+                                            lon=self._impact[haz_ind].coord_exp[:, 1],
+                                            land_geom=geom2)
             if not in_geom.any():
                 continue
             # decide warning level

--- a/climada/engine/impact_data.py
+++ b/climada/engine/impact_data.py
@@ -24,12 +24,12 @@ from datetime import datetime
 from pathlib import Path
 import pandas as pd
 import numpy as np
-from iso3166 import countries as iso_cntry
 from cartopy.io import shapereader
 import shapefile
 
 from climada.util.finance import gdp
 from climada.util.constants import DEF_CRS
+from climada.util.coordinates import country_to_iso
 from climada.engine import Impact
 from climada.entity.tag import Tag
 from climada.hazard.tag import Tag as TagHaz
@@ -258,7 +258,7 @@ def hit_country_per_hazard(intensity_path, names_path, reg_id_path, date_path):
             # loop over hit_country
             for hit in range(0, len(all_hits[track])):
                 # Hit country ISO
-                ctry_iso = iso_cntry.get(all_hits[track][hit]).alpha3
+                ctry_iso = country_to_iso(all_hits[track][hit], "alpha3")
                 # create entry for each country a hazard has hit
                 hit_countries = hit_countries.append({'hit_country': ctry_iso,
                                                       'Date_start': date[track],
@@ -541,7 +541,7 @@ def clean_emdat_df(emdat_file, countries=None, hazard=None, year_range=None,
     if countries and isinstance(countries, list):
         for idx, country in enumerate(countries):
             # convert countries to iso3 alpha code:
-            countries[idx] = iso_cntry.get(country).alpha3
+            countries[idx] = country_to_iso(country, "alpha3")
         df_data = df_data[df_data['ISO'].isin(countries)].reset_index(drop=True)
     # (3.2) Year range:
     if year_range:
@@ -602,7 +602,7 @@ def emdat_countries_by_hazard(emdat_file_csv, hazard=None, year_range=None):
     countries_names = list()
     for iso3a in countries_iso3a:
         try:
-            countries_names.append(iso_cntry.get(iso3a).name)
+            countries_names.append(country_to_iso(iso3a, "name"))
         except KeyError:
             countries_names.append('NA')
     return countries_iso3a, countries_names
@@ -693,7 +693,7 @@ def emdat_impact_yearlysum(emdat_file_csv, countries=None, hazard=None, year_ran
     out = pd.DataFrame(columns=['ISO', 'region_id', 'year', 'impact',
                                 'impact_scaled', 'reference_year'])
     for country in df_data.ISO.unique():
-        country = iso_cntry.get(country).alpha3
+        country = country_to_iso(country, "alpha3")
         if not df_data.loc[df_data.ISO == country].size:
             continue
         all_years = np.arange(min(df_data.Year), max(df_data.Year) + 1)
@@ -704,7 +704,7 @@ def emdat_impact_yearlysum(emdat_file_csv, countries=None, hazard=None, year_ran
             data_out.loc[cnt, 'year'] = year
             data_out.loc[cnt, 'reference_year'] = reference_year
             data_out.loc[cnt, 'ISO'] = country
-            data_out.loc[cnt, 'region_id'] = int(iso_cntry.get(country).numeric)
+            data_out.loc[cnt, 'region_id'] = country_to_iso(country, "numeric")
             data_out.loc[cnt, 'impact'] = \
                 np.nansum(df_country[df_country.Year.isin([year])][imp_str])
             data_out.loc[cnt, 'impact_scaled'] = \
@@ -763,7 +763,7 @@ def emdat_impact_event(emdat_file_csv, countries=None, hazard=None, year_range=N
     for country in df_data.ISO.unique():
         try:
             df_data.loc[df_data.ISO == country, 'region_id'] = \
-                int(iso_cntry.get(country).numeric)
+                country_to_iso(country, "numeric")
         except KeyError:
             LOGGER.warning('ISO3alpha code not found in iso_country: %s', country)
     if '000 US' in imp_str:
@@ -897,7 +897,7 @@ def emdat_to_impact(emdat_file_csv, hazard_type_climada, year_range=None, countr
     impact_instance.eai_exp = np.zeros(len(countries))  # empty: damage at exposure
     for idx, cntry in enumerate(countries):
         try:
-            cntry = iso_cntry.get(cntry).alpha3
+            cntry = country_to_iso(cntry, "alpha3")
         except KeyError:
             print(cntry)
             LOGGER.error('Country not found in iso_country: %s', cntry)
@@ -914,7 +914,7 @@ def emdat_to_impact(emdat_file_csv, hazard_type_climada, year_range=None, countr
             countries_lat.append(np.nan)
             countries_lon.append(np.nan)
         try:
-            countries_reg_id.append(int(iso_cntry.get(cntry).numeric))
+            countries_reg_id.append(country_to_iso(cntry, "numeric"))
         except KeyError:
             countries_reg_id.append(0)
         df_tmp = em_data[em_data[VARNAMES_EMDAT[

--- a/climada/engine/impact_data.py
+++ b/climada/engine/impact_data.py
@@ -603,7 +603,7 @@ def emdat_countries_by_hazard(emdat_file_csv, hazard=None, year_range=None):
     for iso3a in countries_iso3a:
         try:
             countries_names.append(u_coord.country_to_iso(iso3a, "name"))
-        except KeyError:
+        except LookupError:
             countries_names.append('NA')
     return countries_iso3a, countries_names
 
@@ -764,7 +764,7 @@ def emdat_impact_event(emdat_file_csv, countries=None, hazard=None, year_range=N
         try:
             df_data.loc[df_data.ISO == country, 'region_id'] = \
                 u_coord.country_to_iso(country, "numeric")
-        except KeyError:
+        except LookupError:
             LOGGER.warning('ISO3alpha code not found in iso_country: %s', country)
     if '000 US' in imp_str:
         df_data['impact'] *= 1e3
@@ -898,8 +898,7 @@ def emdat_to_impact(emdat_file_csv, hazard_type_climada, year_range=None, countr
     for idx, cntry in enumerate(countries):
         try:
             cntry = u_coord.country_to_iso(cntry, "alpha3")
-        except KeyError:
-            print(cntry)
+        except LookupError:
             LOGGER.error('Country not found in iso_country: %s', cntry)
         cntry_boolean = False
         for rec_i, rec in enumerate(shp.records()):
@@ -915,7 +914,7 @@ def emdat_to_impact(emdat_file_csv, hazard_type_climada, year_range=None, countr
             countries_lon.append(np.nan)
         try:
             countries_reg_id.append(u_coord.country_to_iso(cntry, "numeric"))
-        except KeyError:
+        except LookupError:
             countries_reg_id.append(0)
         df_tmp = em_data[em_data[VARNAMES_EMDAT[
             max(VARNAMES_EMDAT.keys())]['ISO']].str.contains(cntry)]

--- a/climada/engine/impact_data.py
+++ b/climada/engine/impact_data.py
@@ -29,7 +29,7 @@ import shapefile
 
 from climada.util.finance import gdp
 from climada.util.constants import DEF_CRS
-from climada.util.coordinates import country_to_iso
+import climada.util.coordinates as u_coord
 from climada.engine import Impact
 from climada.entity.tag import Tag
 from climada.hazard.tag import Tag as TagHaz
@@ -258,7 +258,7 @@ def hit_country_per_hazard(intensity_path, names_path, reg_id_path, date_path):
             # loop over hit_country
             for hit in range(0, len(all_hits[track])):
                 # Hit country ISO
-                ctry_iso = country_to_iso(all_hits[track][hit], "alpha3")
+                ctry_iso = u_coord.country_to_iso(all_hits[track][hit], "alpha3")
                 # create entry for each country a hazard has hit
                 hit_countries = hit_countries.append({'hit_country': ctry_iso,
                                                       'Date_start': date[track],
@@ -541,7 +541,7 @@ def clean_emdat_df(emdat_file, countries=None, hazard=None, year_range=None,
     if countries and isinstance(countries, list):
         for idx, country in enumerate(countries):
             # convert countries to iso3 alpha code:
-            countries[idx] = country_to_iso(country, "alpha3")
+            countries[idx] = u_coord.country_to_iso(country, "alpha3")
         df_data = df_data[df_data['ISO'].isin(countries)].reset_index(drop=True)
     # (3.2) Year range:
     if year_range:
@@ -602,7 +602,7 @@ def emdat_countries_by_hazard(emdat_file_csv, hazard=None, year_range=None):
     countries_names = list()
     for iso3a in countries_iso3a:
         try:
-            countries_names.append(country_to_iso(iso3a, "name"))
+            countries_names.append(u_coord.country_to_iso(iso3a, "name"))
         except KeyError:
             countries_names.append('NA')
     return countries_iso3a, countries_names
@@ -693,7 +693,7 @@ def emdat_impact_yearlysum(emdat_file_csv, countries=None, hazard=None, year_ran
     out = pd.DataFrame(columns=['ISO', 'region_id', 'year', 'impact',
                                 'impact_scaled', 'reference_year'])
     for country in df_data.ISO.unique():
-        country = country_to_iso(country, "alpha3")
+        country = u_coord.country_to_iso(country, "alpha3")
         if not df_data.loc[df_data.ISO == country].size:
             continue
         all_years = np.arange(min(df_data.Year), max(df_data.Year) + 1)
@@ -704,7 +704,7 @@ def emdat_impact_yearlysum(emdat_file_csv, countries=None, hazard=None, year_ran
             data_out.loc[cnt, 'year'] = year
             data_out.loc[cnt, 'reference_year'] = reference_year
             data_out.loc[cnt, 'ISO'] = country
-            data_out.loc[cnt, 'region_id'] = country_to_iso(country, "numeric")
+            data_out.loc[cnt, 'region_id'] = u_coord.country_to_iso(country, "numeric")
             data_out.loc[cnt, 'impact'] = \
                 np.nansum(df_country[df_country.Year.isin([year])][imp_str])
             data_out.loc[cnt, 'impact_scaled'] = \
@@ -763,7 +763,7 @@ def emdat_impact_event(emdat_file_csv, countries=None, hazard=None, year_range=N
     for country in df_data.ISO.unique():
         try:
             df_data.loc[df_data.ISO == country, 'region_id'] = \
-                country_to_iso(country, "numeric")
+                u_coord.country_to_iso(country, "numeric")
         except KeyError:
             LOGGER.warning('ISO3alpha code not found in iso_country: %s', country)
     if '000 US' in imp_str:
@@ -897,7 +897,7 @@ def emdat_to_impact(emdat_file_csv, hazard_type_climada, year_range=None, countr
     impact_instance.eai_exp = np.zeros(len(countries))  # empty: damage at exposure
     for idx, cntry in enumerate(countries):
         try:
-            cntry = country_to_iso(cntry, "alpha3")
+            cntry = u_coord.country_to_iso(cntry, "alpha3")
         except KeyError:
             print(cntry)
             LOGGER.error('Country not found in iso_country: %s', cntry)
@@ -914,7 +914,7 @@ def emdat_to_impact(emdat_file_csv, hazard_type_climada, year_range=None, countr
             countries_lat.append(np.nan)
             countries_lon.append(np.nan)
         try:
-            countries_reg_id.append(country_to_iso(cntry, "numeric"))
+            countries_reg_id.append(u_coord.country_to_iso(cntry, "numeric"))
         except KeyError:
             countries_reg_id.append(0)
         df_tmp = em_data[em_data[VARNAMES_EMDAT[

--- a/climada/engine/supplychain.py
+++ b/climada/engine/supplychain.py
@@ -29,7 +29,7 @@ import pandas as pd
 
 from climada import CONFIG
 from climada.util import files_handler as u_fh
-from climada.util.coordinates import country_to_iso
+import climada.util.coordinates as u_coord
 from climada.engine import Impact
 from climada.entity.exposures.base import Exposures
 
@@ -304,7 +304,7 @@ class SupplyChain():
         """
 
         if mriot_type == 'WIOD':
-            mriot_reg_name = country_to_iso(exp_regid, "alpha3")
+            mriot_reg_name = u_coord.country_to_iso(exp_regid, "alpha3")
             idx_country = np.where(self.mriot_reg_names == mriot_reg_name)[0]
 
             if not idx_country.size > 0.:

--- a/climada/engine/supplychain.py
+++ b/climada/engine/supplychain.py
@@ -26,10 +26,10 @@ import datetime as dt
 from tqdm import tqdm
 import numpy as np
 import pandas as pd
-from iso3166 import countries_by_numeric
 
 from climada import CONFIG
 from climada.util import files_handler as u_fh
+from climada.util.coordinates import country_to_iso
 from climada.engine import Impact
 from climada.entity.exposures.base import Exposures
 
@@ -300,11 +300,11 @@ class SupplyChain():
     def _map_exp_to_mriot(self, exp_regid, mriot_type):
         """
         Map regions names in exposure into Input-output regions names.
-        exp_regid must be conform to ISO3 country code format.
+        exp_regid must be according to ISO 3166 numeric country codes.
         """
 
         if mriot_type == 'WIOD':
-            mriot_reg_name = countries_by_numeric.get(str(exp_regid)).alpha3
+            mriot_reg_name = country_to_iso(exp_regid, "alpha3")
             idx_country = np.where(self.mriot_reg_names == mriot_reg_name)[0]
 
             if not idx_country.size > 0.:

--- a/climada/entity/exposures/black_marble.py
+++ b/climada/entity/exposures/black_marble.py
@@ -28,14 +28,13 @@ from numpy.polynomial.polynomial import polyval
 from scipy import ndimage
 import shapely.vectorized
 from cartopy.io import shapereader
-from iso3166 import countries as iso_cntry
 
 from climada.entity.tag import Tag
 from climada.entity.exposures.base import Exposures, INDICATOR_IF
 from climada.entity.exposures import nightlight as nl_utils
 from climada.util.constants import SYSTEM_DIR, DEF_CRS
 from climada.util.finance import gdp, income_group
-from climada.util.coordinates import pts_to_raster_meta
+from climada.util.coordinates import pts_to_raster_meta, country_to_iso
 
 LOGGER = logging.getLogger(__name__)
 
@@ -220,7 +219,7 @@ def country_iso_geom(countries, shp_file, admin_key=['ADMIN', 'ADM0_A3']):
             raise ValueError
         iso3 = list_records[country_idx].attributes[admin_key[1]]
         try:
-            cntry_id = int(iso_cntry.get(iso3).numeric)
+            cntry_id = country_to_iso(iso3, "numeric")
         except KeyError:
             cntry_id = 0
         cntry_info[iso3] = [cntry_id, country_name.title(),

--- a/climada/entity/exposures/black_marble.py
+++ b/climada/entity/exposures/black_marble.py
@@ -220,7 +220,7 @@ def country_iso_geom(countries, shp_file, admin_key=['ADMIN', 'ADM0_A3']):
         iso3 = list_records[country_idx].attributes[admin_key[1]]
         try:
             cntry_id = u_coord.country_to_iso(iso3, "numeric")
-        except KeyError:
+        except LookupError:
             cntry_id = 0
         cntry_info[iso3] = [cntry_id, country_name.title(),
                             list_records[country_idx].geometry]

--- a/climada/entity/exposures/black_marble.py
+++ b/climada/entity/exposures/black_marble.py
@@ -34,7 +34,7 @@ from climada.entity.exposures.base import Exposures, INDICATOR_IF
 from climada.entity.exposures import nightlight as nl_utils
 from climada.util.constants import SYSTEM_DIR, DEF_CRS
 from climada.util.finance import gdp, income_group
-from climada.util.coordinates import pts_to_raster_meta, country_to_iso
+import climada.util.coordinates as u_coord
 
 LOGGER = logging.getLogger(__name__)
 
@@ -113,7 +113,7 @@ class BlackMarble(Exposures):
             value_unit='USD'
         )
 
-        rows, cols, ras_trans = pts_to_raster_meta(
+        rows, cols, ras_trans = u_coord.pts_to_raster_meta(
             (self.gdf.longitude.min(), self.gdf.latitude.min(),
              self.gdf.longitude.max(), self.gdf.latitude.max()),
             (coord_nl[0, 1], -coord_nl[0, 1])
@@ -219,7 +219,7 @@ def country_iso_geom(countries, shp_file, admin_key=['ADMIN', 'ADM0_A3']):
             raise ValueError
         iso3 = list_records[country_idx].attributes[admin_key[1]]
         try:
-            cntry_id = country_to_iso(iso3, "numeric")
+            cntry_id = u_coord.country_to_iso(iso3, "numeric")
         except KeyError:
             cntry_id = 0
         cntry_info[iso3] = [cntry_id, country_name.title(),

--- a/climada/entity/exposures/crop_production.py
+++ b/climada/entity/exposures/crop_production.py
@@ -33,10 +33,6 @@ from matplotlib import pyplot as plt
 from climada.entity.exposures.base import Exposures
 from climada.entity.tag import Tag
 import climada.util.coordinates as u_coord
-from climada.util.coordinates import (pts_to_raster_meta,
-                                      get_resolution,
-                                      get_gridcellarea,
-                                      country_to_iso)
 from climada import CONFIG
 
 
@@ -262,7 +258,7 @@ class CropProduction(Exposures):
                     int(yearrange[1] - yearchunk['startyear']))
 
         # The area covered by a grid cell is calculated depending on the latitude
-        area = get_gridcellarea(lat, resolution=0.5)
+        area = u_coord.get_gridcellarea(lat, resolution=0.5)
 
         # The area covered by a crop is calculated as the product of the fraction and
         # the grid cell size
@@ -356,10 +352,10 @@ class CropProduction(Exposures):
         self.crop = crop
         self.ref_year = yearrange
         try:
-            rows, cols, ras_trans = pts_to_raster_meta(
+            rows, cols, ras_trans = u_coord.pts_to_raster_meta(
                 (self.gdf.longitude.min(), self.gdf.latitude.min(),
                  self.gdf.longitude.max(), self.gdf.latitude.max()),
-                get_resolution(self.gdf.longitude, self.gdf.latitude))
+                u_coord.get_resolution(self.gdf.longitude, self.gdf.latitude))
             self.meta = {
                 'width': cols,
                 'height': rows,
@@ -543,7 +539,7 @@ class CropProduction(Exposures):
         iso3alpha = list()
         for reg_id in self.gdf.region_id:
             try:
-                iso3alpha.append(country_to_iso(reg_id, "alpha3"))
+                iso3alpha.append(u_coord.country_to_iso(reg_id, "alpha3"))
             except KeyError:
                 if reg_id in (0, -99):
                     iso3alpha.append('No country')

--- a/climada/entity/exposures/crop_production.py
+++ b/climada/entity/exposures/crop_production.py
@@ -29,12 +29,14 @@ import xarray as xr
 import pandas as pd
 import h5py
 from matplotlib import pyplot as plt
-from iso3166 import countries as iso_cntry
 
 from climada.entity.exposures.base import Exposures
 from climada.entity.tag import Tag
 import climada.util.coordinates as u_coord
-from climada.util.coordinates import pts_to_raster_meta, get_resolution, get_gridcellarea
+from climada.util.coordinates import (pts_to_raster_meta,
+                                      get_resolution,
+                                      get_gridcellarea,
+                                      country_to_iso)
 from climada import CONFIG
 
 
@@ -541,7 +543,7 @@ class CropProduction(Exposures):
         iso3alpha = list()
         for reg_id in self.gdf.region_id:
             try:
-                iso3alpha.append(iso_cntry.get(reg_id).alpha3)
+                iso3alpha.append(country_to_iso(reg_id, "alpha3"))
             except KeyError:
                 if reg_id in (0, -99):
                     iso3alpha.append('No country')

--- a/climada/entity/exposures/gdp_asset.py
+++ b/climada/entity/exposures/gdp_asset.py
@@ -27,8 +27,7 @@ import pandas as pd
 import xarray as xr
 import scipy as sp
 from climada.entity.tag import Tag
-from climada.util.coordinates import pts_to_raster_meta
-from climada.util.coordinates import country_iso2natid, get_region_gridpoints, region2isos
+import climada.util.coordinates as u_coord
 from climada.util.constants import RIVER_FLOOD_REGIONS_CSV, SYSTEM_DIR
 from .base import Exposures, INDICATOR_IF
 
@@ -66,7 +65,7 @@ class GDP2Asset(Exposures):
 
             if not countries:
                 if reg:
-                    natISO = region2isos(reg)
+                    natISO = u_coord.region2isos(reg)
                     countries = np.array(natISO)
                 else:
                     LOGGER.error('set_countries requires countries or reg')
@@ -94,10 +93,9 @@ class GDP2Asset(Exposures):
         # set meta
         res = 0.0416666
 
-        rows, cols, ras_trans = pts_to_raster_meta((self.gdf.longitude.min(),
-                                                    self.gdf.latitude.min(),
-                                                    self.gdf.longitude.max(),
-                                                    self.gdf.latitude.max()), res)
+        rows, cols, ras_trans = u_coord.pts_to_raster_meta(
+            (self.gdf.longitude.min(), self.gdf.latitude.min(),
+             self.gdf.longitude.max(), self.gdf.latitude.max()), res)
         self.meta = {'width': cols, 'height': rows, 'crs': self.crs,
                      'transform': ras_trans}
 
@@ -116,10 +114,10 @@ class GDP2Asset(Exposures):
         Returns:
             GDP2Asset
         """
-        natID = country_iso2natid(countryISO)
+        natID = u_coord.country_iso2natid(countryISO)
         natID_info = pd.read_csv(RIVER_FLOOD_REGIONS_CSV)
         reg_id, if_rf = _fast_if_mapping(natID, natID_info)
-        lat, lon = get_region_gridpoints(countries=[natID], iso=False, basemap="isimip")
+        lat, lon = u_coord.get_region_gridpoints(countries=[natID], iso=False, basemap="isimip")
         coord = np.stack([lat, lon], axis=1)
         assets = _read_GDP(coord, ref_year, path)
         reg_id_info = np.full((len(assets),), reg_id)

--- a/climada/entity/exposures/litpop.py
+++ b/climada/entity/exposures/litpop.py
@@ -32,7 +32,6 @@ from scipy import ndimage as nd
 from scipy import stats
 import shapefile
 from matplotlib import pyplot as plt
-from iso3166 import countries as iso_cntry
 from osgeo import gdal
 from cartopy.io import shapereader
 
@@ -44,7 +43,7 @@ from climada.entity.exposures import gpw_import
 from climada.util import ureg
 from climada.util.finance import gdp, income_group, wealth2gdp, world_bank_wealth_account
 from climada.util.constants import SYSTEM_DIR, DEF_CRS
-from climada.util.coordinates import pts_to_raster_meta, get_resolution
+from climada.util.coordinates import pts_to_raster_meta, get_resolution, country_to_iso
 
 logging.root.setLevel(logging.DEBUG)
 LOGGER = logging.getLogger(__name__)
@@ -300,9 +299,9 @@ class LitPop(Exposures):
             'longitude': lon
         })
         try:
-            lp_ent.gdf['region_id'] = int(iso_cntry.get(cntry_info[1]).numeric)
+            lp_ent.gdf['region_id'] = country_to_iso(cntry_info[1], "numeric")
         except KeyError:
-            lp_ent.gdf['region_id'] = int(iso_cntry.get(curr_country).numeric)
+            lp_ent.gdf['region_id'] = country_to_iso(curr_country, "numeric")
         lp_ent.gdf[INDICATOR_IF + DEF_HAZ_TYPE] = 1
         return lp_ent
 
@@ -1877,7 +1876,7 @@ def exposure_set_admin1(exposure, res_arcsec):
     exposure.gdf['admin1'] = pd.Series()
     exposure.gdf['admin1_ID'] = pd.Series()
     for cntry in np.unique(exposure.gdf.region_id):
-        _, admin1_info = _get_country_info(iso_cntry.get(cntry).alpha3)
+        _, admin1_info = _get_country_info(country_to_iso(cntry, "alpha3"))
         for adm1_shp in admin1_info:
             LOGGER.debug('Extracting admin1 for %s.', adm1_shp[1]['name'])
             mask_adm1 = _mask_from_shape(

--- a/climada/entity/exposures/litpop.py
+++ b/climada/entity/exposures/litpop.py
@@ -43,7 +43,7 @@ from climada.entity.exposures import gpw_import
 from climada.util import ureg
 from climada.util.finance import gdp, income_group, wealth2gdp, world_bank_wealth_account
 from climada.util.constants import SYSTEM_DIR, DEF_CRS
-from climada.util.coordinates import pts_to_raster_meta, get_resolution, country_to_iso
+import climada.util.coordinates as u_coord
 
 logging.root.setLevel(logging.DEBUG)
 LOGGER = logging.getLogger(__name__)
@@ -259,10 +259,10 @@ class LitPop(Exposures):
             value_unit='USD'
         )
         try:
-            rows, cols, ras_trans = pts_to_raster_meta(
+            rows, cols, ras_trans = u_coord.pts_to_raster_meta(
                 (self.gdf.longitude.min(), self.gdf.latitude.min(),
                  self.gdf.longitude.max(), self.gdf.latitude.max()),
-                get_resolution(self.gdf.longitude, self.gdf.latitude))
+                u_coord.get_resolution(self.gdf.longitude, self.gdf.latitude))
             self.meta = {
                 'width': cols,
                 'height': rows,
@@ -299,9 +299,9 @@ class LitPop(Exposures):
             'longitude': lon
         })
         try:
-            lp_ent.gdf['region_id'] = country_to_iso(cntry_info[1], "numeric")
+            lp_ent.gdf['region_id'] = u_coord.country_to_iso(cntry_info[1], "numeric")
         except KeyError:
-            lp_ent.gdf['region_id'] = country_to_iso(curr_country, "numeric")
+            lp_ent.gdf['region_id'] = u_coord.country_to_iso(curr_country, "numeric")
         lp_ent.gdf[INDICATOR_IF + DEF_HAZ_TYPE] = 1
         return lp_ent
 
@@ -1876,7 +1876,7 @@ def exposure_set_admin1(exposure, res_arcsec):
     exposure.gdf['admin1'] = pd.Series()
     exposure.gdf['admin1_ID'] = pd.Series()
     for cntry in np.unique(exposure.gdf.region_id):
-        _, admin1_info = _get_country_info(country_to_iso(cntry, "alpha3"))
+        _, admin1_info = _get_country_info(u_coord.country_to_iso(cntry, "alpha3"))
         for adm1_shp in admin1_info:
             LOGGER.debug('Extracting admin1 for %s.', adm1_shp[1]['name'])
             mask_adm1 = _mask_from_shape(

--- a/climada/entity/exposures/litpop.py
+++ b/climada/entity/exposures/litpop.py
@@ -300,7 +300,7 @@ class LitPop(Exposures):
         })
         try:
             lp_ent.gdf['region_id'] = u_coord.country_to_iso(cntry_info[1], "numeric")
-        except KeyError:
+        except LookupError:
             lp_ent.gdf['region_id'] = u_coord.country_to_iso(curr_country, "numeric")
         lp_ent.gdf[INDICATOR_IF + DEF_HAZ_TYPE] = 1
         return lp_ent

--- a/climada/entity/exposures/spam_agrar.py
+++ b/climada/entity/exposures/spam_agrar.py
@@ -30,7 +30,7 @@ from climada.entity.tag import Tag
 from climada.entity.exposures.base import Exposures, INDICATOR_IF
 from climada.util.files_handler import download_file
 from climada.util.constants import SYSTEM_DIR
-from climada.util.coordinates import country_to_iso
+import climada.util.coordinates as u_coord
 
 logging.root.setLevel(logging.DEBUG)
 LOGGER = logging.getLogger(__name__)
@@ -163,11 +163,11 @@ https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/DHXBJX
         country_id = data.loc[:, 'iso3']
         if country_id.unique().size == 1:
             region_id = np.ones(self.gdf.value.size, int)\
-                * country_to_iso(country_id.iloc[0], "numeric")
+                * u_coord.country_to_iso(country_id.iloc[0], "numeric")
         else:
             region_id = np.zeros(self.gdf.value.size, int)
             for i in range(0, self.gdf.value.size):
-                region_id[i] = country_to_iso(country_id.iloc[i], "numeric")
+                region_id[i] = u_coord.country_to_iso(country_id.iloc[i], "numeric")
         self.gdf['region_id'] = region_id
         self.ref_year = 2005
         self.tag = Tag()

--- a/climada/entity/exposures/spam_agrar.py
+++ b/climada/entity/exposures/spam_agrar.py
@@ -24,13 +24,13 @@ import zipfile
 from pathlib import Path
 import pandas as pd
 import numpy as np
-from iso3166 import countries as iso_cntry
 
 from climada import CONFIG
 from climada.entity.tag import Tag
 from climada.entity.exposures.base import Exposures, INDICATOR_IF
 from climada.util.files_handler import download_file
 from climada.util.constants import SYSTEM_DIR
+from climada.util.coordinates import country_to_iso
 
 logging.root.setLevel(logging.DEBUG)
 LOGGER = logging.getLogger(__name__)
@@ -163,11 +163,11 @@ https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/DHXBJX
         country_id = data.loc[:, 'iso3']
         if country_id.unique().size == 1:
             region_id = np.ones(self.gdf.value.size, int)\
-                * int(iso_cntry.get(country_id.iloc[0]).numeric)
+                * country_to_iso(country_id.iloc[0], "numeric")
         else:
             region_id = np.zeros(self.gdf.value.size, int)
             for i in range(0, self.gdf.value.size):
-                region_id[i] = int(iso_cntry.get(country_id.iloc[i]).numeric)
+                region_id[i] = country_to_iso(country_id.iloc[i], "numeric")
         self.gdf['region_id'] = region_id
         self.ref_year = 2005
         self.tag = Tag()

--- a/climada/entity/exposures/test/test_base.py
+++ b/climada/entity/exposures/test/test_base.py
@@ -32,7 +32,7 @@ from climada.entity.exposures.base import Exposures, INDICATOR_IF, \
 from climada.entity.tag import Tag
 from climada.hazard.base import Hazard, Centroids
 from climada.util.constants import ENT_TEMPLATE_XLS, ONE_LAT_KM, DEF_CRS, HAZ_DEMO_FL
-from climada.util.coordinates import coord_on_land, equal_crs
+import climada.util.coordinates as u_coord
 
 DATA_DIR = CONFIG.exposures.test_data.dir()
 
@@ -86,7 +86,7 @@ class TestFuncs(unittest.TestCase):
         exp = Exposures()
         exp.set_from_raster(HAZ_DEMO_FL, window=Window(10, 20, 50, 60))
         exp.check()
-        self.assertTrue(equal_crs(exp.crs, DEF_CRS))
+        self.assertTrue(u_coord.equal_crs(exp.crs, DEF_CRS))
         self.assertAlmostEqual(exp.gdf['latitude'].max(),
                                10.248220966978932 - 0.009000000000000341 / 2)
         self.assertAlmostEqual(exp.gdf['latitude'].min(),
@@ -298,7 +298,7 @@ class TestAddSea(unittest.TestCase):
 
         on_sea_lat = exp_sea.gdf.latitude.values[11:]
         on_sea_lon = exp_sea.gdf.longitude.values[11:]
-        res_on_sea = coord_on_land(on_sea_lat, on_sea_lon)
+        res_on_sea = u_coord.coord_on_land(on_sea_lat, on_sea_lon)
         res_on_sea = ~res_on_sea
         self.assertTrue(np.all(res_on_sea))
 

--- a/climada/entity/exposures/test/test_gdp_asset.py
+++ b/climada/entity/exposures/test/test_gdp_asset.py
@@ -36,9 +36,9 @@ class TestGDP2AssetClass(unittest.TestCase):
         with self.assertRaises(NameError):
             testGDP2A.set_countries(countries=['CHE'], ref_year=2000,
                                     path='non/existent/test')
-        with self.assertRaises(KeyError):
+        with self.assertRaises(LookupError):
             testGDP2A.set_countries(countries=['OYY'], path=DEMO_GDP2ASSET)
-        with self.assertRaises(KeyError):
+        with self.assertRaises(LookupError):
             testGDP2A.set_countries(countries=['DEU'], ref_year=2600,
                                     path=DEMO_GDP2ASSET)
         with self.assertRaises(ValueError):

--- a/climada/hazard/base.py
+++ b/climada/hazard/base.py
@@ -814,9 +814,8 @@ class Hazard():
         try:
             return self.event_name[np.argwhere(
                 self.event_id == event_id)[0][0]]
-        except IndexError:
-            LOGGER.error("No event with id: %s", event_id)
-            raise ValueError
+        except IndexError as err:
+            raise ValueError(f"No event with id: {event_id}") from err
 
     def get_event_date(self, event=None):
         """Return list of date strings for given event or for all events,

--- a/climada/hazard/centroids/test/test_vec_ras.py
+++ b/climada/hazard/centroids/test/test_vec_ras.py
@@ -32,7 +32,7 @@ from shapely.geometry.polygon import Polygon
 from climada import CONFIG
 from climada.hazard.centroids.centr import Centroids
 from climada.util.constants import HAZ_DEMO_FL, DEF_CRS
-from climada.util.coordinates import NE_EPSG, equal_crs
+import climada.util.coordinates as u_coord
 
 DATA_DIR = CONFIG.hazard.test_data.dir()
 
@@ -631,9 +631,9 @@ class TestReader(unittest.TestCase):
         centr = Centroids()
         inten = centr.set_vector_file(shp_file, ['pop_min', 'pop_max'])
 
-        self.assertEqual(CRS.from_user_input(centr.geometry.crs), CRS.from_epsg(NE_EPSG))
+        self.assertEqual(CRS.from_user_input(centr.geometry.crs), CRS.from_epsg(u_coord.NE_EPSG))
         self.assertEqual(centr.geometry.size, centr.lat.size)
-        self.assertEqual(CRS.from_user_input(centr.geometry.crs), CRS.from_epsg(NE_EPSG))
+        self.assertEqual(CRS.from_user_input(centr.geometry.crs), CRS.from_epsg(u_coord.NE_EPSG))
         self.assertAlmostEqual(centr.lon[0], 12.453386544971766)
         self.assertAlmostEqual(centr.lon[-1], 114.18306345846304)
         self.assertAlmostEqual(centr.lat[0], 41.903282179960115)
@@ -693,7 +693,7 @@ class TestReader(unittest.TestCase):
         self.assertAlmostEqual(centr_read.meta['transform'].d, centr.meta['transform'].d)
         self.assertAlmostEqual(centr_read.meta['transform'].e, centr.meta['transform'].e)
         self.assertAlmostEqual(centr_read.meta['transform'].f, centr.meta['transform'].f)
-        self.assertTrue(equal_crs(centr_read.meta['crs'], centr.meta['crs']))
+        self.assertTrue(u_coord.equal_crs(centr_read.meta['crs'], centr.meta['crs']))
 
     def test_write_read_points_h5(self):
         file_name = str(DATA_DIR.joinpath('test_centr.h5'))
@@ -710,7 +710,7 @@ class TestReader(unittest.TestCase):
         self.assertTrue(centr_read.lon.size)
         self.assertTrue(np.allclose(centr_read.lat, centr.lat))
         self.assertTrue(np.allclose(centr_read.lon, centr.lon))
-        self.assertTrue(equal_crs(centr_read.crs, centr.crs))
+        self.assertTrue(u_coord.equal_crs(centr_read.crs, centr.crs))
 
 class TestCentroidsFuncs(unittest.TestCase):
     """Test Centroids methods"""

--- a/climada/hazard/emulator/geo.py
+++ b/climada/hazard/emulator/geo.py
@@ -68,8 +68,8 @@ class HazRegion():
         lon_min, lon_max, lat_min, lat_max = extent
         extent_poly = gpd.GeoSeries(Polygon([
             (lon_min, lat_min), (lon_min, lat_max), (lon_max, lat_max), (lon_max, lat_min)
-        ]), crs=NE_CRS)
-        self.geometry = gpd.GeoDataFrame({'geometry': extent_poly}, crs=NE_CRS)
+        ]), crs=u_coord.NE_CRS)
+        self.geometry = gpd.GeoDataFrame({'geometry': extent_poly}, crs=u_coord.NE_CRS)
 
         if country is not None:
             self.meta['country'] = country
@@ -190,5 +190,5 @@ def get_tc_basin_geometry(tc_basin):
             (lonmax, latmin)
         ]))
     polygons = shapely.ops.unary_union(polygons)
-    polygons = gpd.GeoSeries(polygons, crs=NE_CRS)
-    return gpd.GeoDataFrame({'geometry': polygons}, crs=NE_CRS)
+    polygons = gpd.GeoSeries(polygons, crs=u_coord.NE_CRS)
+    return gpd.GeoDataFrame({'geometry': polygons}, crs=u_coord.NE_CRS)

--- a/climada/hazard/emulator/geo.py
+++ b/climada/hazard/emulator/geo.py
@@ -27,7 +27,7 @@ import shapely.vectorized
 from shapely.geometry import Polygon
 
 from climada.hazard import Centroids
-from climada.util.coordinates import get_country_geometries, NE_CRS
+import climada.util.coordinates as u_coord
 import climada.hazard.emulator.const as const
 
 LOGGER = logging.getLogger(__name__)
@@ -77,7 +77,7 @@ class HazRegion():
                 country = None
             elif not isinstance(country, list):
                 country = [country]
-            country_geom = get_country_geometries(country_names=country)
+            country_geom = u_coord.get_country_geometries(country_names=country)
             self.geometry = gpd.overlay(self.geometry, country_geom, how="intersection")
 
         if geometry is not None:

--- a/climada/hazard/low_flow.py
+++ b/climada/hazard/low_flow.py
@@ -40,7 +40,7 @@ from scipy import sparse
 from climada.hazard.base import Hazard
 from climada.hazard.tag import Tag as TagHazard
 from climada.hazard.centroids import Centroids
-from climada.util.coordinates import get_resolution
+import climada.util.coordinates as u_coord
 
 LOGGER = logging.getLogger(__name__)
 
@@ -473,7 +473,7 @@ class LowFlow(Hazard):
             res_centr = abs(centroids.meta['transform'][4]), \
                         centroids.meta['transform'][0]
         else:
-            res_centr = np.abs(get_resolution(centroids.lat, centroids.lon))
+            res_centr = np.abs(u_coord.get_resolution(centroids.lat, centroids.lon))
         if np.abs(res_centr[0] - res_centr[1]) > 1.0e-6:
             LOGGER.warning('Centroids do not represent regular pixels %s.', str(res_centr))
             return (res_centr[0] + res_centr[1]) / 2

--- a/climada/hazard/river_flood.py
+++ b/climada/hazard/river_flood.py
@@ -32,11 +32,9 @@ import pandas as pd
 import geopandas as gpd
 from rasterio.warp import Resampling
 from climada.util.constants import RIVER_FLOOD_REGIONS_CSV
-from climada.util.coordinates import get_region_gridpoints,\
-                                     region2isos, country_iso2natid
+import climada.util.coordinates as u_coord
 from climada.hazard.base import Hazard
 from climada.hazard.centroids import Centroids
-from climada.util.coordinates import get_land_geometry, read_raster
 
 NATID_INFO = pd.read_csv(RIVER_FLOOD_REGIONS_CSV)
 
@@ -138,16 +136,16 @@ class RiverFlood(Hazard):
                 self.fraction = sp.sparse.csr_matrix(fraction)
             else:
                 if reg:
-                    iso_codes = region2isos(reg)
+                    iso_codes = u_coord.region2isos(reg)
                     # envelope containing counties
-                    cntry_geom = get_land_geometry(iso_codes)
+                    cntry_geom = u_coord.get_land_geometry(iso_codes)
                     self.set_raster(files_intensity=[dph_path],
                                     files_fraction=[frc_path],
                                     band=bands.tolist(),
                                     geometry=cntry_geom)
                     # self.centroids.set_meta_to_lat_lon()
                 else:
-                    cntry_geom = get_land_geometry(countries)
+                    cntry_geom = u_coord.get_land_geometry(countries)
                     self.set_raster(files_intensity=[dph_path],
                                     files_fraction=[frc_path],
                                     band=bands.tolist(),
@@ -183,8 +181,8 @@ class RiverFlood(Hazard):
             # else:
             if centroids.meta:
                 centroids.set_meta_to_lat_lon()
-            metafrc, fraction = read_raster(frc_path, band=bands.tolist())
-            metaint, intensity = read_raster(dph_path, band=bands.tolist())
+            metafrc, fraction = u_coord.read_raster(frc_path, band=bands.tolist())
+            metaint, intensity = u_coord.read_raster(dph_path, band=bands.tolist())
             x_i = ((centroids.lon - metafrc['transform'][2]) /
                    metafrc['transform'][0]).astype(int)
             y_i = ((centroids.lat - metafrc['transform'][5]) /
@@ -245,7 +243,7 @@ class RiverFlood(Hazard):
             LOGGER.error('Invalid ReturnLevel-file path %s', fld_trend_path)
             raise NameError
         else:
-            metafrc, trend_data = read_raster(fld_trend_path, band=[1])
+            metafrc, trend_data = u_coord.read_raster(fld_trend_path, band=[1])
             x_i = ((self.centroids.lon - metafrc['transform'][2]) /
                    metafrc['transform'][0]).astype(int)
             y_i = ((self.centroids.lat - metafrc['transform'][5]) /
@@ -280,7 +278,7 @@ class RiverFlood(Hazard):
             LOGGER.error('Invalid ReturnLevel-file path %s', frc_path)
             raise NameError
         else:
-            metafrc, fraction = read_raster(frc_path, band=[1])
+            metafrc, fraction = u_coord.read_raster(frc_path, band=[1])
             x_i = ((self.centroids.lon - metafrc['transform'][2]) /
                    metafrc['transform'][0]).astype(int)
             y_i = ((self.centroids.lat - metafrc['transform'][5]) /
@@ -357,15 +355,15 @@ class RiverFlood(Hazard):
         Returns:
             centroids
         """
-        lat, lon = get_region_gridpoints(countries=countries, regions=reg,
-                                         basemap="isimip", resolution=150)
+        lat, lon = u_coord.get_region_gridpoints(
+            countries=countries, regions=reg, basemap="isimip", resolution=150)
 
         if reg:
-            country_isos = region2isos(reg)
+            country_isos = u_coord.region2isos(reg)
         else:
             country_isos = countries if countries else []
 
-        natIDs = country_iso2natid(country_isos)
+        natIDs = u_coord.country_iso2natid(country_isos)
 
         centroids = Centroids()
         centroids.set_lat_lon(lat, lon)

--- a/climada/hazard/test/test_base.py
+++ b/climada/hazard/test/test_base.py
@@ -181,10 +181,9 @@ class TestLoader(unittest.TestCase):
         """Test event_id_to_name function."""
         haz = Hazard('TC')
         haz.read_excel(HAZ_TEMPLATE_XLS)
-        with self.assertLogs('climada.hazard.base', level='ERROR') as cm:
-            with self.assertRaises(ValueError):
-                haz.get_event_name(1050)
-        self.assertIn('No event with id: 1050', cm.output[0])
+        with self.assertRaises(ValueError) as cm:
+            haz.get_event_name(1050)
+        self.assertIn('No event with id: 1050', str(cm.exception))
 
     def test_get_date_strings_pass(self):
         haz = Hazard('TC')

--- a/climada/hazard/test/test_base.py
+++ b/climada/hazard/test/test_base.py
@@ -30,7 +30,7 @@ from climada.hazard.base import Hazard
 from climada.hazard.centroids.centr import Centroids
 import climada.util.dates_times as u_dt
 from climada.util.constants import HAZ_TEMPLATE_XLS, HAZ_DEMO_FL
-from climada.util.coordinates import equal_crs
+import climada.util.coordinates as u_coord
 
 DATA_DIR = CONFIG.hazard.test_data.dir()
 HAZ_TEST_MAT = DATA_DIR.joinpath('atl_prob_no_name.mat')
@@ -988,7 +988,7 @@ class TestHDF5(unittest.TestCase):
             self.assertEqual(hazard.units, haz_read.units)
             self.assertIsInstance(haz_read.units, str)
             self.assertTrue(np.array_equal(hazard.centroids.coord, haz_read.centroids.coord))
-            self.assertTrue(equal_crs(hazard.centroids.crs, haz_read.centroids.crs))
+            self.assertTrue(u_coord.equal_crs(hazard.centroids.crs, haz_read.centroids.crs))
             self.assertTrue(np.array_equal(hazard.event_id, haz_read.event_id))
             self.assertTrue(np.array_equal(hazard.frequency, haz_read.frequency))
             self.assertTrue(np.array_equal(hazard.event_name, haz_read.event_name))
@@ -1017,7 +1017,7 @@ class TestCentroids(unittest.TestCase):
         self.assertIsInstance(haz_fl.intensity, sparse.csr_matrix)
         self.assertIsInstance(haz_fl.fraction, sparse.csr_matrix)
         self.assertEqual(haz_fl.fraction.shape, (1, 1046408))
-        self.assertTrue(equal_crs(haz_fl.centroids.meta['crs'], {'init': 'epsg:2202'}))
+        self.assertTrue(u_coord.equal_crs(haz_fl.centroids.meta['crs'], {'init': 'epsg:2202'}))
         self.assertEqual(haz_fl.centroids.meta['width'], 968)
         self.assertEqual(haz_fl.centroids.meta['height'], 1081)
         self.assertEqual(haz_fl.fraction.min(), 0)
@@ -1049,7 +1049,7 @@ class TestCentroids(unittest.TestCase):
                                - meta_orig['transform'][0] / 2)
         self.assertAlmostEqual(haz_fl.centroids.lon.min(),
                                meta_orig['transform'][2] + meta_orig['transform'][0] / 2)
-        self.assertTrue(equal_crs(haz_fl.centroids.crs, meta_orig['crs']))
+        self.assertTrue(u_coord.equal_crs(haz_fl.centroids.crs, meta_orig['crs']))
         self.assertTrue(np.allclose(haz_fl.intensity.data, inten_orig.data))
         self.assertTrue(np.allclose(haz_fl.fraction.data, fract_orig.data))
 
@@ -1071,7 +1071,7 @@ class TestCentroids(unittest.TestCase):
                                     np.array([331585.4099637291, 696803.88, 1098649.44])))
         self.assertTrue(np.allclose(haz_fl.centroids.lon,
                                     np.array([11625664.37925186, 11939560.43, 12244857.13])))
-        self.assertTrue(equal_crs(haz_fl.centroids.crs, {'init': 'epsg:2202'}))
+        self.assertTrue(u_coord.equal_crs(haz_fl.centroids.crs, {'init': 'epsg:2202'}))
         self.assertTrue(np.allclose(haz_fl.intensity.toarray(), np.array([0.5, 0.2, 0.1])))
         self.assertTrue(np.allclose(haz_fl.fraction.toarray(), np.array([0.5, 0.2, 0.1]) / 2))
 
@@ -1089,7 +1089,7 @@ class TestCentroids(unittest.TestCase):
         haz_fl.check()
 
         haz_fl.vector_to_raster()
-        self.assertTrue(equal_crs(haz_fl.centroids.meta['crs'], {'init': 'epsg:4326'}))
+        self.assertTrue(u_coord.equal_crs(haz_fl.centroids.meta['crs'], {'init': 'epsg:4326'}))
         self.assertAlmostEqual(haz_fl.centroids.meta['transform'][0], 1.0)
         self.assertAlmostEqual(haz_fl.centroids.meta['transform'][1], 0)
         self.assertAlmostEqual(haz_fl.centroids.meta['transform'][2], 0.5)

--- a/climada/hazard/test/test_flood.py
+++ b/climada/hazard/test/test_flood.py
@@ -32,7 +32,7 @@ class TestRiverFlood(unittest.TestCase):
     def test_wrong_iso3_fail(self):
 
         emptyFlood = RiverFlood()
-        with self.assertRaises(KeyError):
+        with self.assertRaises(LookupError):
             RiverFlood._select_exact_area(['OYY'])
         with self.assertRaises(AttributeError):
             emptyFlood.set_from_nc(years=[2600], dph_path=HAZ_DEMO_FLDDPH,

--- a/climada/hazard/test/test_landslide.py
+++ b/climada/hazard/test/test_landslide.py
@@ -26,40 +26,40 @@ from scipy import sparse
 
 from climada import CONFIG
 from climada.hazard.landslide import Landslide, sample_events_from_probs
-from climada.util.coordinates import read_raster
+import climada.util.coordinates as u_coord
 
 DATA_DIR = CONFIG.hazard.test_data.dir()
 LS_HIST_FILE = DATA_DIR / 'test_ls_hist.shp'
 LS_PROB_FILE = DATA_DIR / 'test_ls_prob.tif'
 
-class TestLandslideModule(unittest.TestCase):     
+class TestLandslideModule(unittest.TestCase):
 
     def test_set_ls_hist(self):
         """ Test function set_ls_hist()"""
         LS_hist = Landslide()
-        LS_hist.set_ls_hist(bbox=(20,40,23,46), 
+        LS_hist.set_ls_hist(bbox=(20,40,23,46),
                                   input_gdf=LS_HIST_FILE)
         self.assertEqual(LS_hist.size, 272)
         self.assertEqual(LS_hist.tag.haz_type, 'LS')
         self.assertEqual(np.unique(LS_hist.intensity.data),np.array([1]))
         self.assertEqual(np.unique(LS_hist.fraction.data),np.array([1]))
         self.assertTrue((LS_hist.frequency.data<=1).all())
-        
+
         input_gdf = gpd.read_file(LS_HIST_FILE)
         LS_hist = Landslide()
-        LS_hist.set_ls_hist(bbox=(20,40,23,46), 
+        LS_hist.set_ls_hist(bbox=(20,40,23,46),
                                   input_gdf=input_gdf)
         self.assertEqual(LS_hist.size, 272)
         self.assertEqual(LS_hist.tag.haz_type, 'LS')
         self.assertEqual(np.unique(LS_hist.intensity.data),np.array([1]))
         self.assertEqual(np.unique(LS_hist.fraction.data),np.array([1]))
         self.assertTrue((LS_hist.frequency.data<=1).all())
-        
+
     def test_set_ls_prob(self):
         """ Test the function set_ls_prob()"""
         LS_prob = Landslide()
         n_years=1000
-        LS_prob.set_ls_prob(bbox=(8,45,11,46), 
+        LS_prob.set_ls_prob(bbox=(8,45,11,46),
                             path_sourcefile=LS_PROB_FILE, n_years=n_years,
                             dist='binom')
 
@@ -76,10 +76,10 @@ class TestLandslideModule(unittest.TestCase):
         self.assertEqual(LS_prob.centroids.crs.to_epsg(), 4326)
         self.assertTrue(LS_prob.centroids.coord.max() <= 46)
         self.assertTrue(LS_prob.centroids.coord.min() >= 8)
-        
+
         LS_prob = Landslide()
         n_years=300
-        LS_prob.set_ls_prob(bbox=(8,45,11,46), 
+        LS_prob.set_ls_prob(bbox=(8,45,11,46),
                             path_sourcefile=LS_PROB_FILE,
                             dist='poisson', n_years=n_years)
         self.assertEqual(LS_prob.tag.haz_type, 'LS')
@@ -95,10 +95,10 @@ class TestLandslideModule(unittest.TestCase):
         self.assertEqual(LS_prob.centroids.crs.to_epsg(), 4326)
         self.assertTrue(LS_prob.centroids.coord.max() <= 46)
         self.assertTrue(LS_prob.centroids.coord.min() >= 8)
-        
+
         LS_prob = Landslide()
         corr_fact = 1.8*10e6
-        LS_prob.set_ls_prob(bbox=(8,45,11,46), 
+        LS_prob.set_ls_prob(bbox=(8,45,11,46),
                             path_sourcefile=LS_PROB_FILE,
                             dist='poisson', corr_fact=corr_fact)
         self.assertEqual(LS_prob.tag.haz_type, 'LS')
@@ -114,26 +114,26 @@ class TestLandslideModule(unittest.TestCase):
         self.assertEqual(LS_prob.centroids.crs.to_epsg(), 4326)
         self.assertTrue(LS_prob.centroids.coord.max() <= 46)
         self.assertTrue(LS_prob.centroids.coord.min() >= 8)
-    
+
     def test_sample_events_from_probs(self):
         bbox = (8,45,11,46)
         corr_fact = 10e6
         n_years = 400
-        __, prob_matrix = read_raster(LS_PROB_FILE, geometry=
-                                      [shapely.geometry.box(*bbox, ccw=True)])
+        __, prob_matrix = u_coord.read_raster(
+            LS_PROB_FILE, geometry=[shapely.geometry.box(*bbox, ccw=True)])
         prob_matrix = sparse.csr_matrix(prob_matrix/corr_fact)
-        
-        ev_matrix = sample_events_from_probs(prob_matrix, n_years, 
+
+        ev_matrix = sample_events_from_probs(prob_matrix, n_years,
                                              dist='binom')
         self.assertTrue(max(ev_matrix.data) <= n_years)
         self.assertEqual(min(ev_matrix.data), 0)
-        
-        ev_matrix = sample_events_from_probs(prob_matrix/corr_fact, n_years, 
+
+        ev_matrix = sample_events_from_probs(prob_matrix/corr_fact, n_years,
                                              dist='poisson')
         self.assertTrue(max(ev_matrix.data) <= n_years)
         self.assertEqual(min(ev_matrix.data), 0)
-      
-      
+
+
 if __name__ == "__main__":
     TESTS = unittest.TestLoader().loadTestsFromTestCase(TestLandslideModule)
-    unittest.TextTestRunner(verbosity=2).run(TESTS)           
+    unittest.TextTestRunner(verbosity=2).run(TESTS)

--- a/climada/hazard/test/test_tc_tracks.py
+++ b/climada/hazard/test/test_tc_tracks.py
@@ -31,7 +31,7 @@ import climada.hazard.tc_tracks as tc
 from climada import CONFIG
 from climada.util import ureg
 from climada.util.constants import TC_ANDREW_FL
-from climada.util.coordinates import coord_on_land, dist_to_coast
+import climada.util.coordinates as u_coord
 from climada.entity import Exposures
 
 DATA_DIR = CONFIG.hazard.test_data.dir()
@@ -659,15 +659,16 @@ class TestFuncs(unittest.TestCase):
         tc_track = tc.TCTracks()
         tc_track.read_processed_ibtracs_csv(TC_ANDREW_FL)
         track = tc_track.get_track()
-        track['on_land'] = ('time', coord_on_land(track.lat.values, track.lon.values))
+        track['on_land'] = ('time', u_coord.coord_on_land(track.lat.values, track.lon.values))
         track['dist_since_lf'] = ('time', tc._dist_since_lf(track))
 
         msk = ~track.on_land
         self.assertTrue(np.all(np.isnan(track.dist_since_lf.values[msk])))
         self.assertEqual(track.dist_since_lf.values[msk].size, 38)
 
-        self.assertGreater(track.dist_since_lf.values[-1],
-                           dist_to_coast(track.lat.values[-1], track.lon.values[-1]) / 1000)
+        self.assertGreater(
+            track.dist_since_lf.values[-1],
+            u_coord.dist_to_coast(track.lat.values[-1], track.lon.values[-1]) / 1000)
         self.assertEqual(1020.5431562223974, track['dist_since_lf'].values[-1])
 
         # check distances on land always increase, in second landfall

--- a/climada/hazard/trop_cyclone.py
+++ b/climada/hazard/trop_cyclone.py
@@ -339,9 +339,8 @@ class TropCyclone(Hazard):
         """
         try:
             mod_id = MODEL_VANG[model]
-        except KeyError:
-            LOGGER.error('Model not implemented: %s.', model)
-            raise ValueError
+        except KeyError as err:
+            raise ValueError(f'Model not implemented: {model}.') from err
         ncentroids = centroids.coord.shape[0]
         coastal_centr = centroids.coord[coastal_idx]
         windfields, reachable_centr_idx = compute_windfields(track, coastal_centr, mod_id,

--- a/climada/test/test_LitPop.py
+++ b/climada/test/test_LitPop.py
@@ -27,7 +27,7 @@ from climada.entity.exposures.litpop import LitPop
 from climada.entity.exposures import litpop as lp
 from climada.entity.exposures import gpw_import
 from climada.util.finance import world_bank_wealth_account
-from climada.util.coordinates import equal_crs
+import climada.util.coordinates as u_coord
 
 
 class TestLitPopExposure(unittest.TestCase):
@@ -51,10 +51,10 @@ class TestLitPopExposure(unittest.TestCase):
         self.assertIn('GPW-year=2015', ent.tag.description)
         self.assertIn('BM-year=2016', ent.tag.description)
         self.assertIn('exp=[1, 1]', ent.tag.description)
-        self.assertTrue(equal_crs(ent.crs, {'init': 'epsg:4326'}))
+        self.assertTrue(u_coord.equal_crs(ent.crs, {'init': 'epsg:4326'}))
         self.assertEqual(ent.meta['width'], 54)
         self.assertEqual(ent.meta['height'], 23)
-        self.assertTrue(equal_crs(ent.meta['crs'], {'init': 'epsg:4326'}))
+        self.assertTrue(u_coord.equal_crs(ent.meta['crs'], {'init': 'epsg:4326'}))
         self.assertAlmostEqual(ent.meta['transform'][0], 0.08333333333333333)
         self.assertAlmostEqual(ent.meta['transform'][1], 0)
         self.assertAlmostEqual(ent.meta['transform'][2], 5.9166666666666)

--- a/climada/test/test_blackmarble.py
+++ b/climada/test/test_blackmarble.py
@@ -28,7 +28,7 @@ from climada.entity.exposures.nightlight import load_nightlight_nasa, \
                                                 load_nightlight_noaa, \
                                                 NOAA_BORDER
 from climada.entity.exposures import nightlight as nl_utils
-from climada.util.coordinates import equal_crs
+import climada.util.coordinates as u_coord
 
 class Test2013(unittest.TestCase):
     """Test black marble of previous in 2013."""
@@ -48,10 +48,10 @@ class Test2013(unittest.TestCase):
         self.assertIn("Processing country Spain.", cm.output[1])
         self.assertIn("Generating resolution of approx 1 km.", cm.output[2])
         self.assertTrue(np.isclose(ent.gdf.value.sum(), 1.355e+12 * (4 + 1), 0.001))
-        self.assertTrue(equal_crs(ent.crs, 'epsg:4326'))
+        self.assertTrue(u_coord.equal_crs(ent.crs, 'epsg:4326'))
         self.assertEqual(ent.meta['width'], 2699)
         self.assertEqual(ent.meta['height'], 1938)
-        self.assertTrue(equal_crs(ent.meta['crs'], 'epsg:4326'))
+        self.assertTrue(u_coord.equal_crs(ent.meta['crs'], 'epsg:4326'))
         self.assertAlmostEqual(ent.meta['transform'][0], 0.008333333333333333)
         self.assertAlmostEqual(ent.meta['transform'][1], 0)
         self.assertAlmostEqual(ent.meta['transform'][2], -18.1625000000000)
@@ -66,7 +66,7 @@ class Test2013(unittest.TestCase):
             ent.set_countries(country_name, 2013, res_km=0.2)
         self.assertIn('GDP SXM 2013: 1.023e+09.', cm.output[0])
         self.assertIn('Income group SXM 2013: 4.', cm.output[1])
-        self.assertTrue(equal_crs(ent.crs, 'epsg:4326'))
+        self.assertTrue(u_coord.equal_crs(ent.crs, 'epsg:4326'))
 
         with self.assertLogs('climada.entity.exposures.black_marble', level='INFO') as cm:
             ent.set_countries(country_name, 2013, res_km=0.2)
@@ -75,7 +75,7 @@ class Test2013(unittest.TestCase):
         self.assertIn("Processing country Sint Maarten.", cm.output[1])
         self.assertIn("Generating resolution of approx 0.2 km.", cm.output[2])
         self.assertTrue(np.isclose(ent.gdf.value.sum(), 1.023e+09 * (4 + 1), 0.001))
-        self.assertTrue(equal_crs(ent.crs, 'epsg:4326'))
+        self.assertTrue(u_coord.equal_crs(ent.crs, 'epsg:4326'))
 
     def test_anguilla_pass(self):
         country_name = ['Anguilla']
@@ -84,7 +84,7 @@ class Test2013(unittest.TestCase):
         self.assertEqual(ent.ref_year, 2013)
         self.assertIn("Anguilla 2013 GDP: 1.754e+08 income group: 3", ent.tag.description)
         self.assertAlmostEqual(ent.gdf.value.sum(), 1.754e+08 * (3 + 1))
-        self.assertTrue(equal_crs(ent.crs, 'epsg:4326'))
+        self.assertTrue(u_coord.equal_crs(ent.crs, 'epsg:4326'))
 
 class Test1968(unittest.TestCase):
     """Test black marble of previous years to 1992."""
@@ -103,7 +103,7 @@ class Test1968(unittest.TestCase):
         self.assertTrue("Processing country Switzerland." in cm.output[-2])
         self.assertTrue("Generating resolution of approx 0.5 km." in cm.output[-1])
         self.assertTrue(np.isclose(ent.gdf.value.sum(), 1.894e+10 * (4 + 1), 4))
-        self.assertTrue(equal_crs(ent.crs, 'epsg:4326'))
+        self.assertTrue(u_coord.equal_crs(ent.crs, 'epsg:4326'))
 
 class Test2012(unittest.TestCase):
     """Test year 2012 flags."""
@@ -138,7 +138,7 @@ class Test2012(unittest.TestCase):
         self.assertTrue(np.isclose(ent.gdf.value.sum(), 8.740e+11 * (3 + 1), 4))
         size3 = ent.gdf.value.size
         self.assertEqual(size1, size3)
-        self.assertTrue(equal_crs(ent.crs, 'epsg:4326'))
+        self.assertTrue(u_coord.equal_crs(ent.crs, 'epsg:4326'))
 
 class BMFuncs(unittest.TestCase):
     """Test plot functions."""

--- a/climada/util/constants.py
+++ b/climada/util/constants.py
@@ -162,8 +162,33 @@ ISIMIP_NATID_TO_ISO = [
     'TUN', 'TUR', 'TUV', 'TWN', 'TZA', 'UGA', 'UKR', 'URY', 'USA', 'UZB', 'VCT',
     'VEN', 'VGB', 'VIR', 'VNM', 'VUT', 'WLF', 'WSM', 'YEM', 'ZAF', 'ZMB', 'ZWE',
 ]
-"""ISO3166 alpha-3 codes of countries used in ISIMIP_GPWV3_NATID_150AS"""
+"""ISO 3166 alpha-3 codes of countries used in ISIMIP_GPWV3_NATID_150AS"""
 
+NONISO_REGIONS = [
+    # Dummy region for numeric 0 (or empty string), sometimes used for oceans
+    dict(name="", alpha_2="", alpha_3="", numeric="000"),
+    dict(name="Akrotiri", alpha_2="XA", alpha_3="XXA", numeric="901"),
+    dict(name="Baikonur", alpha_2="XB", alpha_3="XXB", numeric="902"),
+    dict(name="Bajo Nuevo Bank", alpha_2="XJ", alpha_3="XXJ", numeric="903"),
+    dict(name="Clipperton I.", alpha_2="XC", alpha_3="XXC", numeric="904"),
+    dict(name="Coral Sea Is.", alpha_2="XO", alpha_3="XXO", numeric="905"),
+    dict(name="Cyprus U.N. Buffer Zone", alpha_2="XU", alpha_3="XXU", numeric="906"),
+    dict(name="Dhekelia", alpha_2="XD", alpha_3="XXD", numeric="907"),
+    dict(name="Indian Ocean Ter.", alpha_2="XI", alpha_3="XXI", numeric="908"),
+    # For Kosovo, we follow the iso3166 package and the statistical office of Canada:
+    # https://www.statcan.gc.ca/eng/subjects/standard/sccai/2011/scountry-desc
+    dict(name="Kosovo", alpha_2="XK", alpha_3="XKO", numeric="983"),
+    dict(name="N. Cyprus", alpha_2="XY", alpha_3="XXY", numeric="910"),
+    dict(name="Scarborough Reef", alpha_2="XS", alpha_3="XXS", numeric="912"),
+    dict(name="Serranilla Bank", alpha_2="XR", alpha_3="XXR", numeric="913"),
+    dict(name="Siachen Glacier", alpha_2="XH", alpha_3="XXH", numeric="914"),
+    dict(name="Somaliland", alpha_2="XM", alpha_3="XXM", numeric="915"),
+    dict(name="Spratly Is.", alpha_2="XP", alpha_3="XXP", numeric="916"),
+    dict(name="USNB Guantanamo Bay", alpha_2="XG", alpha_3="XXG", numeric="917"),
+]
+"""Geopolitical areas that are not listed in the ISO 3166 standard, but might be relevant when
+working, e.g. with Natural Earth shape files. The alpha-2, alpha-3 and numeric representations are
+unofficial and for internal use only."""
 
 ONE_LAT_KM = 111.12
 """Mean one latitude (in degrees) to km"""

--- a/climada/util/coordinates.py
+++ b/climada/util/coordinates.py
@@ -23,8 +23,9 @@ import ast
 import copy
 import logging
 import math
-from pathlib import Path
 from multiprocessing import cpu_count
+from pathlib import Path
+import re
 
 import zipfile
 
@@ -32,9 +33,9 @@ from cartopy.io import shapereader
 import dask.dataframe as dd
 from fiona.crs import from_epsg
 import geopandas as gpd
-from iso3166 import countries as iso_cntry
 import numpy as np
 import pandas as pd
+import pycountry
 import rasterio
 import rasterio.crs
 import rasterio.features
@@ -50,6 +51,7 @@ from climada.util.constants import (DEF_CRS, SYSTEM_DIR, ONE_LAT_KM,
                                     NATEARTH_CENTROIDS,
                                     ISIMIP_GPWV3_NATID_150AS,
                                     ISIMIP_NATID_TO_ISO,
+                                    NONISO_REGIONS,
                                     RIVER_FLOOD_REGIONS_CSV)
 from climada.util.files_handler import download_file
 import climada.util.hdf5_handler as u_hdf5
@@ -684,7 +686,7 @@ def get_country_geometries(country_names=None, extent=None, resolution=10):
     Parameters
     ----------
     country_names : list, optional
-        list with ISO3 names of countries, e.g ['ZWE', 'GBR', 'VNM', 'UZB']
+        list with ISO 3166 alpha-3 codes of countries, e.g ['ZWE', 'GBR', 'VNM', 'UZB']
     extent : tuple (min_lon, max_lon, min_lat, max_lat), optional
         Extent, assumed to be in the same CRS as the natural earth data.
     resolution : float, optional
@@ -710,15 +712,8 @@ def get_country_geometries(country_names=None, extent=None, resolution=10):
     nat_earth.loc[gap_mask, 'ISO_A3'] = nat_earth.loc[gap_mask, 'ADM0_A3']
 
     gap_mask = (nat_earth['ISO_N3'] == '-99')
-    for idx in nat_earth[gap_mask].index:
-        for col in ['ISO_A3', 'ADM0_A3', 'NAME']:
-            try:
-                num = iso_cntry.get(nat_earth.loc[idx, col]).numeric
-            except KeyError:
-                continue
-            else:
-                nat_earth.loc[idx, 'ISO_N3'] = num
-                break
+    for idx, country in nat_earth[gap_mask].iterrows():
+        nat_earth.loc[idx, "ISO_N3"] = f"{natearth_country_to_int(country):03d}"
 
     out = nat_earth
     if country_names:
@@ -957,94 +952,99 @@ def region2isos(regions):
         isos += list(reg_info['ISO'][region_msk].values)
     return list(set(isos))
 
-def country_iso_alpha2numeric(iso_alpha):
-    """Convert ISO 3166-1 alpha-3 to numeric-3 codes
+def country_to_iso(countries, representation="alpha3"):
+    """Determine ISO 3166 representation of countries
+
+    Example
+    -------
+    >>> country_to_iso(840)
+    'USA'
+    >>> country_to_iso("United States", representation="alpha2")
+    'US'
+    >>> country_to_iso(["United States of America", "SU"], "numeric")
+    [840, 810]
+
+    Some geopolitical areas that are not covered by ISO 3166 are added in the "user-assigned"
+    range of ISO 3166-compliant values:
+
+    >>> country_to_iso(["XK", "Dhekelia"], "numeric")  # XK for Kosovo
+    [983, 907]
 
     Parameters
     ----------
-    isos : str or list of str
-        ISO alpha-3 codes of countries (or single code).
+    countries : one of str, int, list of str, list of int
+        Country identifiers: name, official name, alpha-2, alpha-3 or numeric ISO codes.
+        Numeric representations may be specified as str or int.
+    representation : str, one of "alpha3", "alpha2", "numeric", "name"
+        All countries are converted to this representation according to ISO 3166.
+        Default: "alpha3".
 
     Returns
     -------
-    iso_num : int or list of int
-        ISO numeric-3 codes of countries. 
-        Will only return a list if the input is a list.
+    iso_list : one of str, int, list of str, list of int
+        ISO 3166 representation of countries. Will only return a list if the input is a list.
+        Numeric representations are returned as integers.
     """
-    return_int = isinstance(iso_alpha, str)
-    iso_list = [iso_alpha] if return_int else iso_alpha
-    old_iso = {
-        '': 0,  # Ocean or fill_value
-        "ANT": 530,  # Netherlands Antilles: split up since 2010
-        "SCG": 891,  # Serbia and Montenegro: split up since 2006
-    }
-    iso_num = []
-    for iso in iso_list:
-        try:
-            if iso in old_iso:
-                num = old_iso[iso]
-            else:
-                num = int(iso_cntry.get(iso).numeric)
-            iso_num.append(num)
-        except ValueError as ver:
-            raise KeyError(f'Unknown country ISO: {iso}') from ver
-    return iso_num[0] if return_int else iso_num
+    return_single = isinstance(countries, (str, int))
+    countries = [countries] if return_single else countries
 
-def country_iso_numeric2alpha(iso_numeric):
-    """Convert ISO 3166-1 numeric-3codes to alpha-3
-    
-    Parameters
-    ----------
-    iso_numeric : int or list of int
-        ISO numeric-3 codes of countries (or single code).
-        
-    Returns
-    -------
-    iso_list : str or list of str
-        ISO alpha-3 codes of countries. 
-        Will only return a list if the input is a list.
-    """
-    return_str = isinstance(iso_numeric, int)
-    iso_num_list = [iso_numeric] if return_str else iso_numeric
-    old_iso = {
-        0: '',  # Ocean or fill_value
-        530: "ANT", # Netherlands Antilles: split up since 2010
-        891: "SCG", # Serbia and Montenegro: split up since 2006
-    }
+    if not re.match(r"(alpha[-_]?[23]|numeric|name)", representation):
+        raise ValueError(f"Unknown ISO representation: {representation}")
+    representation = re.sub(r"alpha-?([23])", r"alpha_\1", representation)
+
     iso_list = []
-    for iso_num in iso_num_list:  
+    for country in countries:
+        country = f"{country:03d}" if isinstance(country, int) else country
         try:
-            if iso_num in old_iso:
-                iso = old_iso[iso_num]
-            else:
-                iso = iso_cntry.get(iso_num).alpha3
-            iso_list.append(iso)
-        except ValueError as ver:
-            raise KeyError(f'Unknown country ISO: {iso}') from ver
-    return iso_list[0] if return_str else iso_list
+            match = pycountry.countries.lookup(country)
+        except LookupError:
+            try:
+                match = pycountry.historic_countries.lookup(country)
+            except LookupError:
+                match = next(filter(lambda c: country in c.values(), NONISO_REGIONS), None)
+                if match is not None:
+                    match = pycountry.db.Data(**match)
+                else:
+                    raise LookupError(f'Unknown country identifier: {country}')
+        iso = getattr(match, representation)
+        if representation == "numeric":
+            iso = int(iso)
+        iso_list.append(iso)
+    return iso_list[0] if return_single else iso_list
 
-def country_natid2iso(natids):
+def country_iso_alpha2numeric(iso_alpha):
+    """Deprecated: Use `country_to_iso` with `representation="numeric"` instead"""
+    LOGGER.warning("country_iso_alpha2numeric is deprecated, use country_to_iso instead.")
+    return country_to_iso(iso_alpha, "numeric")
+
+def country_natid2iso(natids, representation="alpha3"):
     """Convert internal NatIDs to ISO 3166-1 alpha-3 codes
 
     Parameters
     ----------
     natids : int or list of int
-        Internal NatIDs of countries (or single ID).
+        NatIDs of countries (or single ID) as used in ISIMIP's version of the GPWv3
+        national identifier grid.
+    representation : str, one of "alpha3", "alpha2" or "numeric"
+        All countries are converted to this representation according to ISO 3166.
+        Default: "alpha3".
 
     Returns
     -------
-    isos : str or list of str
-        Will only return a list if the input is a list
+    iso_list : one of str, int, list of str, list of int
+        ISO 3166 representation of countries. Will only return a list if the input is a list.
+        Numeric representations are returned as integers.
     """
     return_str = isinstance(natids, int)
     natids = [natids] if return_str else natids
-    isos = []
+    iso_list = []
     for natid in natids:
         if natid < 0 or natid >= len(ISIMIP_NATID_TO_ISO):
-            LOGGER.error('Unknown country NatID: %s', natid)
-            raise KeyError
-        isos.append(ISIMIP_NATID_TO_ISO[natid])
-    return isos[0] if return_str else isos
+            raise LookupError('Unknown country NatID: %s', natid)
+        iso_list.append(ISIMIP_NATID_TO_ISO[natid])
+    if representation != "alpha3":
+        iso_list = country_to_iso(iso_list, representation)
+    return iso_list[0] if return_str else iso_list
 
 def country_iso2natid(isos):
     """Convert ISO 3166-1 alpha-3 codes to internal NatIDs
@@ -1066,29 +1066,8 @@ def country_iso2natid(isos):
         try:
             natids.append(ISIMIP_NATID_TO_ISO.index(iso))
         except ValueError as ver:
-            LOGGER.error('Unknown country ISO: %s', iso)
-            raise KeyError(f'Unknown country ISO: {iso}') from ver
+            raise LookupError(f'Unknown country ISO: {iso}') from ver
     return natids[0] if return_int else natids
-
-NATEARTH_AREA_NONISO_NUMERIC = {
-    "Akrotiri": 901,
-    "Baikonur": 902,
-    "Bajo Nuevo Bank": 903,
-    "Clipperton I.": 904,
-    "Coral Sea Is.": 905,
-    "Cyprus U.N. Buffer Zone": 906,
-    "Dhekelia": 907,
-    "Indian Ocean Ter.": 908,
-    "Kosovo": 983,  # Same as iso3166 package
-    "N. Cyprus": 910,
-    "Norway": 578,  # Bug in Natural Earth
-    "Scarborough Reef": 912,
-    "Serranilla Bank": 913,
-    "Siachen Glacier": 914,
-    "Somaliland": 915,
-    "Spratly Is.": 916,
-    "USNB Guantanamo Bay": 917,
-}
 
 def natearth_country_to_int(country):
     """Integer representation (ISO 3166, if possible) of Natural Earth GeoPandas country row
@@ -1096,7 +1075,7 @@ def natearth_country_to_int(country):
     Parameters
     ----------
     country : GeoSeries
-        Row from GeoDataFrame.
+        Row from Natural Earth GeoDataFrame.
 
     Returns
     -------
@@ -1105,7 +1084,7 @@ def natearth_country_to_int(country):
     """
     if country.ISO_N3 != '-99':
         return int(country.ISO_N3)
-    return NATEARTH_AREA_NONISO_NUMERIC[str(country.NAME)]
+    return country_to_iso(str(country.NAME), representation="numeric")
 
 def get_country_code(lat, lon, gridded=False):
     """Provide numeric (ISO 3166) code for every point.

--- a/climada/util/test/test_coordinates.py
+++ b/climada/util/test/test_coordinates.py
@@ -36,40 +36,6 @@ from rasterio.crs import CRS as RCRS
 from climada import CONFIG
 from climada.util.constants import HAZ_DEMO_FL, DEF_CRS
 import climada.util.coordinates as u_coord
-from climada.util.coordinates import (convert_wgs_to_utm,
-                                      coord_on_land,
-                                      country_iso_alpha2numeric,
-                                      country_iso2natid,
-                                      country_natid2iso,
-                                      country_to_iso,
-                                      dist_approx,
-                                      dist_to_coast,
-                                      dist_to_coast_nasa,
-                                      equal_crs,
-                                      get_admin1_info,
-                                      get_coastlines,
-                                      get_country_code,
-                                      get_country_geometries,
-                                      get_gridcellarea,
-                                      get_land_geometry,
-                                      get_resolution,
-                                      grid_is_regular,
-                                      latlon_bounds,
-                                      latlon_to_geosph_vector,
-                                      lon_normalize,
-                                      nat_earth_resolution,
-                                      points_to_raster,
-                                      pts_to_raster_meta,
-                                      read_raster,
-                                      read_raster_sample,
-                                      read_raster_bounds,
-                                      read_vector,
-                                      refine_raster_data,
-                                      set_df_geometry_points,
-                                      to_crs_user_input,
-                                      write_raster,
-                                      NE_EPSG,
-                                      ONE_LAT_KM)
 
 DATA_DIR = CONFIG.util.test_data.dir()
 
@@ -80,46 +46,46 @@ class TestFunc(unittest.TestCase):
         data = np.array([-180, 20.1, -30, 190, -350])
 
         # test in place operation
-        lon_normalize(data)
+        u_coord.lon_normalize(data)
         np.testing.assert_array_almost_equal(data, [180, 20.1, -30, -170, 10])
 
         # test with specific center and return value
-        data = lon_normalize(data, center=-170)
+        data = u_coord.lon_normalize(data, center=-170)
         np.testing.assert_array_almost_equal(data, [-180, -339.9, -30, -170, 10])
 
         # test with center determined automatically (which is 280.05)
-        data = lon_normalize(data, center=None)
+        data = u_coord.lon_normalize(data, center=None)
         np.testing.assert_array_almost_equal(data, [180, 380.1, 330, 190, 370])
 
     def test_latlon_bounds(self):
         """Test latlon_bounds function"""
         lat, lon = np.array([0, -2, 5]), np.array([-179, 175, 178])
-        bounds = latlon_bounds(lat, lon)
+        bounds = u_coord.latlon_bounds(lat, lon)
         self.assertEqual(bounds, (175, -2, 181, 5))
-        bounds = latlon_bounds(lat, lon, buffer=1)
+        bounds = u_coord.latlon_bounds(lat, lon, buffer=1)
         self.assertEqual(bounds, (174, -3, 182, 6))
 
         # buffer exceeding antimeridian
         lat, lon = np.array([0, -2.1, 5]), np.array([-179.5, -175, -178])
-        bounds = latlon_bounds(lat, lon, buffer=1)
+        bounds = u_coord.latlon_bounds(lat, lon, buffer=1)
         self.assertEqual(bounds, (179.5, -3.1, 186, 6))
 
         # longitude values need to be normalized before they lie between computed bounds:
         lon_mid = 0.5 * (bounds[0] + bounds[2])
-        lon = lon_normalize(lon, center=lon_mid)
+        lon = u_coord.lon_normalize(lon, center=lon_mid)
         self.assertTrue(np.all((bounds[0] <= lon) & (lon <= bounds[2])))
 
         # data covering almost the whole longitudinal range
         lat, lon = np.linspace(-90, 90, 180), np.linspace(-180.0, 179, 360)
-        bounds = latlon_bounds(lat, lon)
+        bounds = u_coord.latlon_bounds(lat, lon)
         self.assertEqual(bounds, (-179, -90, 180, 90))
-        bounds = latlon_bounds(lat, lon, buffer=1)
+        bounds = u_coord.latlon_bounds(lat, lon, buffer=1)
         self.assertEqual(bounds, (-180, -90, 180, 90))
 
     def test_geosph_vector(self):
         """Test conversion from lat/lon to unit vector on geosphere"""
         data = np.array([[0, 0], [-13, 179]], dtype=np.float64)
-        vn, vbasis = latlon_to_geosph_vector(data[:, 0], data[:, 1], basis=True)
+        vn, vbasis = u_coord.latlon_to_geosph_vector(data[:, 0], data[:, 1], basis=True)
         basis_scal = (vbasis[..., 0, :] * vbasis[..., 1, :]).sum(axis=-1)
         basis_norm = np.linalg.norm(vbasis, axis=-1)
         self.assertTrue(np.allclose(np.linalg.norm(vn, axis=-1), 1))
@@ -137,10 +103,12 @@ class TestFunc(unittest.TestCase):
             [-3, -130.1, 4, -30.5, 11079.7217421, 11087.0352544],
         ])
         compute_dist = np.stack([
-            dist_approx(data[:, None, 0], data[:, None, 1],
-                        data[:, None, 2], data[:, None, 3], method="equirect")[:, 0, 0],
-            dist_approx(data[:, None, 0], data[:, None, 1],
-                        data[:, None, 2], data[:, None, 3], method="geosphere")[:, 0, 0],
+            u_coord.dist_approx(data[:, None, 0], data[:, None, 1],
+                                data[:, None, 2], data[:, None, 3],
+                                method="equirect")[:, 0, 0],
+            u_coord.dist_approx(data[:, None, 0], data[:, None, 1],
+                                data[:, None, 2], data[:, None, 3],
+                                method="geosphere")[:, 0, 0],
         ], axis=-1)
         self.assertEqual(compute_dist.shape[0], data.shape[0])
         for d, cd in zip(data[:, 4:], compute_dist):
@@ -148,15 +116,15 @@ class TestFunc(unittest.TestCase):
             self.assertAlmostEqual(d[1], cd[1])
 
         for units, factor in zip(["radian", "degree", "km"],
-                                 [np.radians(1.0), 1.0, ONE_LAT_KM]):
-            factor /= ONE_LAT_KM
+                                 [np.radians(1.0), 1.0, u_coord.ONE_LAT_KM]):
+            factor /= u_coord.ONE_LAT_KM
             compute_dist = np.stack([
-                dist_approx(data[:, None, 0], data[:, None, 1],
-                            data[:, None, 2], data[:, None, 3],
-                            method="equirect", units=units)[:, 0, 0],
-                dist_approx(data[:, None, 0], data[:, None, 1],
-                            data[:, None, 2], data[:, None, 3],
-                            method="geosphere", units=units)[:, 0, 0],
+                u_coord.dist_approx(data[:, None, 0], data[:, None, 1],
+                                    data[:, None, 2], data[:, None, 3],
+                                    method="equirect", units=units)[:, 0, 0],
+                u_coord.dist_approx(data[:, None, 0], data[:, None, 1],
+                                    data[:, None, 2], data[:, None, 3],
+                                    method="geosphere", units=units)[:, 0, 0],
             ], axis=-1)
             self.assertEqual(compute_dist.shape[0], data.shape[0])
             for d, cd in zip(data[:, 4:], compute_dist):
@@ -172,11 +140,11 @@ class TestFunc(unittest.TestCase):
         ])
         for i, method in enumerate(["equirect", "geosphere"]):
             for units, factor in zip(["radian", "degree", "km"],
-                                     [np.radians(1.0), 1.0, ONE_LAT_KM]):
-                factor /= ONE_LAT_KM
-                dist, vec = dist_approx(data[:, None, 0], data[:, None, 1],
-                                        data[:, None, 2], data[:, None, 3],
-                                        log=True, method=method, units=units)
+                                     [np.radians(1.0), 1.0, u_coord.ONE_LAT_KM]):
+                factor /= u_coord.ONE_LAT_KM
+                dist, vec = u_coord.dist_approx(data[:, None, 0], data[:, None, 1],
+                                                data[:, None, 2], data[:, None, 3],
+                                                log=True, method=method, units=units)
                 dist, vec = dist[:, 0, 0], vec[:, 0, 0]
                 np.testing.assert_allclose(np.linalg.norm(vec, axis=-1), dist)
                 np.testing.assert_allclose(dist, data[:, 4 + i] * factor)
@@ -191,7 +159,7 @@ class TestFunc(unittest.TestCase):
 
         lat = np.array([54.75, 54.25])
         resolution = 0.5
-        area = get_gridcellarea(lat, resolution)
+        area = u_coord.get_gridcellarea(lat, resolution)
 
         self.assertAlmostEqual(area[0], 178159.73363005)
         self.assertAlmostEqual(area[1], 180352.82386516)
@@ -201,9 +169,9 @@ class TestFunc(unittest.TestCase):
         """Test one columns data"""
         shp_file = shapereader.natural_earth(resolution='110m', category='cultural',
                                              name='populated_places_simple')
-        lat, lon, geometry, intensity = read_vector(shp_file, ['pop_min', 'pop_max'])
+        lat, lon, geometry, intensity = u_coord.read_vector(shp_file, ['pop_min', 'pop_max'])
 
-        self.assertEqual(PCRS.from_user_input(geometry.crs), PCRS.from_epsg(NE_EPSG))
+        self.assertEqual(PCRS.from_user_input(geometry.crs), PCRS.from_epsg(u_coord.NE_EPSG))
         self.assertEqual(geometry.size, lat.size)
         self.assertAlmostEqual(lon[0], 12.453386544971766)
         self.assertAlmostEqual(lon[-1], 114.18306345846304)
@@ -222,7 +190,7 @@ class TestFunc(unittest.TestCase):
         """Compare two crs"""
         crs_one = {'init': 'epsg:4326'}
         crs_two = {'init': 'epsg:4326', 'no_defs': True}
-        self.assertTrue(equal_crs(crs_one, crs_two))
+        self.assertTrue(u_coord.equal_crs(crs_one, crs_two))
 
     def test_set_df_geometry_points_pass(self):
         """Test set_df_geometry_points"""
@@ -230,18 +198,18 @@ class TestFunc(unittest.TestCase):
         df_val['latitude'] = np.ones(10) * 40.0
         df_val['longitude'] = np.ones(10) * 0.50
 
-        set_df_geometry_points(df_val)
+        u_coord.set_df_geometry_points(df_val)
         self.assertTrue(np.allclose(df_val.geometry[:].x.values, np.ones(10) * 0.5))
         self.assertTrue(np.allclose(df_val.geometry[:].y.values, np.ones(10) * 40.))
 
     def test_convert_wgs_to_utm_pass(self):
         """Test convert_wgs_to_utm"""
         lat, lon = 17.346597, -62.768669
-        epsg = convert_wgs_to_utm(lon, lat)
+        epsg = u_coord.convert_wgs_to_utm(lon, lat)
         self.assertEqual(epsg, 32620)
 
         lat, lon = 41.522410, 1.891026
-        epsg = convert_wgs_to_utm(lon, lat)
+        epsg = u_coord.convert_wgs_to_utm(lon, lat)
         self.assertEqual(epsg, 32631)
 
     def test_to_crs_user_input(self):
@@ -249,25 +217,25 @@ class TestFunc(unittest.TestCase):
         rcrs = RCRS.from_epsg(4326)
 
         # are they the default?
-        self.assertTrue(pcrs == PCRS.from_user_input(to_crs_user_input(DEF_CRS)))
-        self.assertEqual(rcrs, RCRS.from_user_input(to_crs_user_input(DEF_CRS)))
+        self.assertTrue(pcrs == PCRS.from_user_input(u_coord.to_crs_user_input(DEF_CRS)))
+        self.assertEqual(rcrs, RCRS.from_user_input(u_coord.to_crs_user_input(DEF_CRS)))
 
         # can they be understood from the provider?
         for arg in ['epsg:4326', b'epsg:4326', DEF_CRS, 4326]:
-            self.assertEqual(pcrs, PCRS.from_user_input(to_crs_user_input(arg)))
-            self.assertEqual(rcrs, RCRS.from_user_input(to_crs_user_input(arg)))
+            self.assertEqual(pcrs, PCRS.from_user_input(u_coord.to_crs_user_input(arg)))
+            self.assertEqual(rcrs, RCRS.from_user_input(u_coord.to_crs_user_input(arg)))
 
         # can they be misunderstood from the provider?
         for arg in [{'init': 'epsg:4326', 'no_defs': True}, b'{"init": "epsg:4326", "no_defs": True}' ]:
-            self.assertFalse(pcrs == PCRS.from_user_input(to_crs_user_input(arg)))
-            self.assertEqual(rcrs, RCRS.from_user_input(to_crs_user_input(arg)))
+            self.assertFalse(pcrs == PCRS.from_user_input(u_coord.to_crs_user_input(arg)))
+            self.assertEqual(rcrs, RCRS.from_user_input(u_coord.to_crs_user_input(arg)))
 
         # are they noticed?
         for arg in [4326.0, [4326]]:
             with self.assertRaises(ValueError):
-                to_crs_user_input(arg)
+                u_coord.to_crs_user_input(arg)
         with self.assertRaises(SyntaxError):
-            to_crs_user_input('{init: epsg:4326, no_defs: True}')
+            u_coord.to_crs_user_input('{init: epsg:4326, no_defs: True}')
 
     def test_country_iso_alpha2numeric(self):
         self.assertEqual(country_iso_alpha2numeric('NOR'), 578)  # 578 for Norway
@@ -335,49 +303,50 @@ class TestFunc(unittest.TestCase):
         natid_list = [0, 217, 9, 104, 13, 154, 128]
 
         # examples from docstring:
-        self.assertEqual(country_to_iso(840), "USA")
-        self.assertEqual(country_to_iso("United States", representation="alpha2"), "US")
-        self.assertEqual(country_to_iso(["United States of America", "SU"], "numeric"), [840, 810])
-        self.assertEqual(country_to_iso(["XK", "Dhekelia"], "numeric"), [983, 907])
+        self.assertEqual(u_coord.country_to_iso(840), "USA")
+        self.assertEqual(u_coord.country_to_iso("United States", representation="alpha2"), "US")
+        self.assertEqual(u_coord.country_to_iso(["United States of America", "SU"], "numeric"),
+                         [840, 810])
+        self.assertEqual(u_coord.country_to_iso(["XK", "Dhekelia"], "numeric"), [983, 907])
 
         # test cases:
         iso_lists = [name_list, al2_list, al3_list, num_list]
         for l1 in iso_lists:
             for l2, representation in zip(iso_lists, ["name", "alpha2", "alpha3", "numeric"]):
-                self.assertEqual(country_to_iso(l1, representation), l2)
+                self.assertEqual(u_coord.country_to_iso(l1, representation), l2)
 
         # deprecated API `country_iso_alpha2numeric`
-        self.assertEqual(country_iso_alpha2numeric(al3_list[-2]), num_list[-2])
-        self.assertEqual(country_iso_alpha2numeric(al3_list), num_list)
+        self.assertEqual(u_coord.country_iso_alpha2numeric(al3_list[-2]), num_list[-2])
+        self.assertEqual(u_coord.country_iso_alpha2numeric(al3_list), num_list)
 
         # conversion to/from ISIMIP natid
-        self.assertEqual(country_iso2natid(al3_list[2]), natid_list[2])
-        self.assertEqual(country_iso2natid(al3_list), natid_list)
-        self.assertEqual(country_natid2iso(natid_list, "numeric"), num_list)
-        self.assertEqual(country_natid2iso(natid_list, "alpha2"), al2_list)
-        self.assertEqual(country_natid2iso(natid_list, "alpha3"), al3_list)
-        self.assertEqual(country_natid2iso(natid_list), al3_list)
-        self.assertEqual(country_natid2iso(natid_list[1]), al3_list[1])
+        self.assertEqual(u_coord.country_iso2natid(al3_list[2]), natid_list[2])
+        self.assertEqual(u_coord.country_iso2natid(al3_list), natid_list)
+        self.assertEqual(u_coord.country_natid2iso(natid_list, "numeric"), num_list)
+        self.assertEqual(u_coord.country_natid2iso(natid_list, "alpha2"), al2_list)
+        self.assertEqual(u_coord.country_natid2iso(natid_list, "alpha3"), al3_list)
+        self.assertEqual(u_coord.country_natid2iso(natid_list), al3_list)
+        self.assertEqual(u_coord.country_natid2iso(natid_list[1]), al3_list[1])
 
 class TestGetGeodata(unittest.TestCase):
     def test_nat_earth_resolution_pass(self):
         """Correct resolution."""
-        self.assertEqual(nat_earth_resolution(10), '10m')
-        self.assertEqual(nat_earth_resolution(50), '50m')
-        self.assertEqual(nat_earth_resolution(110), '110m')
+        self.assertEqual(u_coord.nat_earth_resolution(10), '10m')
+        self.assertEqual(u_coord.nat_earth_resolution(50), '50m')
+        self.assertEqual(u_coord.nat_earth_resolution(110), '110m')
 
     def test_nat_earth_resolution_fail(self):
         """Wrong resolution."""
         with self.assertRaises(ValueError):
-            nat_earth_resolution(11)
+            u_coord.nat_earth_resolution(11)
         with self.assertRaises(ValueError):
-            nat_earth_resolution(51)
+            u_coord.nat_earth_resolution(51)
         with self.assertRaises(ValueError):
-            nat_earth_resolution(111)
+            u_coord.nat_earth_resolution(111)
 
     def test_get_coastlines_all_pass(self):
         """Check get_coastlines function over whole earth"""
-        coast = get_coastlines(resolution=110)
+        coast = u_coord.get_coastlines(resolution=110)
         tot_bounds = coast.total_bounds
         self.assertEqual((134, 1), coast.shape)
         self.assertAlmostEqual(tot_bounds[0], -180)
@@ -388,7 +357,7 @@ class TestGetGeodata(unittest.TestCase):
     def test_get_coastlines_pass(self):
         """Check get_coastlines function in defined extent"""
         bounds = (-100, -55, -20, 35)
-        coast = get_coastlines(bounds, resolution=110)
+        coast = u_coord.get_coastlines(bounds, resolution=110)
         ex_box = box(bounds[0], bounds[1], bounds[2], bounds[3])
         self.assertEqual(coast.shape[0], 14)
         self.assertTrue(coast.total_bounds[2] < 0)
@@ -399,21 +368,21 @@ class TestGetGeodata(unittest.TestCase):
     def test_get_land_geometry_country_pass(self):
         """get_land_geometry with selected countries."""
         iso_countries = ['DEU', 'VNM']
-        res = get_land_geometry(iso_countries, 110)
+        res = u_coord.get_land_geometry(iso_countries, 110)
         self.assertIsInstance(res, shapely.geometry.multipolygon.MultiPolygon)
         for res, ref in zip(res.bounds, (5.85248986800, 8.56557851800,
                                          109.47242272200, 55.065334377000)):
             self.assertAlmostEqual(res, ref)
 
         iso_countries = ['ESP']
-        res = get_land_geometry(iso_countries, 110)
+        res = u_coord.get_land_geometry(iso_countries, 110)
         self.assertIsInstance(res, shapely.geometry.multipolygon.MultiPolygon)
         for res, ref in zip(res.bounds, (-18.16722571499986, 27.642238674000,
                                          4.337087436000, 43.793443101)):
             self.assertAlmostEqual(res, ref)
 
         iso_countries = ['FRA']
-        res = get_land_geometry(iso_countries, 110)
+        res = u_coord.get_land_geometry(iso_countries, 110)
         self.assertIsInstance(res, shapely.geometry.multipolygon.MultiPolygon)
         for res, ref in zip(res.bounds, (-61.79784094999991, -21.37078215899993,
                                          55.854502800000034, 51.08754088371883)):
@@ -423,7 +392,7 @@ class TestGetGeodata(unittest.TestCase):
         """get_land_geometry with selected countries."""
         lat = np.array([28.203216, 28.555994, 28.860875])
         lon = np.array([-16.567489, -18.554130, -9.532476])
-        res = get_land_geometry(extent=(np.min(lon), np.max(lon),
+        res = u_coord.get_land_geometry(extent=(np.min(lon), np.max(lon),
                                 np.min(lat), np.max(lat)), resolution=10)
         self.assertIsInstance(res, shapely.geometry.multipolygon.MultiPolygon)
         self.assertAlmostEqual(res.bounds[0], -18.002186653)
@@ -433,7 +402,7 @@ class TestGetGeodata(unittest.TestCase):
 
     def test_get_land_geometry_all_pass(self):
         """get_land_geometry with all earth."""
-        res = get_land_geometry(resolution=110)
+        res = u_coord.get_land_geometry(resolution=110)
         self.assertIsInstance(res, shapely.geometry.multipolygon.MultiPolygon)
         self.assertAlmostEqual(res.area, 21496.99098799273)
 
@@ -441,7 +410,7 @@ class TestGetGeodata(unittest.TestCase):
         """check point on land with 1:50.000.000 resolution."""
         lat = np.array([28.203216, 28.555994, 28.860875])
         lon = np.array([-16.567489, -18.554130, -9.532476])
-        res = coord_on_land(lat, lon)
+        res = u_coord.coord_on_land(lat, lon)
         self.assertEqual(res.size, 3)
         self.assertTrue(res[0])
         self.assertFalse(res[1])
@@ -459,11 +428,11 @@ class TestGetGeodata(unittest.TestCase):
         ])
         dists = [2594.2071059573445, 1382985.2459744606, 0.088222234]
         for d, p in zip(dists, points):
-            res = dist_to_coast(*p)
+            res = u_coord.dist_to_coast(*p)
             self.assertAlmostEqual(d, res[0])
 
         # All at once requires more than one UTM
-        res = dist_to_coast(points)
+        res = u_coord.dist_to_coast(points)
         for d, r in zip(dists, res):
             self.assertAlmostEqual(d, r)
 
@@ -480,8 +449,8 @@ class TestGetGeodata(unittest.TestCase):
         dists = [-3000, -1393549.5, 48.77]
         dists_lowres = [416.66666667, 1393448.09801077, 1191.38205367]
         # Warning: This will download more than 300 MB of data!
-        result = dist_to_coast_nasa(points[:, 0], points[:, 1], highres=True, signed=True)
-        result_lowres = dist_to_coast_nasa(points[:, 0], points[:, 1])
+        result = u_coord.dist_to_coast_nasa(points[:, 0], points[:, 1], highres=True, signed=True)
+        result_lowres = u_coord.dist_to_coast_nasa(points[:, 0], points[:, 1])
         for d, r in zip(dists, result):
             self.assertAlmostEqual(d, r)
         for d, r in zip(dists_lowres, result_lowres):
@@ -492,7 +461,7 @@ class TestGetGeodata(unittest.TestCase):
         natural earth data should be caught by test_get_land_geometry_* since
         it's very similar"""
         iso_countries = ['NLD', 'VNM']
-        res = get_country_geometries(iso_countries, resolution=110)
+        res = u_coord.get_country_geometries(iso_countries, resolution=110)
         self.assertIsInstance(res, gpd.geodataframe.GeoDataFrame)
         self.assertEqual(res.shape[0], 2)
 
@@ -500,8 +469,8 @@ class TestGetGeodata(unittest.TestCase):
         """test correct numeric ISO3 for country Norway"""
         iso_countries = ['NOR']
         extent = [10, 11, 55, 60]
-        res1 = get_country_geometries(iso_countries)
-        res2 = get_country_geometries(extent=extent)
+        res1 = u_coord.get_country_geometries(iso_countries)
+        res2 = u_coord.get_country_geometries(extent=extent)
         self.assertEqual(res1.ISO_N3.values[0], '578')
         self.assertIn('578', res2.ISO_N3.values)
         self.assertIn('NOR', res2.ISO_A3.values)
@@ -514,7 +483,7 @@ class TestGetGeodata(unittest.TestCase):
         lat = np.array([28.203216, 28.555994, 28.860875])
         lon = np.array([-16.567489, -18.554130, -9.532476])
 
-        res = get_country_geometries(extent=(
+        res = u_coord.get_country_geometries(extent=(
             np.min(lon), np.max(lon),
             np.min(lat), np.max(lat)
         ))
@@ -539,7 +508,7 @@ class TestGetGeodata(unittest.TestCase):
     def test_get_country_geometries_all_pass(self):
         """get_country_geometries with no countries or extent; i.e. the whole
         earth"""
-        res = get_country_geometries(resolution=110)
+        res = u_coord.get_country_geometries(resolution=110)
         self.assertIsInstance(res, gpd.geodataframe.GeoDataFrame)
         self.assertAlmostEqual(res.area[0], 1.639510995900778)
 
@@ -552,8 +521,8 @@ class TestGetGeodata(unittest.TestCase):
         lat = np.array([13.125, 13.20833333, 13.29166667, 13.125, 13.20833333,
                         13.125, 12.625, 12.70833333])
         for gridded in [True, False]:
-            region_id = get_country_code(lat, lon, gridded=gridded)
-            region_id_OSLO = get_country_code(59.91, 10.75, gridded=gridded)
+            region_id = u_coord.get_country_code(lat, lon, gridded=gridded)
+            region_id_OSLO = u_coord.get_country_code(59.91, 10.75, gridded=gridded)
             self.assertEqual(np.count_nonzero(region_id), 6)
             # 052 for barbados
             self.assertTrue(np.all(region_id[:6] == 52))
@@ -563,7 +532,7 @@ class TestGetGeodata(unittest.TestCase):
     def test_get_admin1_info_pass(self):
         """test get_admin1_info()"""
         country_names = ['CHE', 'IDN', 'USA']
-        admin1_info, admin1_shapes = get_admin1_info(country_names)
+        admin1_info, admin1_shapes = u_coord.get_admin1_info(country_names)
         self.assertEqual(len(admin1_info), 3)
         self.assertEqual(len(admin1_info['CHE']), len(admin1_shapes['CHE']))
         self.assertEqual(len(admin1_info['CHE']), 26)
@@ -575,31 +544,31 @@ class TestRasterMeta(unittest.TestCase):
     def test_is_regular_pass(self):
         """Test is_regular function."""
         coord = np.array([[1, 2], [4.4, 5.4], [4, 5]])
-        reg, hei, wid = grid_is_regular(coord)
+        reg, hei, wid = u_coord.grid_is_regular(coord)
         self.assertFalse(reg)
         self.assertEqual(hei, 1)
         self.assertEqual(wid, 1)
 
         coord = np.array([[1, 2], [4.4, 5], [4, 5]])
-        reg, hei, wid = grid_is_regular(coord)
+        reg, hei, wid = u_coord.grid_is_regular(coord)
         self.assertFalse(reg)
         self.assertEqual(hei, 1)
         self.assertEqual(wid, 1)
 
         coord = np.array([[1, 2], [4, 5]])
-        reg, hei, wid = grid_is_regular(coord)
+        reg, hei, wid = u_coord.grid_is_regular(coord)
         self.assertFalse(reg)
         self.assertEqual(hei, 1)
         self.assertEqual(wid, 1)
 
         coord = np.array([[1, 2], [4, 5], [1, 5], [4, 3]])
-        reg, hei, wid = grid_is_regular(coord)
+        reg, hei, wid = u_coord.grid_is_regular(coord)
         self.assertFalse(reg)
         self.assertEqual(hei, 2)
         self.assertEqual(wid, 1)
 
         coord = np.array([[1, 2], [4, 5], [1, 5], [4, 2]])
-        reg, hei, wid = grid_is_regular(coord)
+        reg, hei, wid = u_coord.grid_is_regular(coord)
         self.assertTrue(reg)
         self.assertEqual(hei, 2)
         self.assertEqual(wid, 2)
@@ -609,7 +578,7 @@ class TestRasterMeta(unittest.TestCase):
         grid_x = grid_x.reshape(-1,)
         grid_y = grid_y.reshape(-1,)
         coord = np.array([grid_x, grid_y]).transpose()
-        reg, hei, wid = grid_is_regular(coord)
+        reg, hei, wid = u_coord.grid_is_regular(coord)
         self.assertTrue(reg)
         self.assertEqual(hei, 5)
         self.assertEqual(wid, 5)
@@ -619,7 +588,7 @@ class TestRasterMeta(unittest.TestCase):
         grid_x = grid_x.reshape(-1,)
         grid_y = grid_y.reshape(-1,)
         coord = np.array([grid_x, grid_y]).transpose()
-        reg, hei, wid = grid_is_regular(coord)
+        reg, hei, wid = u_coord.grid_is_regular(coord)
         self.assertTrue(reg)
         self.assertEqual(hei, 5)
         self.assertEqual(wid, 4)
@@ -634,7 +603,7 @@ class TestRasterMeta(unittest.TestCase):
             -59.5416666666667, -59.4583333333333, -60.2083333333333, -60.2083333333333,
             -60.2083333333333, -60.2083333333333, -60.2083333333333, -60.2083333333333
         ])
-        res_lat, res_lon = get_resolution(lat, lon)
+        res_lat, res_lon = u_coord.get_resolution(lat, lon)
         self.assertAlmostEqual(res_lat, 0.0833333333333)
         self.assertAlmostEqual(res_lon, 0.0833333333333)
 
@@ -643,7 +612,7 @@ class TestRasterMeta(unittest.TestCase):
         xmin, ymin, xmax, ymax = -60, -5, -50, 10  # bounds of points == centers pixels
         points_bounds = (xmin, ymin, xmax, ymax)
         res = 0.5
-        rows, cols, ras_trans = pts_to_raster_meta(points_bounds, (res, -res))
+        rows, cols, ras_trans = u_coord.pts_to_raster_meta(points_bounds, (res, -res))
         self.assertEqual(xmin - res / 2 + res * cols, xmax + res / 2)
         self.assertEqual(ymax + res / 2 - res * rows, ymin - res / 2)
         self.assertEqual(ras_trans[0], res)
@@ -661,7 +630,7 @@ class TestRasterMeta(unittest.TestCase):
         points_bounds = (-124.19473, 32.81908, -114.4632, 42.020759999999996)
         xmin, ymin, xmax, ymax = points_bounds
         res = 0.013498920086393088
-        rows, cols, ras_trans = pts_to_raster_meta(points_bounds, (res, -res))
+        rows, cols, ras_trans = u_coord.pts_to_raster_meta(points_bounds, (res, -res))
         self.assertEqual(ras_trans[0], res)
         self.assertEqual(ras_trans[4], -res)
         self.assertEqual(ras_trans[1], 0.0)
@@ -678,8 +647,8 @@ class TestRasterMeta(unittest.TestCase):
         df_val['latitude'] = y.flatten()
         df_val['longitude'] = x.flatten()
         df_val['value'] = np.ones(len(df_val)) * 10
-        _raster, meta = points_to_raster(df_val, val_names=['value'])
-        self.assertTrue(equal_crs(meta['crs'], df_val.crs))
+        _raster, meta = u_coord.points_to_raster(df_val, val_names=['value'])
+        self.assertTrue(u_coord.equal_crs(meta['crs'], df_val.crs))
         self.assertAlmostEqual(meta['transform'][0], 0.5)
         self.assertAlmostEqual(meta['transform'][1], 0)
         self.assertAlmostEqual(meta['transform'][2], -0.25)
@@ -694,8 +663,9 @@ class TestRasterMeta(unittest.TestCase):
         df_val['latitude'] = [1, 0, 1, 0]
         df_val['longitude'] = [178, -179.0, 181, -180]
         df_val['value'] = np.arange(4)
-        r_data, meta = points_to_raster(df_val, val_names=['value'], res=0.5, raster_res=1.0)
-        self.assertTrue(equal_crs(meta['crs'], df_val.crs))
+        r_data, meta = u_coord.points_to_raster(
+            df_val, val_names=['value'], res=0.5, raster_res=1.0)
+        self.assertTrue(u_coord.equal_crs(meta['crs'], df_val.crs))
         self.assertAlmostEqual(meta['transform'][0], 1.0)
         self.assertAlmostEqual(meta['transform'][1], 0)
         self.assertAlmostEqual(meta['transform'][2], 177.5)
@@ -718,8 +688,8 @@ class TestRasterIO(unittest.TestCase):
             'crs': 'epsg:2202',
             'compress': 'deflate',
         }
-        write_raster(test_file, data, meta)
-        read_meta, read_data = read_raster(test_file)
+        u_coord.write_raster(test_file, data, meta)
+        read_meta, read_data = u_coord.read_raster(test_file)
         self.assertEqual(read_meta['transform'], meta['transform'])
         self.assertEqual(read_meta['width'], meta['width'])
         self.assertEqual(read_meta['height'], meta['height'])
@@ -729,7 +699,7 @@ class TestRasterIO(unittest.TestCase):
 
     def test_window_raster_pass(self):
         """Test window"""
-        meta, inten_ras = read_raster(HAZ_DEMO_FL, window=Window(10, 20, 50.1, 60))
+        meta, inten_ras = u_coord.read_raster(HAZ_DEMO_FL, window=Window(10, 20, 50.1, 60))
         self.assertAlmostEqual(meta['crs'], DEF_CRS)
         self.assertAlmostEqual(meta['transform'].c, -69.2471495969998)
         self.assertAlmostEqual(meta['transform'].a, 0.009000000000000341)
@@ -745,7 +715,7 @@ class TestRasterIO(unittest.TestCase):
     def test_poly_raster_pass(self):
         """Test geometry"""
         poly = box(-69.2471495969998, 9.708220966978912, -68.79714959699979, 10.248220966978932)
-        meta, inten_ras = read_raster(HAZ_DEMO_FL, geometry=[poly])
+        meta, inten_ras = u_coord.read_raster(HAZ_DEMO_FL, geometry=[poly])
         self.assertAlmostEqual(meta['crs'], DEF_CRS)
         self.assertAlmostEqual(meta['transform'].c, -69.2471495969998)
         self.assertAlmostEqual(meta['transform'].a, 0.009000000000000341)
@@ -759,8 +729,8 @@ class TestRasterIO(unittest.TestCase):
 
     def test_crs_raster_pass(self):
         """Test change projection"""
-        meta, inten_ras = read_raster(HAZ_DEMO_FL, dst_crs={'init': 'epsg:2202'},
-                                      resampling=Resampling.nearest)
+        meta, inten_ras = u_coord.read_raster(
+            HAZ_DEMO_FL, dst_crs={'init': 'epsg:2202'}, resampling=Resampling.nearest)
         self.assertAlmostEqual(meta['crs'], {'init': 'epsg:2202'})
         self.assertAlmostEqual(meta['transform'].c, 462486.8490210658)
         self.assertAlmostEqual(meta['transform'].a, 998.576177833903)
@@ -783,8 +753,9 @@ class TestRasterIO(unittest.TestCase):
             (500000, 1105412.49126517),
             (478080.8562247154, 1105419.13439131)
         ])
-        meta, inten_ras = read_raster(HAZ_DEMO_FL, dst_crs={'init': 'epsg:2202'},
-                                      geometry=[ply], resampling=Resampling.nearest)
+        meta, inten_ras = u_coord.read_raster(
+            HAZ_DEMO_FL, dst_crs={'init': 'epsg:2202'}, geometry=[ply],
+            resampling=Resampling.nearest)
         self.assertAlmostEqual(meta['crs'], {'init': 'epsg:2202'})
         self.assertEqual(meta['height'], 12)
         self.assertEqual(meta['width'], 23)
@@ -795,7 +766,8 @@ class TestRasterIO(unittest.TestCase):
     def test_transform_raster_pass(self):
         transform = Affine(0.009000000000000341, 0.0, -69.33714959699981,
                            0.0, -0.009000000000000341, 10.42822096697894)
-        meta, inten_ras = read_raster(HAZ_DEMO_FL, transform=transform, height=500, width=501)
+        meta, inten_ras = u_coord.read_raster(
+            HAZ_DEMO_FL, transform=transform, height=500, width=501)
 
         left = meta['transform'].xoff
         top = meta['transform'].yoff
@@ -811,7 +783,7 @@ class TestRasterIO(unittest.TestCase):
         self.assertEqual(meta['crs'].to_epsg(), 4326)
         self.assertEqual(inten_ras.shape, (1, 500 * 501))
 
-        meta, inten_all = read_raster(HAZ_DEMO_FL, window=Window(0, 0, 501, 500))
+        meta, inten_all = u_coord.read_raster(HAZ_DEMO_FL, window=Window(0, 0, 501, 500))
         self.assertTrue(np.array_equal(inten_all, inten_ras))
 
     def test_sample_raster(self):
@@ -834,13 +806,13 @@ class TestRasterIO(unittest.TestCase):
         res = 0.009000000000000341
         lat = 10.42822096697894 - res / 2 - i_j_vals[:, 0] * res
         lon = -69.33714959699981 + res / 2 + i_j_vals[:, 1] * res
-        values = read_raster_sample(HAZ_DEMO_FL, lat, lon, fill_value=fill_value)
+        values = u_coord.read_raster_sample(HAZ_DEMO_FL, lat, lon, fill_value=fill_value)
         self.assertEqual(values.size, lat.size)
         for i, val in enumerate(i_j_vals[:, 2]):
             self.assertAlmostEqual(values[i], val)
 
         # with explicit intermediate resolution
-        values = read_raster_sample(HAZ_DEMO_FL, lat, lon, fill_value=fill_value,
+        values = u_coord.read_raster_sample(HAZ_DEMO_FL, lat, lon, fill_value=fill_value,
                                     intermediate_res=res)
         self.assertEqual(values.size, lat.size)
         for i, val in enumerate(i_j_vals[:, 2]):
@@ -854,7 +826,7 @@ class TestRasterIO(unittest.TestCase):
         ])
         transform = Affine(0.5, 0, 0, 0, 0.5, 0)
         new_res = 0.1
-        new_data, new_transform = refine_raster_data(data, transform, new_res)
+        new_data, new_transform = u_coord.refine_raster_data(data, transform, new_res)
 
         self.assertEqual(new_transform[0], new_res)
         self.assertEqual(new_transform[4], new_res)
@@ -868,7 +840,7 @@ class TestRasterIO(unittest.TestCase):
     def test_bounded_refined_raster(self):
         """Test reading a raster within specified bounds and at specified resolution"""
         bounds = (-69.14, 9.99, -69.11, 10.03)
-        z, transform = read_raster_bounds(HAZ_DEMO_FL, bounds, res=0.004)
+        z, transform = u_coord.read_raster_bounds(HAZ_DEMO_FL, bounds, res=0.004)
 
         # the first dimension corresponds to the raster bands:
         self.assertEqual(z.shape[0], 1)

--- a/climada/util/test/test_coordinates.py
+++ b/climada/util/test/test_coordinates.py
@@ -237,20 +237,6 @@ class TestFunc(unittest.TestCase):
         with self.assertRaises(SyntaxError):
             u_coord.to_crs_user_input('{init: epsg:4326, no_defs: True}')
 
-    def test_country_iso_alpha2numeric(self):
-        self.assertEqual(country_iso_alpha2numeric('NOR'), 578)  # 578 for Norway
-
-        isos_list = ['', 'USA', 'ARG', 'JPN', 'AUS', 'NOR', 'MDG']
-        nums_list = [0, 840, 32, 392, 36, 578, 450]
-        self.assertEqual(country_iso_alpha2numeric(isos_list), nums_list)
-
-    def test_country_iso_numeric2alpha(self):
-        self.assertEqual(country_iso_numeric2alpha(578), 'NOR')  # 578 for Norway
-
-        isos_list = ['', 'USA', 'ARG', 'JPN', 'AUS', 'NOR', 'MDG']
-        nums_list = [0, 840, 32, 392, 36, 578, 450]
-        self.assertEqual(country_iso_numeric2alpha(nums_list), isos_list)
-
     def test_assign_grid_points(self):
         """Test assign_grid_points function"""
         res = (1, -0.5)
@@ -318,6 +304,9 @@ class TestFunc(unittest.TestCase):
         # deprecated API `country_iso_alpha2numeric`
         self.assertEqual(u_coord.country_iso_alpha2numeric(al3_list[-2]), num_list[-2])
         self.assertEqual(u_coord.country_iso_alpha2numeric(al3_list), num_list)
+
+        # test fillvalue-parameter for unknown countries
+        self.assertEqual(u_coord.country_to_iso("ABC", fillvalue="XOT"), "XOT")
 
         # conversion to/from ISIMIP natid
         self.assertEqual(u_coord.country_iso2natid(al3_list[2]), natid_list[2])

--- a/requirements/env_climada.yml
+++ b/requirements/env_climada.yml
@@ -11,7 +11,6 @@ dependencies:
   - geopandas>=0.6,<0.9
   - h5py>=2.10
   - haversine>=2.3
-  - iso3166>=1.0
   - matplotlib>=3.2
   - netcdf4>=1.5
   - numba>=0.51

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,6 @@ setup(
         'geopandas',
         'h5py',
         'haversine',
-        'iso3166',
         'matplotlib',
         'netcdf4',
         'numba',


### PR DESCRIPTION
Currently, CLIMADA uses the Python package `iso3166` to look up country codes according to the ISO 3166 standard. Unfortunately, that package doesn't cover historical countries that are covered in ISO 3166-3, but only the countries in ISO 3166-1. Furthermore, the package `iso3166` maintains its own database of country codes instead of building upon already existing and well-maintained databases of country codes like Debian's [iso-codes](https://salsa.debian.org/iso-codes-team/iso-codes).

Furtunately, there is an alternative to `iso3166` that is build on Debian's iso-codes: `pycountry`. That package is well-maintained and covers ISO 3166-1 as well as ISO 3166-3 (historic countries), so we don't have to manually deal with those (see #201).

This PR adds the requirement `pycountry` and removes `iso3166`. It makes sure that there are no places in CLIMADA left where `iso3166` is used and provides a util function `country_to_iso` that is able to replace all future use cases where users might want to have a functionality that was formerly provided by `iso3166`. 