### PR TITLE
Improve speed of subsetting an Impact by centroids

### DIFF
--- a/climada/engine/impact.py
+++ b/climada/engine/impact.py
@@ -1093,6 +1093,7 @@ class Impact():
         else:
             coords_merged = pd.DataFrame(self.coord_exp).merge(pd.DataFrame(coord_exp), how='left', indicator=True)
             sel_exp = np.where(coords_merged['_merge'] == 'both')[0]
+            sel_exp = list(sel_exp)
             if not sel_exp:
                 LOGGER.warning("No exposure coordinates matches the selection.")
 

--- a/climada/engine/impact.py
+++ b/climada/engine/impact.py
@@ -1091,11 +1091,8 @@ class Impact():
         if coord_exp is None:
             sel_exp = []
         else:
-            sel_exp =  [
-                j
-                for j, coord in enumerate(self.coord_exp)
-                if coord in coord_exp
-                ]
+            coords_merged = pd.DataFrame(self.coord_exp).merge(pd.DataFrame(coord_exp), how='left', indicator=True)
+            sel_exp = np.where(coords_merged['_merge'] == 'both')[0]
             if not sel_exp:
                 LOGGER.warning("No exposure coordinates matches the selection.")
 

--- a/climada/engine/impact.py
+++ b/climada/engine/impact.py
@@ -1091,9 +1091,8 @@ class Impact():
         if coord_exp is None:
             sel_exp = []
         else:
-            coords_merged = pd.DataFrame(self.coord_exp).merge(pd.DataFrame(coord_exp), how='left', indicator=True)
-            sel_exp = np.where(coords_merged['_merge'] == 'both')[0]
-            sel_exp = list(sel_exp)
+            assigned_idx = u_coord.assign_coordinates(self.coord_exp, coord_exp, threshold=0)
+            sel_exp = list((assigned_idx >= 0).nonzero()[0])
             if not sel_exp:
                 LOGGER.warning("No exposure coordinates matches the selection.")
 

--- a/climada/engine/impact.py
+++ b/climada/engine/impact.py
@@ -1007,10 +1007,10 @@ class Impact():
         nb_exp = len(self.coord_exp)
 
         if self.imp_mat.shape != (nb_events, nb_exp):
-            raise ValueError("The impact matrix is missing or incomplete. " +
-                             "The eai_exp and aai_agg cannot be computed. " +
-                             "Please recompute impact.calc() with save_mat=True" +
-                             " before using impact.select()")
+            raise ValueError("The impact matrix is missing or incomplete. "
+                             "The eai_exp and aai_agg cannot be computed. "
+                             "Please recompute impact.calc() with save_mat=True "
+                             "before using impact.select()")
 
         if nb_events == nb_exp:
             LOGGER.warning("The number of events is equal to the number of "
@@ -1021,54 +1021,41 @@ class Impact():
                            "method.")
             return None
 
-
         if (dates, event_ids, event_names) != (None, None, None):
-            sel_ev = self._selected_events_idx(event_ids, event_names,\
-                                          dates, nb_events)
+            sel_ev = self._selected_events_idx(event_ids, event_names, dates, nb_events)
         else:
             sel_ev = None
 
-        if coord_exp is not None:
-            sel_exp = self._selected_exposures_idx(coord_exp)
-        else:
-            sel_exp = None
-
-
         imp = copy.deepcopy(self)
 
-        #apply event selection to impact attributes
+        # apply event selection to impact attributes
         if sel_ev:
             # set all attributes that are 'per event', i.e. have a dimension
             # of length equal to the number of events (=nb_events)
             for attr in get_attributes_with_matching_dimension(imp, [nb_events]):
-
                 value = imp.__getattribute__(attr)
                 if isinstance(value, np.ndarray):
                     if value.ndim == 1:
                         setattr(imp, attr, value[sel_ev])
                     else:
                         LOGGER.warning("Found a multidimensional numpy array "
-                            " with one dimension matching the number of events. "
-                            " But multidimensional numpy arrays are not handled "
-                            " in impact.select")
-
+                                       "with one dimension matching the number of events. "
+                                       "But multidimensional numpy arrays are not handled "
+                                       "in impact.select")
                 elif isinstance(value, sparse.csr_matrix):
                     setattr(imp, attr, value[sel_ev, :])
-
                 elif isinstance(value, list) and value:
                     setattr(imp, attr, [value[idx] for idx in sel_ev])
-
                 else:
                     pass
 
             LOGGER.info("The eai_exp and aai_agg are computed for the "
-                    "selected subset of events WITHOUT modification of "
-                    "the frequencies.")
+                        "selected subset of events WITHOUT modification of "
+                        "the frequencies.")
 
-
-        #apply exposure selection to impact attributes
-        if sel_exp:
-
+        # apply exposure selection to impact attributes
+        if coord_exp is not None:
+            sel_exp = self._selected_exposures_idx(coord_exp)
             imp.coord_exp = imp.coord_exp[sel_exp]
             imp.imp_mat = imp.imp_mat[:, sel_exp]
 
@@ -1076,7 +1063,7 @@ class Impact():
             imp.at_event = imp.imp_mat.sum(axis=1).A1
             imp.tot_value = None
             LOGGER.info("The total value cannot be re-computed for a "
-                           "subset of exposures and is set to None.")
+                        "subset of exposures and is set to None.")
 
         # cast frequency vector into 2d array for sparse matrix multiplication
         freq_mat = imp.frequency.reshape(len(imp.frequency), 1)
@@ -1087,19 +1074,13 @@ class Impact():
         return imp
 
     def _selected_exposures_idx(self, coord_exp):
-
-        if coord_exp is None:
-            sel_exp = []
-        else:
-            assigned_idx = u_coord.assign_coordinates(self.coord_exp, coord_exp, threshold=0)
-            sel_exp = list((assigned_idx >= 0).nonzero()[0])
-            if not sel_exp:
-                LOGGER.warning("No exposure coordinates matches the selection.")
-
+        assigned_idx = u_coord.assign_coordinates(self.coord_exp, coord_exp, threshold=0)
+        sel_exp = (assigned_idx >= 0).nonzero()[0]
+        if sel_exp.size == 0:
+            LOGGER.warning("No exposure coordinates match the selection.")
         return sel_exp
 
     def _selected_events_idx(self, event_ids, event_names, dates, nb_events):
-
         # filter events by date
         if dates is None:
             mask_dt = np.zeros(nb_events, dtype=bool)

--- a/climada/entity/exposures/base.py
+++ b/climada/entity/exposures/base.py
@@ -296,7 +296,7 @@ class Exposures():
             "approx", see `climada.util.interpolation.interpol_index`. Default: "haversine"
         threshold : float
             If the distance to the nearest neighbor exceeds `threshold`, the index `-1` is
-            assigned. Set `threshold` to 0, to disable nearest neighbor matching. Default: 100
+            assigned. Set `threshold` to 0, to disable nearest neighbor matching. Default: 100 (km)
         """
         LOGGER.info('Matching %s exposures with %s centroids.',
                     str(self.gdf.shape[0]), str(hazard.centroids.size))

--- a/climada/util/coordinates.py
+++ b/climada/util/coordinates.py
@@ -900,8 +900,13 @@ def assign_coordinates(coords, coords_to_assign, method="NN", distance="haversin
     is assigned.
 
     Currently, the nearest neighbor matching works with lat/lon coordinates only. However, you can
-    disable nearest neighbor matching by setting `threshold` to 0. In this case, only exactly
+    disable nearest neighbor matching by setting `threshold` to 0, in which case only exactly
     matching coordinates are assigned to each other.
+
+    Make sure that all coordinates are according to the same coordinate reference system. In case
+    of lat/lon coordinates, the "haversine" distance is able to correctly compute the distance
+    across the antimeridian. However, when exact matches are enforced with `threshold=0`, lat/lon
+    coordinates need to be given in the same longitudinal range (such as (-180, 180)).
 
     Parameters
     ----------
@@ -920,7 +925,7 @@ def assign_coordinates(coords, coords_to_assign, method="NN", distance="haversin
         `climada.util.interpolation.interpol_index`. Default: "haversine"
     threshold : float, optional
         If the distance to the nearest neighbor exceeds `threshold`, the index `-1` is assigned.
-        Set `threshold` to 0, to disable nearest neighbor matching. Default: 100
+        Set `threshold` to 0 to disable nearest neighbor matching. Default: 100 (km)
 
     Returns
     -------

--- a/climada/util/test/test_coordinates.py
+++ b/climada/util/test/test_coordinates.py
@@ -299,13 +299,14 @@ class TestFunc(unittest.TestCase):
 
     def test_assign_coordinates(self):
         """Test assign_coordinates function"""
-        coords = np.array([(0.2, 2), (0, 0), (0, 2), (2.1, 3), (1, 1), (-1, 1)])
-        coords_to_assign = np.array([(2.1, 3), (0, 0), (0, 2), (0.9, 1.0)])
+        # note that the coordinates are in lat/lon
+        coords = np.array([(0.2, 2), (0, 0), (0, 2), (2.1, 3), (1, 1), (-1, 1), (0, 179.9)])
+        coords_to_assign = np.array([(2.1, 3), (0, 0), (0, 2), (0.9, 1.0), (0, -179.9)])
         expected_results = [
-            # test with different thresholds
-            (100, [2, 1, 2, 0, 3, -1]),
-            (20, [-1, 1, 2, 0, 3, -1]),
-            (0, [-1, 1, 2, 0, -1, -1]),
+            # test with different thresholds (in km)
+            (100, [2, 1, 2, 0, 3, -1, 4]),
+            (20, [-1, 1, 2, 0, 3, -1, -1]),
+            (0, [-1, 1, 2, 0, -1, -1, -1]),
         ]
 
         # make sure that it works for both float32 and float64


### PR DESCRIPTION
The existing method for subsetting an Impact by centroid was very slow when working with Impacts and selections that had large numbers of points.

The culprit was in `Impact._selected_exposures_idx()` which constructed a list of the indices of centroids to select using a list comprehension. I've changed this: it now converts all coordinates to pandas data frames, joins them, and records the indices of common values. It's a lot faster.

There may be an even better way, but this takes large calculations down from ~40 seconds to < 1 sec which is all I need.

Tests all pass 👍 