### PR TITLE
Avoid some errors by coercing some Impact.select() input vars

### DIFF
--- a/climada/engine/impact.py
+++ b/climada/engine/impact.py
@@ -1021,6 +1021,13 @@ class Impact():
                            "method.")
             return None
 
+        if not isinstance(dates, list):
+            dates = list(dates)
+        if not isinstance(event_ids, list):
+            event_ids = list(event_ids)
+        if not isinstance(event_names, list):
+            event_names = list(event_names)
+
         if (dates, event_ids, event_names) != (None, None, None):
             sel_ev = self._selected_events_idx(event_ids, event_names, dates, nb_events)
         else:

--- a/climada/engine/impact.py
+++ b/climada/engine/impact.py
@@ -1022,11 +1022,11 @@ class Impact():
             return None
 
         if not isinstance(dates, list):
-            dates = list(dates)
+            dates = dates.tolist()
         if not isinstance(event_ids, list):
-            event_ids = list(event_ids)
+            event_ids = event_ids.tolist()
         if not isinstance(event_names, list):
-            event_names = list(event_names)
+            event_names = event_names.tolist()
 
         if (dates, event_ids, event_names) != (None, None, None):
             sel_ev = self._selected_events_idx(event_ids, event_names, dates, nb_events)

--- a/climada/engine/impact.py
+++ b/climada/engine/impact.py
@@ -1021,22 +1021,11 @@ class Impact():
                            "method.")
             return None
 
-        if not isinstance(dates, list):
-            dates = dates.tolist()
-        if not isinstance(event_ids, list):
-            event_ids = event_ids.tolist()
-        if not isinstance(event_names, list):
-            event_names = event_names.tolist()
-
-        if (dates, event_ids, event_names) != (None, None, None):
-            sel_ev = self._selected_events_idx(event_ids, event_names, dates, nb_events)
-        else:
-            sel_ev = None
-
         imp = copy.deepcopy(self)
 
         # apply event selection to impact attributes
-        if sel_ev:
+        sel_ev = self._selected_events_idx(event_ids, event_names, dates, nb_events)
+        if sel_ev is not None:
             # set all attributes that are 'per event', i.e. have a dimension
             # of length equal to the number of events (=nb_events)
             for attr in get_attributes_with_matching_dimension(imp, [nb_events]):
@@ -1088,6 +1077,9 @@ class Impact():
         return sel_exp
 
     def _selected_events_idx(self, event_ids, event_names, dates, nb_events):
+        if all(var is None for var in [dates, event_ids, event_names]):
+            return None
+
         # filter events by date
         if dates is None:
             mask_dt = np.zeros(nb_events, dtype=bool)
@@ -1102,35 +1094,30 @@ class Impact():
             if not np.any(mask_dt):
                 LOGGER.info('No impact event in given date range %s.', dates)
 
-        sel_dt = list(np.argwhere(mask_dt).reshape(-1)) # Convert bool to indices
+        sel_dt = mask_dt.nonzero()[0]  # Convert bool to indices
 
         # filter events by id
         if event_ids is None:
-            sel_id = []
+            sel_id = np.array([], dtype=int)
         else:
-            sel_id = [list(self.event_id).index(_id) for _id in event_ids]
-            if not sel_id:
-                LOGGER.info('No impact event with given ids %s found.',
-                            event_ids)
+            sel_id = np.isin(self.event_id, event_ids).nonzero()[0]
+            if sel_id.size == 0:
+                LOGGER.info('No impact event with given ids %s found.', event_ids)
 
         # filter events by name
         if event_names is None:
-            sel_na = []
+            sel_na = np.array([], dtype=int)
         else:
-            sel_na = [list(self.event_name).index(name) for name in event_names]
-            if not sel_na:
-                LOGGER.info('No impact event with given names %s found.',
-                            event_names)
+            sel_na = np.isin(self.event_name, event_names).nonzero()[0]
+            if sel_na.size == 0:
+                LOGGER.info('No impact event with given names %s found.', event_names)
 
+        # select events with machting id, name or date field.
+        sel_ev = np.unique(np.concatenate([sel_dt, sel_id, sel_na]))
 
-        #select events with machting id, name or date field.
-        sel_ev = [idx for idx in set(sel_dt + sel_id + sel_na)]
-
-        #if no event found matching ids, names or dates, return None
-        if (dates, event_ids, event_names) != (None, None, None)\
-            and not sel_ev:
+        # if no event found matching ids, names or dates, warn the user
+        if sel_ev.size == 0:
             LOGGER.warning("No event matches the selection. ")
-            return None
 
         return sel_ev
 

--- a/climada/engine/test/test_impact.py
+++ b/climada/engine/test/test_impact.py
@@ -754,10 +754,24 @@ class TestSelect(unittest.TestCase):
         self.assertTrue(np.array_equal(sel_imp.coord_exp,
                                        np.array([[1, 2], [1.5, 2.5]])))
 
-
         self.assertIsInstance(sel_imp, Impact)
         self.assertIsInstance(sel_imp.imp_mat, sparse.csr_matrix)
 
+    def test_select_nothing(self):
+        """Test select with no matches"""
+        imp = dummy_impact()
+        sel_imp = imp.select(event_ids=[100])
+        self.assertIsInstance(sel_imp, Impact)
+        self.assertIsInstance(sel_imp.imp_mat, sparse.csr_matrix)
+        self.assertEqual(sel_imp.crs, imp.crs)
+        self.assertEqual(sel_imp.unit, imp.unit)
+        self.assertEqual(sel_imp.event_id.size, 0)
+        self.assertEqual(len(sel_imp.event_name), 0)
+        self.assertEqual(sel_imp.date.size, 0)
+        self.assertEqual(sel_imp.frequency.size, 0)
+        self.assertEqual(sel_imp.at_event.size, 0)
+        self.assertEqual(sel_imp.imp_mat.shape[0], 0)
+        self.assertEqual(sel_imp.aai_agg, 0)
 
     def test_select_id_name_dates_pass(self):
         """Test select by event ids, names, and dates"""


### PR DESCRIPTION
`Impact.select()` takes lists as input for its dates, event_ids and event_names parameters. If you instead pass a numpy array, the method fails at line 1031:
```
   if (dates, event_ids, event_names) != (None, None, None):
```
with a ValueError:
```
ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()
```

It's not obvious to the user why this is. So I've added lines at the start of this method to coerce the input to a list. This will allow a bit more flexibility with inputs and when it fails it will be more obvious why.

Questions:
- Do we want to be even more explicit with type checking (e.g. make this a try/except)?
- Could there be any unexpected consequences using `tolist()`here?