### PR TITLE
Bug fix: impacts tutorial (TC synthetic tracks)

### DIFF
--- a/climada/hazard/tc_tracks_synth.py
+++ b/climada/hazard/tc_tracks_synth.py
@@ -110,7 +110,7 @@ def calc_perturbed_trajectories(tracks,
         np.random.seed(seed)
 
     # ensure tracks have constant time steps
-    time_step_h = np.unique([np.unique(x['time_step']) for x in tracks.data])
+    time_step_h = np.unique(np.concatenate([np.unique(x['time_step']) for x in tracks.data]))
     if not np.allclose(time_step_h, time_step_h[0]):
         LOGGER.error('Tracks have different temporal resolution. '
                      'Please ensure constant time steps by applying equal_timestep beforehand')


### PR DESCRIPTION
This PR fixes issue #199.

However, note that the notebook `climada_engine_Impact.ipynb` should also be edited as follows in cell 4, since

1. `calc_random_walk` has been replaced with `calc_perturbed_trajectories`.
2. This method requires equal timesteps, hence `equal_timestep` must be called before and not after generating synthetic tracks.

```
from climada.hazard import TCTracks, TropCyclone, Centroids

# Load histrocial tropical cyclone tracks from ibtracs over the North Atlantic basin between 2010-2012
ibtracks_na = TCTracks()
ibtracks_na.read_ibtracs_netcdf(provider='usa', basin='NA', year_range=(2010, 2012), correct_pres=True)
print('num tracks hist:', ibtracks_na.size)

ibtracks_na.equal_timestep(0.5)  # Interpolation to make the track smooth and to allow applying calc_perturbed_trajectories
# Add randomly generated tracks using the calc_perturbed_trajectories method (1 per historical track)
ibtracks_na.calc_perturbed_trajectories(nb_synth_tracks=1)
print('num tracks hist+syn:', ibtracks_na.size)
```

I did not edit this because I'm not sure how to edit the notebook properly, so I leave that up to @emanuel-schmid to do so (feel free to do so within this PR).

@emanuel-schmid Please also note that I've run a string search for `calc_random_walk` on the climada code and found a usage in `./climada/test/test_tc.py`. However the whole function in which the call for `calc_random_walk` occurs is commented out. Is this file event needed and/or used anywhere? It might be worth checking.