### PR TITLE
Feature/update tc clim

### DIFF
--- a/climada/hazard/tc_clim_change.py
+++ b/climada/hazard/tc_clim_change.py
@@ -126,7 +126,7 @@ def get_knutson_criterion():
          'year': 2100, 'change': 1.033, 'variable': 'intensity'}
         ]
 
-    return na + ep + wp +sp + ni + si
+    return na + ep + wp + sp + ni + si
 
 def calc_scale_knutson(ref_year=2050, rcp_scenario=45):
     """

--- a/climada/hazard/tc_clim_change.py
+++ b/climada/hazard/tc_clim_change.py
@@ -39,10 +39,10 @@ def get_knutson_criterion():
     """
     criterion = list()
     # NA
-    tmp_chg = {'basin': 'NA', 'category': [0, 1, 3, 4, 5],
+    tmp_chg = {'basin': 'NA', 'category': [0, 1, 2, 3, 4, 5],
                'year': 2100, 'change': 1, 'variable': 'frequency', 'function': np.multiply}
     criterion.append(tmp_chg)
-    tmp_chg = {'basin': 'NA', 'category': [1, 3, 4, 5],
+    tmp_chg = {'basin': 'NA', 'category': [1, 2, 3, 4, 5],
                'year': 2100, 'change': 1, 'variable': 'frequency', 'function': np.multiply}
     criterion.append(tmp_chg)
     tmp_chg = {'basin': 'NA', 'category': [3, 4, 5],
@@ -51,13 +51,13 @@ def get_knutson_criterion():
     tmp_chg = {'basin': 'NA', 'category': [4, 5],
                'year': 2100, 'change': 1, 'variable': 'frequency', 'function': np.multiply}
     criterion.append(tmp_chg)
-    
+
     tmp_chg = {'basin': 'NA', 'category': [1, 2, 3, 4, 5],
                'year': 2100, 'change': 1.045, 'variable': 'intensity', 'function': np.multiply}
     criterion.append(tmp_chg)
 
     # EP
-    tmp_chg = {'basin': 'EP', 'category': [0, 1, 3, 4, 5],
+    tmp_chg = {'basin': 'EP', 'category': [0, 1, 2, 3, 4, 5],
                'year': 2100, 'change': 1.163, 'variable': 'frequency', 'function': np.multiply}
     criterion.append(tmp_chg)
     tmp_chg = {'basin': 'EP', 'category': [1, 2, 3, 4, 5],

--- a/climada/hazard/tc_clim_change.py
+++ b/climada/hazard/tc_clim_change.py
@@ -29,119 +29,124 @@ TOT_RADIATIVE_FORCE = SYSTEM_DIR.joinpath('rcp_db.xls')
 generated: 2018-07-04 10:47:59."""
 
 def get_knutson_criterion():
-    """Fill changes in TCs according to Knutson et al. 2015 Global projections
+    """
+    Fill changes in TCs according to Knutson et al. 2015 Global projections
     of intense tropical cyclone activity for the late twenty-first century from
     dynamical downscaling of CMIP5/RCP4.5 scenarios.
 
-    Returns:
-        list(dict) with items 'criteria' (dict with variable_name and list(possible values)),
-        'year' (int), 'change' (float), 'variable' (str), 'function' (np function)
+    Returns
+    -------
+    criterion : list(dict)
+        list of the criterion dictionary for frequency and intensity change
+        per basin, per category taken from the Table 3 in Knutson et al. 2015.
+        with items 'basin' (str), 'category' (list(int)), 'year' (int),
+        'change' (float), 'variable' ('intensity' or 'frequency')
     """
     criterion = list()
     # NA
     tmp_chg = {'basin': 'NA', 'category': [0, 1, 2, 3, 4, 5],
-               'year': 2100, 'change': 1, 'variable': 'frequency', 'function': np.multiply}
+               'year': 2100, 'change': 1, 'variable': 'frequency'}
     criterion.append(tmp_chg)
     tmp_chg = {'basin': 'NA', 'category': [1, 2, 3, 4, 5],
-               'year': 2100, 'change': 1, 'variable': 'frequency', 'function': np.multiply}
+               'year': 2100, 'change': 1, 'variable': 'frequency'}
     criterion.append(tmp_chg)
     tmp_chg = {'basin': 'NA', 'category': [3, 4, 5],
-               'year': 2100, 'change': 1, 'variable': 'frequency', 'function': np.multiply}
+               'year': 2100, 'change': 1, 'variable': 'frequency'}
     criterion.append(tmp_chg)
     tmp_chg = {'basin': 'NA', 'category': [4, 5],
-               'year': 2100, 'change': 1, 'variable': 'frequency', 'function': np.multiply}
+               'year': 2100, 'change': 1, 'variable': 'frequency'}
     criterion.append(tmp_chg)
 
     tmp_chg = {'basin': 'NA', 'category': [1, 2, 3, 4, 5],
-               'year': 2100, 'change': 1.045, 'variable': 'intensity', 'function': np.multiply}
+               'year': 2100, 'change': 1.045, 'variable': 'intensity'}
     criterion.append(tmp_chg)
 
     # EP
     tmp_chg = {'basin': 'EP', 'category': [0, 1, 2, 3, 4, 5],
-               'year': 2100, 'change': 1.163, 'variable': 'frequency', 'function': np.multiply}
+               'year': 2100, 'change': 1.163, 'variable': 'frequency'}
     criterion.append(tmp_chg)
     tmp_chg = {'basin': 'EP', 'category': [1, 2, 3, 4, 5],
-               'year': 2100, 'change': 1.193, 'variable': 'frequency', 'function': np.multiply}
+               'year': 2100, 'change': 1.193, 'variable': 'frequency'}
     criterion.append(tmp_chg)
     tmp_chg = {'basin': 'EP', 'category': [3, 4, 5],
-               'year': 2100, 'change': 1.837, 'variable': 'frequency', 'function': np.multiply}
+               'year': 2100, 'change': 1.837, 'variable': 'frequency'}
     criterion.append(tmp_chg)
     tmp_chg = {'basin': 'EP', 'category': [4, 5],
-               'year': 2100, 'change': 3.375, 'variable': 'frequency', 'function': np.multiply}
+               'year': 2100, 'change': 3.375, 'variable': 'frequency'}
     criterion.append(tmp_chg)
 
     tmp_chg = {'basin': 'EP', 'category': [0],
-               'year': 2100, 'change': 1.082, 'variable': 'intensity', 'function': np.multiply}
+               'year': 2100, 'change': 1.082, 'variable': 'intensity'}
     criterion.append(tmp_chg)
     tmp_chg = {'basin': 'EP', 'category': [1, 2, 3, 4, 5],
-               'year': 2100, 'change': 1.078, 'variable': 'intensity', 'function': np.multiply}
+               'year': 2100, 'change': 1.078, 'variable': 'intensity'}
     criterion.append(tmp_chg)
 
     # WP
     tmp_chg = {'basin': 'WP', 'category': [0, 1, 2, 3, 4, 5],
-               'year': 2100, 'change': 1 - 0.345, 'variable': 'frequency', 'function': np.multiply}
+               'year': 2100, 'change': 1 - 0.345, 'variable': 'frequency'}
     criterion.append(tmp_chg)
     tmp_chg = {'basin': 'WP', 'category': [1, 2, 3, 4, 5],
-               'year': 2100, 'change': 1 - 0.316, 'variable': 'frequency', 'function': np.multiply}
+               'year': 2100, 'change': 1 - 0.316, 'variable': 'frequency'}
     criterion.append(tmp_chg)
     tmp_chg = {'basin': 'WP', 'category': [3, 4, 5],
-               'year': 2100, 'change': 1 - 0.169, 'variable': 'frequency', 'function': np.multiply}
+               'year': 2100, 'change': 1 - 0.169, 'variable': 'frequency'}
     criterion.append(tmp_chg)
     tmp_chg = {'basin': 'WP', 'category': [4, 5],
-               'year': 2100, 'change': 1, 'variable': 'frequency', 'function': np.multiply}
+               'year': 2100, 'change': 1, 'variable': 'frequency'}
     criterion.append(tmp_chg)
 
     tmp_chg = {'basin': 'WP', 'category': [0],
-               'year': 2100, 'change': 1.074, 'variable': 'intensity', 'function': np.multiply}
+               'year': 2100, 'change': 1.074, 'variable': 'intensity'}
     criterion.append(tmp_chg)
     tmp_chg = {'basin': 'WP', 'category': [1, 2, 3, 4, 5],
-               'year': 2100, 'change': 1.055, 'variable': 'intensity', 'function': np.multiply}
+               'year': 2100, 'change': 1.055, 'variable': 'intensity'}
     criterion.append(tmp_chg)
 
     # NI
     tmp_chg = {'basin': 'NI', 'category': [0, 1, 2, 3, 4, 5],
-               'year': 2100, 'change': 1, 'variable': 'frequency', 'function': np.multiply}
+               'year': 2100, 'change': 1, 'variable': 'frequency'}
     criterion.append(tmp_chg)
     tmp_chg = {'basin': 'NI', 'category': [1, 2, 3, 4, 5],
-               'year': 2100, 'change': 1.256, 'variable': 'frequency', 'function': np.multiply}
+               'year': 2100, 'change': 1.256, 'variable': 'frequency'}
     criterion.append(tmp_chg)
     tmp_chg = {'basin': 'NI', 'category': [3, 4, 5],
-               'year': 2100, 'change': 1, 'variable': 'frequency', 'function': np.multiply}
+               'year': 2100, 'change': 1, 'variable': 'frequency'}
     criterion.append(tmp_chg)
     tmp_chg = {'basin': 'NI', 'category': [4, 5],
-               'year': 2100, 'change': 1, 'variable': 'frequency', 'function': np.multiply}
+               'year': 2100, 'change': 1, 'variable': 'frequency'}
     criterion.append(tmp_chg)
 
     # SI
     tmp_chg = {'basin': 'SI', 'category': [0, 1, 2, 3, 4, 5],
-               'year': 2100, 'change': 1 - 0.261, 'variable': 'frequency', 'function': np.multiply}
+               'year': 2100, 'change': 1 - 0.261, 'variable': 'frequency'}
     criterion.append(tmp_chg)
     tmp_chg = {'basin': 'SI', 'category': [1, 2, 3, 4, 5],
-               'year': 2100, 'change': 1 - 0.284, 'variable': 'frequency', 'function': np.multiply}
+               'year': 2100, 'change': 1 - 0.284, 'variable': 'frequency'}
     criterion.append(tmp_chg)
     tmp_chg = {'basin': 'SI', 'category': [3, 4, 5],
-               'year': 2100, 'change': 1, 'variable': 'frequency', 'function': np.multiply}
+               'year': 2100, 'change': 1, 'variable': 'frequency'}
     criterion.append(tmp_chg)
     tmp_chg = {'basin': 'SI', 'category': [4, 5],
-               'year': 2100, 'change': 1, 'variable': 'frequency', 'function': np.multiply}
+               'year': 2100, 'change': 1, 'variable': 'frequency'}
     criterion.append(tmp_chg)
 
     tmp_chg = {'basin': 'SI', 'category': [1, 2, 3, 4, 5],
-               'year': 2100, 'change': 1.033, 'variable': 'intensity', 'function': np.multiply}
+               'year': 2100, 'change': 1.033, 'variable': 'intensity'}
     criterion.append(tmp_chg)
 
     # SP
     tmp_chg = {'basin': 'SP', 'category': [0, 1, 2, 3, 4, 5],
-               'year': 2100, 'change': 1 - 0.366, 'variable': 'frequency', 'function': np.multiply}
+               'year': 2100, 'change': 1 - 0.366, 'variable': 'frequency'}
     criterion.append(tmp_chg)
     tmp_chg = {'basin': 'SP', 'category': [1, 2, 3, 4, 5],
-               'year': 2100, 'change': 1 - 0.406, 'variable': 'frequency', 'function': np.multiply}
+               'year': 2100, 'change': 1 - 0.406, 'variable': 'frequency'}
     criterion.append(tmp_chg)
     tmp_chg = {'basin': 'SP', 'category': [3, 4, 5],
-               'year': 2100, 'change': 1 - 0.506, 'variable': 'frequency', 'function': np.multiply}
+               'year': 2100, 'change': 1 - 0.506, 'variable': 'frequency'}
     criterion.append(tmp_chg)
     tmp_chg = {'basin': 'SP', 'category': [4, 5],
-               'year': 2100, 'change': 1 - 0.583, 'variable': 'frequency', 'function': np.multiply}
+               'year': 2100, 'change': 1 - 0.583, 'variable': 'frequency'}
     criterion.append(tmp_chg)
 
     return criterion
@@ -150,17 +155,23 @@ def calc_scale_knutson(ref_year=2050, rcp_scenario=45):
     """Comparison 2081-2100 (i.e., late twenty-first century) and 2001-20
     (i.e., present day). Late twenty-first century effects on intensity and
     frequency per Saffir-Simpson-category and ocean basin is scaled to target
-    year and target RCP proportional to total radiative forcing of the respective
-    RCP and year.
+    year and target RCP proportional to total radiative forcing of the
+    respective RCP and year.
 
-    Parameters:
-        ref_year (int): year between 2000 ad 2100. Default: 2050
-        rcp_scenario (int):  26 for RCP 2.6, 45 for RCP 4.5 (default),
-            60 for RCP 6.0 and 85 for RCP 8.5.
+    Parameters
+    ----------
+    ref_year : int, optional
+        year between 2000 ad 2100. Default: 2050
+    rcp_scenario: int, optional
+        26 for RCP 2.6, 45 for RCP 4.5. The default is 45
+        60 for RCP 6.0 and 85 for RCP 8.5.
 
-    Returns:
-        float
+    Returns
+    -------
+        : float
+        factor to scale Knuston parameters to the give RCP and year
     """
+
     # Parameters used in Knutson et al 2015
     base_knu = np.arange(2001, 2021)
     end_knu = np.arange(2081, 2101)

--- a/climada/hazard/tc_clim_change.py
+++ b/climada/hazard/tc_clim_change.py
@@ -39,77 +39,108 @@ def get_knutson_criterion():
     """
     criterion = list()
     # NA
-    tmp_chg = {'criteria': {'basin': ['NA'], 'category': [1, 2, 3, 4, 5]},
+    tmp_chg = {'basin': 'NA', 'category': [0, 1, 3, 4, 5],
+               'year': 2100, 'change': 1, 'variable': 'frequency', 'function': np.multiply}
+    criterion.append(tmp_chg)
+    tmp_chg = {'basin': 'NA', 'category': [1, 3, 4, 5],
+               'year': 2100, 'change': 1, 'variable': 'frequency', 'function': np.multiply}
+    criterion.append(tmp_chg)
+    tmp_chg = {'basin': 'NA', 'category': [3, 4, 5],
+               'year': 2100, 'change': 1, 'variable': 'frequency', 'function': np.multiply}
+    criterion.append(tmp_chg)
+    tmp_chg = {'basin': 'NA', 'category': [4, 5],
+               'year': 2100, 'change': 1, 'variable': 'frequency', 'function': np.multiply}
+    criterion.append(tmp_chg)
+    
+    tmp_chg = {'basin': 'NA', 'category': [1, 2, 3, 4, 5],
                'year': 2100, 'change': 1.045, 'variable': 'intensity', 'function': np.multiply}
     criterion.append(tmp_chg)
 
     # EP
-    tmp_chg = {'criteria': {'basin': ['EP'], 'category': [0]},
+    tmp_chg = {'basin': 'EP', 'category': [0, 1, 3, 4, 5],
                'year': 2100, 'change': 1.163, 'variable': 'frequency', 'function': np.multiply}
     criterion.append(tmp_chg)
-    tmp_chg = {'criteria': {'basin': ['EP'], 'category': [1, 2]},
+    tmp_chg = {'basin': 'EP', 'category': [1, 2, 3, 4, 5],
                'year': 2100, 'change': 1.193, 'variable': 'frequency', 'function': np.multiply}
     criterion.append(tmp_chg)
-    tmp_chg = {'criteria': {'basin': ['EP'], 'category': [3]},
+    tmp_chg = {'basin': 'EP', 'category': [3, 4, 5],
                'year': 2100, 'change': 1.837, 'variable': 'frequency', 'function': np.multiply}
     criterion.append(tmp_chg)
-    tmp_chg = {'criteria': {'basin': ['EP'], 'category': [4, 5]},
+    tmp_chg = {'basin': 'EP', 'category': [4, 5],
                'year': 2100, 'change': 3.375, 'variable': 'frequency', 'function': np.multiply}
     criterion.append(tmp_chg)
 
-    tmp_chg = {'criteria': {'basin': ['EP'], 'category': [0]},
+    tmp_chg = {'basin': 'EP', 'category': [0],
                'year': 2100, 'change': 1.082, 'variable': 'intensity', 'function': np.multiply}
     criterion.append(tmp_chg)
-    tmp_chg = {'criteria': {'basin': ['EP'], 'category': [1, 2, 3, 4, 5]},
+    tmp_chg = {'basin': 'EP', 'category': [1, 2, 3, 4, 5],
                'year': 2100, 'change': 1.078, 'variable': 'intensity', 'function': np.multiply}
     criterion.append(tmp_chg)
 
     # WP
-    tmp_chg = {'criteria': {'basin': ['WP'], 'category': [0]},
+    tmp_chg = {'basin': 'WP', 'category': [0, 1, 2, 3, 4, 5],
                'year': 2100, 'change': 1 - 0.345, 'variable': 'frequency', 'function': np.multiply}
     criterion.append(tmp_chg)
-    tmp_chg = {'criteria': {'basin': ['WP'], 'category': [1, 2]},
+    tmp_chg = {'basin': 'WP', 'category': [1, 2, 3, 4, 5],
                'year': 2100, 'change': 1 - 0.316, 'variable': 'frequency', 'function': np.multiply}
     criterion.append(tmp_chg)
-    tmp_chg = {'criteria': {'basin': ['WP'], 'category': [3, 4, 5]},
+    tmp_chg = {'basin': 'WP', 'category': [3, 4, 5],
                'year': 2100, 'change': 1 - 0.169, 'variable': 'frequency', 'function': np.multiply}
     criterion.append(tmp_chg)
+    tmp_chg = {'basin': 'WP', 'category': [4, 5],
+               'year': 2100, 'change': 1, 'variable': 'frequency', 'function': np.multiply}
+    criterion.append(tmp_chg)
 
-    tmp_chg = {'criteria': {'basin': ['WP'], 'category': [0]},
+    tmp_chg = {'basin': 'WP', 'category': [0],
                'year': 2100, 'change': 1.074, 'variable': 'intensity', 'function': np.multiply}
     criterion.append(tmp_chg)
-    tmp_chg = {'criteria': {'basin': ['WP'], 'category': [1, 2, 3, 4, 5]},
+    tmp_chg = {'basin': 'WP', 'category': [1, 2, 3, 4, 5],
                'year': 2100, 'change': 1.055, 'variable': 'intensity', 'function': np.multiply}
     criterion.append(tmp_chg)
 
     # NI
-    tmp_chg = {'criteria': {'basin': ['NI'], 'category': [1, 2, 3, 4, 5]},
+    tmp_chg = {'basin': 'NI', 'category': [0, 1, 2, 3, 4, 5],
+               'year': 2100, 'change': 1, 'variable': 'frequency', 'function': np.multiply}
+    criterion.append(tmp_chg)
+    tmp_chg = {'basin': 'NI', 'category': [1, 2, 3, 4, 5],
                'year': 2100, 'change': 1.256, 'variable': 'frequency', 'function': np.multiply}
+    criterion.append(tmp_chg)
+    tmp_chg = {'basin': 'NI', 'category': [3, 4, 5],
+               'year': 2100, 'change': 1, 'variable': 'frequency', 'function': np.multiply}
+    criterion.append(tmp_chg)
+    tmp_chg = {'basin': 'NI', 'category': [4, 5],
+               'year': 2100, 'change': 1, 'variable': 'frequency', 'function': np.multiply}
     criterion.append(tmp_chg)
 
     # SI
-    tmp_chg = {'criteria': {'basin': ['SI'], 'category': [0]},
+    tmp_chg = {'basin': 'SI', 'category': [0, 1, 2, 3, 4, 5],
                'year': 2100, 'change': 1 - 0.261, 'variable': 'frequency', 'function': np.multiply}
     criterion.append(tmp_chg)
-    tmp_chg = {'criteria': {'basin': ['SI'], 'category': [1, 2, 3, 4, 5]},
+    tmp_chg = {'basin': 'SI', 'category': [1, 2, 3, 4, 5],
                'year': 2100, 'change': 1 - 0.284, 'variable': 'frequency', 'function': np.multiply}
     criterion.append(tmp_chg)
+    tmp_chg = {'basin': 'SI', 'category': [3, 4, 5],
+               'year': 2100, 'change': 1, 'variable': 'frequency', 'function': np.multiply}
+    criterion.append(tmp_chg)
+    tmp_chg = {'basin': 'SI', 'category': [4, 5],
+               'year': 2100, 'change': 1, 'variable': 'frequency', 'function': np.multiply}
+    criterion.append(tmp_chg)
 
-    tmp_chg = {'criteria': {'basin': ['SI'], 'category': [1, 2, 3, 4, 5]},
+    tmp_chg = {'basin': 'SI', 'category': [1, 2, 3, 4, 5],
                'year': 2100, 'change': 1.033, 'variable': 'intensity', 'function': np.multiply}
     criterion.append(tmp_chg)
 
     # SP
-    tmp_chg = {'criteria': {'basin': ['SP'], 'category': [0]},
+    tmp_chg = {'basin': 'SP', 'category': [0, 1, 2, 3, 4, 5],
                'year': 2100, 'change': 1 - 0.366, 'variable': 'frequency', 'function': np.multiply}
     criterion.append(tmp_chg)
-    tmp_chg = {'criteria': {'basin': ['SP'], 'category': [1, 2]},
+    tmp_chg = {'basin': 'SP', 'category': [1, 2, 3, 4, 5],
                'year': 2100, 'change': 1 - 0.406, 'variable': 'frequency', 'function': np.multiply}
     criterion.append(tmp_chg)
-    tmp_chg = {'criteria': {'basin': ['SP'], 'category': [3]},
+    tmp_chg = {'basin': 'SP', 'category': [3, 4, 5],
                'year': 2100, 'change': 1 - 0.506, 'variable': 'frequency', 'function': np.multiply}
     criterion.append(tmp_chg)
-    tmp_chg = {'criteria': {'basin': ['SP'], 'category': [4, 5]},
+    tmp_chg = {'basin': 'SP', 'category': [4, 5],
                'year': 2100, 'change': 1 - 0.583, 'variable': 'frequency', 'function': np.multiply}
     criterion.append(tmp_chg)
 

--- a/climada/hazard/tc_clim_change.py
+++ b/climada/hazard/tc_clim_change.py
@@ -42,117 +42,95 @@ def get_knutson_criterion():
         with items 'basin' (str), 'category' (list(int)), 'year' (int),
         'change' (float), 'variable' ('intensity' or 'frequency')
     """
-    criterion = list()
     # NA
-    tmp_chg = {'basin': 'NA', 'category': [0, 1, 2, 3, 4, 5],
-               'year': 2100, 'change': 1, 'variable': 'frequency'}
-    criterion.append(tmp_chg)
-    tmp_chg = {'basin': 'NA', 'category': [1, 2, 3, 4, 5],
-               'year': 2100, 'change': 1, 'variable': 'frequency'}
-    criterion.append(tmp_chg)
-    tmp_chg = {'basin': 'NA', 'category': [3, 4, 5],
-               'year': 2100, 'change': 1, 'variable': 'frequency'}
-    criterion.append(tmp_chg)
-    tmp_chg = {'basin': 'NA', 'category': [4, 5],
-               'year': 2100, 'change': 1, 'variable': 'frequency'}
-    criterion.append(tmp_chg)
-
-    tmp_chg = {'basin': 'NA', 'category': [1, 2, 3, 4, 5],
-               'year': 2100, 'change': 1.045, 'variable': 'intensity'}
-    criterion.append(tmp_chg)
+    na = [
+        {'basin': 'NA', 'category': [0, 1, 2, 3, 4, 5],
+         'year': 2100, 'change': 1, 'variable': 'frequency'},
+        {'basin': 'NA', 'category': [1, 2, 3, 4, 5],
+         'year': 2100, 'change': 1, 'variable': 'frequency'},
+        {'basin': 'NA', 'category': [3, 4, 5],
+         'year': 2100, 'change': 1, 'variable': 'frequency'},
+        {'basin': 'NA', 'category': [4, 5],
+         'year': 2100, 'change': 1, 'variable': 'frequency'},
+        {'basin': 'NA', 'category': [1, 2, 3, 4, 5],
+         'year': 2100, 'change': 1.045, 'variable': 'intensity'}
+        ]
 
     # EP
-    tmp_chg = {'basin': 'EP', 'category': [0, 1, 2, 3, 4, 5],
-               'year': 2100, 'change': 1.163, 'variable': 'frequency'}
-    criterion.append(tmp_chg)
-    tmp_chg = {'basin': 'EP', 'category': [1, 2, 3, 4, 5],
-               'year': 2100, 'change': 1.193, 'variable': 'frequency'}
-    criterion.append(tmp_chg)
-    tmp_chg = {'basin': 'EP', 'category': [3, 4, 5],
-               'year': 2100, 'change': 1.837, 'variable': 'frequency'}
-    criterion.append(tmp_chg)
-    tmp_chg = {'basin': 'EP', 'category': [4, 5],
-               'year': 2100, 'change': 3.375, 'variable': 'frequency'}
-    criterion.append(tmp_chg)
-
-    tmp_chg = {'basin': 'EP', 'category': [0],
-               'year': 2100, 'change': 1.082, 'variable': 'intensity'}
-    criterion.append(tmp_chg)
-    tmp_chg = {'basin': 'EP', 'category': [1, 2, 3, 4, 5],
-               'year': 2100, 'change': 1.078, 'variable': 'intensity'}
-    criterion.append(tmp_chg)
+    ep = [
+        {'basin': 'EP', 'category': [0, 1, 2, 3, 4, 5],
+         'year': 2100, 'change': 1.163, 'variable': 'frequency'},
+        {'basin': 'EP', 'category': [1, 2, 3, 4, 5],
+         'year': 2100, 'change': 1.193, 'variable': 'frequency'},
+        {'basin': 'EP', 'category': [3, 4, 5],
+         'year': 2100, 'change': 1.837, 'variable': 'frequency'},
+        {'basin': 'EP', 'category': [4, 5],
+         'year': 2100, 'change': 3.375, 'variable': 'frequency'},
+        {'basin': 'EP', 'category': [0],
+         'year': 2100, 'change': 1.082, 'variable': 'intensity'},
+        {'basin': 'EP', 'category': [1, 2, 3, 4, 5],
+         'year': 2100, 'change': 1.078, 'variable': 'intensity'}
+        ]
 
     # WP
-    tmp_chg = {'basin': 'WP', 'category': [0, 1, 2, 3, 4, 5],
-               'year': 2100, 'change': 1 - 0.345, 'variable': 'frequency'}
-    criterion.append(tmp_chg)
-    tmp_chg = {'basin': 'WP', 'category': [1, 2, 3, 4, 5],
-               'year': 2100, 'change': 1 - 0.316, 'variable': 'frequency'}
-    criterion.append(tmp_chg)
-    tmp_chg = {'basin': 'WP', 'category': [3, 4, 5],
-               'year': 2100, 'change': 1 - 0.169, 'variable': 'frequency'}
-    criterion.append(tmp_chg)
-    tmp_chg = {'basin': 'WP', 'category': [4, 5],
-               'year': 2100, 'change': 1, 'variable': 'frequency'}
-    criterion.append(tmp_chg)
-
-    tmp_chg = {'basin': 'WP', 'category': [0],
-               'year': 2100, 'change': 1.074, 'variable': 'intensity'}
-    criterion.append(tmp_chg)
-    tmp_chg = {'basin': 'WP', 'category': [1, 2, 3, 4, 5],
-               'year': 2100, 'change': 1.055, 'variable': 'intensity'}
-    criterion.append(tmp_chg)
-
-    # NI
-    tmp_chg = {'basin': 'NI', 'category': [0, 1, 2, 3, 4, 5],
-               'year': 2100, 'change': 1, 'variable': 'frequency'}
-    criterion.append(tmp_chg)
-    tmp_chg = {'basin': 'NI', 'category': [1, 2, 3, 4, 5],
-               'year': 2100, 'change': 1.256, 'variable': 'frequency'}
-    criterion.append(tmp_chg)
-    tmp_chg = {'basin': 'NI', 'category': [3, 4, 5],
-               'year': 2100, 'change': 1, 'variable': 'frequency'}
-    criterion.append(tmp_chg)
-    tmp_chg = {'basin': 'NI', 'category': [4, 5],
-               'year': 2100, 'change': 1, 'variable': 'frequency'}
-    criterion.append(tmp_chg)
-
-    # SI
-    tmp_chg = {'basin': 'SI', 'category': [0, 1, 2, 3, 4, 5],
-               'year': 2100, 'change': 1 - 0.261, 'variable': 'frequency'}
-    criterion.append(tmp_chg)
-    tmp_chg = {'basin': 'SI', 'category': [1, 2, 3, 4, 5],
-               'year': 2100, 'change': 1 - 0.284, 'variable': 'frequency'}
-    criterion.append(tmp_chg)
-    tmp_chg = {'basin': 'SI', 'category': [3, 4, 5],
-               'year': 2100, 'change': 1, 'variable': 'frequency'}
-    criterion.append(tmp_chg)
-    tmp_chg = {'basin': 'SI', 'category': [4, 5],
-               'year': 2100, 'change': 1, 'variable': 'frequency'}
-    criterion.append(tmp_chg)
-
-    tmp_chg = {'basin': 'SI', 'category': [1, 2, 3, 4, 5],
-               'year': 2100, 'change': 1.033, 'variable': 'intensity'}
-    criterion.append(tmp_chg)
+    wp = [
+        {'basin': 'WP', 'category': [0, 1, 2, 3, 4, 5],
+         'year': 2100, 'change': 1 - 0.345, 'variable': 'frequency'},
+        {'basin': 'WP', 'category': [1, 2, 3, 4, 5],
+         'year': 2100, 'change': 1 - 0.316, 'variable': 'frequency'},
+        {'basin': 'WP', 'category': [3, 4, 5],
+         'year': 2100, 'change': 1 - 0.169, 'variable': 'frequency'},
+        {'basin': 'WP', 'category': [4, 5],
+         'year': 2100, 'change': 1, 'variable': 'frequency'},
+        {'basin': 'WP', 'category': [0],
+         'year': 2100, 'change': 1.074, 'variable': 'intensity'},
+        {'basin': 'WP', 'category': [1, 2, 3, 4, 5],
+         'year': 2100, 'change': 1.055, 'variable': 'intensity'},
+        ]
 
     # SP
-    tmp_chg = {'basin': 'SP', 'category': [0, 1, 2, 3, 4, 5],
-               'year': 2100, 'change': 1 - 0.366, 'variable': 'frequency'}
-    criterion.append(tmp_chg)
-    tmp_chg = {'basin': 'SP', 'category': [1, 2, 3, 4, 5],
-               'year': 2100, 'change': 1 - 0.406, 'variable': 'frequency'}
-    criterion.append(tmp_chg)
-    tmp_chg = {'basin': 'SP', 'category': [3, 4, 5],
-               'year': 2100, 'change': 1 - 0.506, 'variable': 'frequency'}
-    criterion.append(tmp_chg)
-    tmp_chg = {'basin': 'SP', 'category': [4, 5],
-               'year': 2100, 'change': 1 - 0.583, 'variable': 'frequency'}
-    criterion.append(tmp_chg)
+    sp = [
+        {'basin': 'SP', 'category': [0, 1, 2, 3, 4, 5],
+         'year': 2100, 'change': 1 - 0.366, 'variable': 'frequency'},
+        {'basin': 'SP', 'category': [1, 2, 3, 4, 5],
+         'year': 2100, 'change': 1 - 0.406, 'variable': 'frequency'},
+        {'basin': 'SP', 'category': [3, 4, 5],
+         'year': 2100, 'change': 1 - 0.506, 'variable': 'frequency'},
+        {'basin': 'SP', 'category': [4, 5],
+         'year': 2100, 'change': 1 - 0.583, 'variable': 'frequency'}
+        ]
 
-    return criterion
+    # NI
+    ni = [
+        {'basin': 'NI', 'category': [0, 1, 2, 3, 4, 5],
+         'year': 2100, 'change': 1, 'variable': 'frequency'},
+        {'basin': 'NI', 'category': [1, 2, 3, 4, 5],
+         'year': 2100, 'change': 1.256, 'variable': 'frequency'},
+        {'basin': 'NI', 'category': [3, 4, 5],
+         'year': 2100, 'change': 1, 'variable': 'frequency'},
+        {'basin': 'NI', 'category': [4, 5],
+         'year': 2100, 'change': 1, 'variable': 'frequency'}
+        ]
+
+    # SI
+    si = [
+        {'basin': 'SI', 'category': [0, 1, 2, 3, 4, 5],
+         'year': 2100, 'change': 1 - 0.261, 'variable': 'frequency'},
+        {'basin': 'SI', 'category': [1, 2, 3, 4, 5],
+         'year': 2100, 'change': 1 - 0.284, 'variable': 'frequency'},
+        {'basin': 'SI', 'category': [3, 4, 5],
+         'year': 2100, 'change': 1, 'variable': 'frequency'},
+        {'basin': 'SI', 'category': [4, 5],
+         'year': 2100, 'change': 1, 'variable': 'frequency'},
+        {'basin': 'SI', 'category': [1, 2, 3, 4, 5],
+         'year': 2100, 'change': 1.033, 'variable': 'intensity'}
+        ]
+
+    return na + ep + wp +sp + ni + si
 
 def calc_scale_knutson(ref_year=2050, rcp_scenario=45):
-    """Comparison 2081-2100 (i.e., late twenty-first century) and 2001-20
+    """
+    Comparison 2081-2100 (i.e., late twenty-first century) and 2001-20
     (i.e., present day). Late twenty-first century effects on intensity and
     frequency per Saffir-Simpson-category and ocean basin is scaled to target
     year and target RCP proportional to total radiative forcing of the
@@ -168,10 +146,9 @@ def calc_scale_knutson(ref_year=2050, rcp_scenario=45):
 
     Returns
     -------
-        : float
-        factor to scale Knuston parameters to the give RCP and year
+    factor : float
+        factor to scale Knutson parameters to the give RCP and year
     """
-
     # Parameters used in Knutson et al 2015
     base_knu = np.arange(2001, 2021)
     end_knu = np.arange(2081, 2101)

--- a/climada/hazard/test/test_trop_cyclone.py
+++ b/climada/hazard/test/test_trop_cyclone.py
@@ -37,7 +37,7 @@ TEST_TRACK = DATA_DIR.joinpath("trac_brb_test.csv")
 TEST_TRACK_SHORT = DATA_DIR.joinpath("trac_short_test.csv")
 
 CENTR_TEST_BRB = Centroids()
-#CENTR_TEST_BRB.read_mat(DATA_DIR.joinpath('centr_brb_test.mat'))
+CENTR_TEST_BRB.read_mat(DATA_DIR.joinpath('centr_brb_test.mat'))
 
 
 class TestReader(unittest.TestCase):
@@ -256,10 +256,9 @@ class TestClimateSce(unittest.TestCase):
 
     def test_apply_criterion_track(self):
         """Test _apply_criterion function."""
-        criterion = list()
-        tmp_chg = {'basin': 'NA', 'category': [1, 2, 3, 4, 5],
-                   'year': 2100, 'change': 1.045, 'variable': 'intensity', 'function': np.multiply}
-        criterion.append(tmp_chg)
+        criterion = [{'basin': 'NA', 'category': [1, 2, 3, 4, 5],
+                   'year': 2100, 'change': 1.045, 'variable': 'intensity'}
+                   ]
         scale = 0.75
 
         # artificially increase the size of the hazard by repeating (tiling) the data:
@@ -298,30 +297,22 @@ class TestClimateSce(unittest.TestCase):
 
     def test_two_criterion_track(self):
         """Test _apply_criterion function with two criteria"""
-        criterion = list()
-        tmp_chg = {'basin': 'NA', 'category': [1, 2, 3, 4, 5],
-                   'year': 2100, 'change': 1.045, 'variable': 'intensity', 'function': np.multiply}
-        criterion.append(tmp_chg)
-        tmp_chg = {'basin': 'WP', 'category': [1, 2, 3, 4, 5],
-                   'year': 2100, 'change': 1.025, 'variable': 'intensity', 'function': np.multiply}
-        criterion.append(tmp_chg)
-
-        tmp_chg = {'basin': 'WP', 'category': [1, 2, 3, 4, 5],
-                   'year': 2100, 'change': 1.025, 'variable': 'frequency', 'function': np.multiply}
-        criterion.append(tmp_chg)
-
-        tmp_chg = {'basin': 'NA', 'category': [0, 1, 2, 3, 4, 5],
-                    'year': 2100, 'change': 0.7, 'variable': 'frequency', 'function': np.multiply}
-        criterion.append(tmp_chg)
-        tmp_chg = {'basin': 'NA', 'category': [1, 2, 3, 4, 5],
-                    'year': 2100, 'change': 1, 'variable': 'frequency', 'function': np.multiply}
-        criterion.append(tmp_chg)
-        tmp_chg = {'basin': 'NA', 'category': [3, 4, 5],
-                    'year': 2100, 'change': 1, 'variable': 'frequency', 'function': np.multiply}
-        criterion.append(tmp_chg)
-        tmp_chg = {'basin': 'NA', 'category': [4, 5],
-                   'year': 2100, 'change': 2, 'variable': 'frequency', 'function': np.multiply}
-        criterion.append(tmp_chg)
+        criterion = [
+            {'basin': 'NA', 'category': [1, 2, 3, 4, 5],
+             'year': 2100, 'change': 1.045, 'variable': 'intensity'},
+            {'basin': 'WP', 'category': [1, 2, 3, 4, 5],
+             'year': 2100, 'change': 1.025, 'variable': 'intensity'},
+            {'basin': 'WP', 'category': [1, 2, 3, 4, 5],
+             'year': 2100, 'change': 1.025, 'variable': 'frequency'},
+            {'basin': 'NA', 'category': [0, 1, 2, 3, 4, 5],
+             'year': 2100, 'change': 0.7, 'variable': 'frequency'},
+            {'basin': 'NA', 'category': [1, 2, 3, 4, 5],
+             'year': 2100, 'change': 1, 'variable': 'frequency'},
+            {'basin': 'NA', 'category': [3, 4, 5],
+             'year': 2100, 'change': 1, 'variable': 'frequency'},
+            {'basin': 'NA', 'category': [4, 5],
+             'year': 2100, 'change': 2, 'variable': 'frequency'}
+            ]
         scale = 0.75
 
         tc = TropCyclone()
@@ -360,7 +351,7 @@ class TestClimateSce(unittest.TestCase):
         self.assertTrue(np.allclose(tc_cc.frequency, res_frequency))
 
     def test_negative_freq_error(self):
-
+        """Test _apply_knutson_criterion with infeasible input."""
         criterion = [{'basin': 'NA', 'category': [0, 1],
                       'year': 2100, 'change': 1.1,
                       'variable': 'frequency'},
@@ -375,7 +366,6 @@ class TestClimateSce(unittest.TestCase):
         tc.category = np.array([0, 1])
         with self.assertRaises(ValueError):
             tc._apply_knutson_criterion(criterion, 1)
-
 
 
 if __name__ == "__main__":

--- a/climada/hazard/test/test_trop_cyclone.py
+++ b/climada/hazard/test/test_trop_cyclone.py
@@ -37,7 +37,7 @@ TEST_TRACK = DATA_DIR.joinpath("trac_brb_test.csv")
 TEST_TRACK_SHORT = DATA_DIR.joinpath("trac_short_test.csv")
 
 CENTR_TEST_BRB = Centroids()
-CENTR_TEST_BRB.read_mat(DATA_DIR.joinpath('centr_brb_test.mat'))
+#CENTR_TEST_BRB.read_mat(DATA_DIR.joinpath('centr_brb_test.mat'))
 
 
 class TestReader(unittest.TestCase):
@@ -358,6 +358,25 @@ class TestClimateSce(unittest.TestCase):
         res_frequency[1] = 0.5 * 0.325
         res_frequency[2] = 0.5 * 1.75
         self.assertTrue(np.allclose(tc_cc.frequency, res_frequency))
+
+    def test_negative_freq_error(self):
+
+        criterion = [{'basin': 'NA', 'category': [0, 1],
+                      'year': 2100, 'change': 1.1,
+                      'variable': 'frequency'},
+                     {'basin': 'NA', 'category': [1],
+                      'year': 2100, 'change': 3,
+                      'variable': 'frequency'},
+                     ]
+
+        tc = TropCyclone()
+        tc.frequency = np.ones(2)
+        tc.basin = ['NA', 'NA']
+        tc.category = np.array([0, 1])
+        with self.assertRaises(ValueError):
+            tc._apply_knutson_criterion(criterion, 1)
+
+
 
 if __name__ == "__main__":
     TESTS = unittest.TestLoader().loadTestsFromTestCase(TestReader)

--- a/climada/hazard/test/test_trop_cyclone.py
+++ b/climada/hazard/test/test_trop_cyclone.py
@@ -257,7 +257,7 @@ class TestClimateSce(unittest.TestCase):
     def test_apply_criterion_track(self):
         """Test _apply_criterion function."""
         criterion = list()
-        tmp_chg = {'criteria': {'basin': ['NA'], 'category': [1, 2, 3, 4, 5]},
+        tmp_chg = {'basin': 'NA', 'category': [1, 2, 3, 4, 5],
                    'year': 2100, 'change': 1.045, 'variable': 'intensity', 'function': np.multiply}
         criterion.append(tmp_chg)
         scale = 0.75
@@ -279,7 +279,7 @@ class TestClimateSce(unittest.TestCase):
         tc.category = np.array(ntiles * [2, 0, 4, 1])
         tc.event_id = np.arange(tc.intensity.shape[0])
 
-        tc_cc = tc._apply_criterion(criterion, scale)
+        tc_cc = tc._apply_knutson_criterion(criterion, scale)
         for i_tile in range(ntiles):
             offset = i_tile * 4
             # no factor applied because of category 0
@@ -299,14 +299,28 @@ class TestClimateSce(unittest.TestCase):
     def test_two_criterion_track(self):
         """Test _apply_criterion function with two criteria"""
         criterion = list()
-        tmp_chg = {'criteria': {'basin': ['NA'], 'category': [1, 2, 3, 4, 5]},
+        tmp_chg = {'basin': 'NA', 'category': [1, 2, 3, 4, 5],
                    'year': 2100, 'change': 1.045, 'variable': 'intensity', 'function': np.multiply}
         criterion.append(tmp_chg)
-        tmp_chg = {'criteria': {'basin': ['WP'], 'category': [1, 2, 3, 4, 5]},
+        tmp_chg = {'basin': 'WP', 'category': [1, 2, 3, 4, 5],
                    'year': 2100, 'change': 1.025, 'variable': 'intensity', 'function': np.multiply}
         criterion.append(tmp_chg)
-        tmp_chg = {'criteria': {'basin': ['WP'], 'category': [1, 2, 3, 4, 5]},
+        
+        tmp_chg = {'basin': 'WP', 'category': [1, 2, 3, 4, 5],
                    'year': 2100, 'change': 1.025, 'variable': 'frequency', 'function': np.multiply}
+        criterion.append(tmp_chg)
+        
+        tmp_chg = {'basin': 'NA', 'category': [0, 1, 2, 3, 4, 5],
+                    'year': 2100, 'change': 0.7, 'variable': 'frequency', 'function': np.multiply}
+        criterion.append(tmp_chg)
+        tmp_chg = {'basin': 'NA', 'category': [1, 2, 3, 4, 5],
+                    'year': 2100, 'change': 1, 'variable': 'frequency', 'function': np.multiply}
+        criterion.append(tmp_chg)
+        tmp_chg = {'basin': 'NA', 'category': [3, 4, 5],
+                    'year': 2100, 'change': 1, 'variable': 'frequency', 'function': np.multiply}
+        criterion.append(tmp_chg)
+        tmp_chg = {'basin': 'NA', 'category': [4, 5],
+                   'year': 2100, 'change': 2, 'variable': 'frequency', 'function': np.multiply}
         criterion.append(tmp_chg)
         scale = 0.75
 
@@ -323,7 +337,7 @@ class TestClimateSce(unittest.TestCase):
         tc.category = np.array([2, 0, 4, 1])
         tc.event_id = np.arange(4)
 
-        tc_cc = tc._apply_criterion(criterion, scale)
+        tc_cc = tc._apply_knutson_criterion(criterion, scale)
         self.assertTrue(np.allclose(tc.intensity[1, :].toarray(), tc_cc.intensity[1, :].toarray()))
         self.assertFalse(
             np.allclose(tc.intensity[3, :].toarray(), tc_cc.intensity[3, :].toarray()))
@@ -337,8 +351,12 @@ class TestClimateSce(unittest.TestCase):
             np.allclose(tc.intensity[2, :].toarray() * 1.03375, tc_cc.intensity[2, :].toarray()))
         self.assertTrue(
             np.allclose(tc.intensity[3, :].toarray() * 1.01875, tc_cc.intensity[3, :].toarray()))
+        
         res_frequency = np.ones(4) * 0.5
         res_frequency[3] = 0.5 * 1.01875
+        res_frequency[0] = 0.5 * 0.25
+        res_frequency[1] = 0.5 * 0.325
+        res_frequency[2] = 0.5 * 1.75
         self.assertTrue(np.allclose(tc_cc.frequency, res_frequency))
 
 if __name__ == "__main__":

--- a/climada/hazard/test/test_trop_cyclone.py
+++ b/climada/hazard/test/test_trop_cyclone.py
@@ -305,11 +305,11 @@ class TestClimateSce(unittest.TestCase):
         tmp_chg = {'basin': 'WP', 'category': [1, 2, 3, 4, 5],
                    'year': 2100, 'change': 1.025, 'variable': 'intensity', 'function': np.multiply}
         criterion.append(tmp_chg)
-        
+
         tmp_chg = {'basin': 'WP', 'category': [1, 2, 3, 4, 5],
                    'year': 2100, 'change': 1.025, 'variable': 'frequency', 'function': np.multiply}
         criterion.append(tmp_chg)
-        
+
         tmp_chg = {'basin': 'NA', 'category': [0, 1, 2, 3, 4, 5],
                     'year': 2100, 'change': 0.7, 'variable': 'frequency', 'function': np.multiply}
         criterion.append(tmp_chg)
@@ -351,7 +351,7 @@ class TestClimateSce(unittest.TestCase):
             np.allclose(tc.intensity[2, :].toarray() * 1.03375, tc_cc.intensity[2, :].toarray()))
         self.assertTrue(
             np.allclose(tc.intensity[3, :].toarray() * 1.01875, tc_cc.intensity[3, :].toarray()))
-        
+
         res_frequency = np.ones(4) * 0.5
         res_frequency[3] = 0.5 * 1.01875
         res_frequency[0] = 0.5 * 0.25

--- a/climada/hazard/trop_cyclone.py
+++ b/climada/hazard/trop_cyclone.py
@@ -432,7 +432,6 @@ class TropCyclone(Hazard):
         # Criterion per basin
         for basin in np.unique(tc_cc.basin):
 
-            #basin_chg = [chg for chg in chg_int_freq if chg['basin'] == basin]
             bas_sel = (np.array(tc_cc.basin) == basin)
 
             # Apply intensity change
@@ -482,10 +481,10 @@ class TropCyclone(Hazard):
 
         if (tc_cc.frequency < 0).any():
             raise ValueError("The application of the given climate scenario"
-                         "resulted in at least one negative frequenciy."
-                         "This is likely due to the use of a"
-                         "non-representative event set (too small, "
-                         "incorrect reference period, ...)")
+                             "resulted in at least one negative frequenciy."
+                             "This is likely due to the use of a"
+                             "non-representative event set (too small, "
+                             "incorrect reference period, ...)")
 
         return tc_cc
 

--- a/climada/hazard/trop_cyclone.py
+++ b/climada/hazard/trop_cyclone.py
@@ -206,6 +206,11 @@ class TropCyclone(Hazard):
         applied to sufficiently large tropical cyclone event sets that
         approximate the reference years 1981 - 2008 used in Knutson et. al.
 
+        The frequency and intensity changes are applied independently from
+        one another. The mean intensity factors can thus slightly deviate
+        from the Knutson value (deviation was found to be less than 1%
+        for default IBTrACS event sets 1980-2020 for each basin).
+
         Parameters
         ----------
         ref_year : int

--- a/climada/hazard/trop_cyclone.py
+++ b/climada/hazard/trop_cyclone.py
@@ -63,25 +63,30 @@ NM_TO_KM = (1.0 * ureg.nautical_mile).to(ureg.kilometer).magnitude
 """Unit conversion factors for JIT functions that can't use ureg"""
 
 class TropCyclone(Hazard):
-    """Contains tropical cyclone events.
-    Attributes:
-        category (np.array(int)): for every event, the TC category using the
-            Saffir-Simpson scale:
-                -1 tropical depression
-                 0 tropical storm
-                 1 Hurrican category 1
-                 2 Hurrican category 2
-                 3 Hurrican category 3
-                 4 Hurrican category 4
-                 5 Hurrican category 5
-        basin (list(str)): basin where every event starts
-            'NA' North Atlantic
-            'EP' Eastern North Pacific
-            'WP' Western North Pacific
-            'NI' North Indian
-            'SI' South Indian
-            'SP' Southern Pacific
-            'SA' South Atlantic
+    """
+    Contains tropical cyclone events.
+
+    Attributes
+    ----------
+    category : np.array(int)
+        for every event, the TC category using the
+        Saffir-Simpson scale:
+            -1 tropical depression
+             0 tropical storm
+             1 Hurrican category 1
+             2 Hurrican category 2
+             3 Hurrican category 3
+             4 Hurrican category 4
+             5 Hurrican category 5
+    basin : list(str)
+        basin where every event starts
+        'NA' North Atlantic
+        'EP' Eastern North Pacific
+        'WP' Western North Pacific
+        'NI' North Indian
+        'SI' South Indian
+        'SP' Southern Pacific
+        'SA' South Atlantic
     """
     intensity_thres = 17.5
     """intensity threshold for storage in m/s"""
@@ -103,7 +108,8 @@ class TropCyclone(Hazard):
     def set_from_tracks(self, tracks, centroids=None, description='',
                         model='H08', ignore_distance_to_coast=False,
                         store_windfields=False, metric="equirect"):
-        """Clear and fill with windfields from specified tracks.
+        """
+        Clear and fill with windfields from specified tracks.
 
         Parameters
         ----------
@@ -238,25 +244,35 @@ class TropCyclone(Hazard):
     def video_intensity(track_name, tracks, centroids, file_name=None,
                         writer=animation.PillowWriter(bitrate=500),
                         figsize=(9, 13), **kwargs):
-        """Generate video of TC wind fields node by node and returns its
+        """
+        Generate video of TC wind fields node by node and returns its
         corresponding TropCyclone instances and track pieces.
 
-        Parameters:
-            track_name (str): name of the track contained in tracks to record
-            tracks (TCTracks): tracks
-            centroids (Centroids): centroids where wind fields are mapped
-            file_name (str, optional): file name to save video, if provided
-            writer = (matplotlib.animation.*, optional): video writer. Default:
-                pillow with bitrate=500
-            figsize (tuple, optional): figure size for plt.subplots
-            kwargs (optional): arguments for pcolormesh matplotlib function
-                used in event plots
+        Parameters
+        ----------
+        track_name : str
+            name of the track contained in tracks to record
+        tracks : climada.hazard.TCTracks
+            tropical cyclone tracks
+        centroids : climada.hazard.Centroids
+            centroids where wind fields are mapped
+        file_name : str, optional
+            file name to save video (including full path and file extension)
+        writer : matplotlib.animation.*, optional
+            video writer. Default is pillow with bitrate=500
+        figsize : tuple, optional
+            figure size for plt.subplots
+        kwargs : optional
+            arguments for pcolormesh matplotlib function used in event plots
 
-        Returns:
-            list(TropCyclone), list(np.array)
+        Returns
+        -------
+        tc_list, tc_coord : list(TropCyclone), list(np.array)
 
-        Raises:
-            ValueError
+        Raises
+        ------
+        ValueError
+
         """
         # initialization
         track = tracks.get_track(track_name)
@@ -317,10 +333,12 @@ class TropCyclone(Hazard):
         return tc_list, tr_coord
 
     def frequency_from_tracks(self, tracks):
-        """Set hazard frequency from tracks data.
+        """
+        Set hazard frequency from tracks data.
 
-        Parameters:
-            tracks (list of xarray.Dataset)
+        Parameters
+        ----------
+        tracks : list of xarray.Dataset
         """
         if not tracks:
             return
@@ -333,7 +351,8 @@ class TropCyclone(Hazard):
 
     def _tc_from_track(self, track, centroids, coastal_idx, model='H08',
                        store_windfields=False, metric="equirect"):
-        """Generate windfield hazard from a single track dataset
+        """
+        Generate windfield hazard from a single track dataset
 
         Parameters
         ----------
@@ -691,7 +710,8 @@ def _vtrans(t_lat, t_lon, t_tstep, metric="equirect"):
     return v_trans_norm, v_trans
 
 def _bs_hol08(v_trans, penv, pcen, prepcen, lat, tint):
-    """Holland's 2008 b-value computation for sustained surface winds
+    """
+    Holland's 2008 b-value computation for sustained surface winds
 
     The parameter applies to 1-minute sustained winds at 10 meters above ground.
     It is taken from equation (11) in the following paper:
@@ -717,16 +737,24 @@ def _bs_hol08(v_trans, penv, pcen, prepcen, lat, tint):
     of the Coriolis term is 1 while wind speed is 50 (which changes away from the
     radius of maximum winds and as the TC moves away from the equator).
 
-    Parameters:
-        v_trans (float): translational wind (m/s)
-        penv (float): environmental pressure (hPa)
-        pcen (float): central pressure (hPa)
-        prepcen (float): previous central pressure (hPa)
-        lat (float): latitude (degrees)
-        tint (float): time step (h)
+    Parameters
+    ----------
+    v_trans : float
+        translational wind (m/s)
+    penv : float
+        environmental pressure (hPa)
+    pcen : float
+        central pressure (hPa)
+    prepcen : float
+        previous central pressure (hPa)
+    lat : float
+        latitude (degrees)
+    tint : float
+        time step (h)
 
-    Returns:
-        float
+    Returns
+    -------
+    b_s : float
     """
     hol_xx = 0.6 * (1. - (penv - pcen) / 215)
     hol_b = -4.4e-5 * (penv - pcen)**2 + 0.01 * (penv - pcen) + \
@@ -735,7 +763,8 @@ def _bs_hol08(v_trans, penv, pcen, prepcen, lat, tint):
     return np.clip(hol_b, 1, 2.5)
 
 def _stat_holland(d_centr, r_max, hol_b, penv, pcen, lat, close_centr):
-    """Holland symmetric and static wind field (in m/s)
+    """
+    Holland symmetric and static wind field (in m/s)
 
     This function applies the gradient wind model expressed in equation (4) (combined with
     equation (6)) from

--- a/climada/hazard/trop_cyclone.py
+++ b/climada/hazard/trop_cyclone.py
@@ -388,25 +388,29 @@ class TropCyclone(Hazard):
         return new_haz
 
     def _apply_knutson_criterion(self, chg_int_freq, scaling_rcp_year):
-        """Apply changes defined in criterion with a given scale
+        """
+        Apply changes defined in criterion with a given scale.
+
         Parameters:
             criterion (list(dict)): list of criteria
             scale (float): scale parameter because of chosen year and RCP
         Returns:
             TropCyclone
         """
+
         tc_cc = copy.deepcopy(self)
 
         # Criterion per basin
         for basin in np.unique(tc_cc.basin):
 
-            basin_chg = [chg for chg in chg_int_freq if chg['basin'] == basin]
+            #basin_chg = [chg for chg in chg_int_freq if chg['basin'] == basin]
             bas_sel = (np.array(tc_cc.basin) == basin)
 
             # Apply intensity change
             inten_chg = [chg
-                         for chg in basin_chg
-                         if chg['variable'] == 'intensity'
+                         for chg in chg_int_freq
+                         if (chg['variable'] == 'intensity' and
+                             chg['basin'] == basin)
                          ]
             for chg in inten_chg:
                 sel_cat_chg = np.isin(tc_cc.category, chg['category']) & bas_sel
@@ -417,14 +421,14 @@ class TropCyclone(Hazard):
 
             # Apply frequency change
             freq_chg = [chg
-                        for chg in basin_chg
-                        if chg['variable'] == 'frequency'
+                        for chg in chg_int_freq
+                        if (chg['variable'] == 'frequency' and
+                            chg['basin'] == basin)
                         ]
             freq_chg.sort(reverse=False, key=lambda x: len(x['category']))
 
-
             # Iteratively scale frequencies for each category such that
-            # cumulative frequencies are scaled according to Knuston criterion.
+            # cumulative frequencies are scaled according to Knutson criterion.
 
             cat_larger_list = []
             for chg in freq_chg:

--- a/climada/hazard/trop_cyclone.py
+++ b/climada/hazard/trop_cyclone.py
@@ -396,18 +396,17 @@ class TropCyclone(Hazard):
             TropCyclone
         """
         tc_cc = copy.deepcopy(self)
-        tc_cc_basin = np.array(tc_cc.basin)
-        
-        #criterion per basin
-        for basin in np.unique(tc_cc_basin):
-        
-            basin_chg = [chg for chg in chg_int_freq if chg['basin'] == basin]
-            bas_sel = (tc_cc_basin == basin)
 
-            #Apply intensity change
+        # Criterion per basin
+        for basin in np.unique(tc_cc.basin):
+
+            basin_chg = [chg for chg in chg_int_freq if chg['basin'] == basin]
+            bas_sel = (np.array(tc_cc.basin) == basin)
+
+            # Apply intensity change
             inten_chg = [chg
                          for chg in basin_chg
-                         if chg['variable'] =='intensity'
+                         if chg['variable'] == 'intensity'
                          ]
             for chg in inten_chg:
                 sel_cat_chg = np.isin(tc_cc.category, chg['category']) & bas_sel
@@ -415,28 +414,28 @@ class TropCyclone(Hazard):
                 tc_cc.intensity = sparse.diags(
                     np.where(sel_cat_chg, inten_scaling, 1)
                     ).dot(tc_cc.intensity)
-            
-            #Apply frequency change
-            freq_chg = [chg 
-                        for chg in basin_chg
-                        if chg['variable']=='frequency'
-                        ]
-            freq_chg.sort(reverse = False, key = lambda x: len(x['category']))
-            
 
-            #Iteratively scale frequencies for each category such that 
-            #cumulative frequencies are scaled according to Knuston criterion.
+            # Apply frequency change
+            freq_chg = [chg
+                        for chg in basin_chg
+                        if chg['variable'] == 'frequency'
+                        ]
+            freq_chg.sort(reverse=False, key=lambda x: len(x['category']))
+
+
+            # Iteratively scale frequencies for each category such that
+            # cumulative frequencies are scaled according to Knuston criterion.
 
             cat_larger_list = []
             for chg in freq_chg:
-                cat_chg_list = [cat 
+                cat_chg_list = [cat
                                 for cat in chg['category']
                                 if cat not in cat_larger_list
                                 ]
                 sel_cat_chg = np.isin(tc_cc.category, cat_chg_list) & bas_sel
                 if sel_cat_chg.any():
                     freq_scaling = 1 + (chg['change'] - 1) * scaling_rcp_year
-                    sel_cat_all = (np.isin(tc_cc.category, chg['category']) 
+                    sel_cat_all = (np.isin(tc_cc.category, chg['category'])
                                    & bas_sel)
                     sel_cat_larger = (np.isin(tc_cc.category, cat_larger_list)
                                       & bas_sel)
@@ -447,9 +446,9 @@ class TropCyclone(Hazard):
                     )
                     tc_cc.frequency[sel_cat_chg] *= freq_scaling_cor
                 cat_larger_list += cat_chg_list
-                
+
         return tc_cc
-    
+
 
 def compute_windfields(track, centroids, model, metric="equirect"):
     """Compute 1-minute sustained winds (in m/s) at 10 meters above ground

--- a/climada/hazard/trop_cyclone.py
+++ b/climada/hazard/trop_cyclone.py
@@ -227,12 +227,6 @@ class TropCyclone(Hazard):
         haz_cc = self._apply_knutson_criterion(chg_int_freq, scale_rcp_year)
         haz_cc.tag.description = 'climate change scenario for year %s and RCP %s '\
         'from Knutson et al 2015.' % (str(ref_year), str(rcp_scenario))
-        if (haz_cc.frequency < 0).any():
-            raise ValueError("The application of the given climate scenario"
-                             "lead to negative frequencies. This is"
-                             "likely due to the use of a"
-                             "non-representative event set (too small, "
-                             "incorrect reference period, ...)")
         return haz_cc
 
     @staticmethod
@@ -480,6 +474,13 @@ class TropCyclone(Hazard):
                     )
                     tc_cc.frequency[sel_cat_chg] *= freq_scaling_cor
                 cat_larger_list += cat_chg_list
+
+        if (tc_cc.frequency < 0).any():
+            raise ValueError("The application of the given climate scenario"
+                         "resulted in at least one negative frequenciy."
+                         "This is likely due to the use of a"
+                         "non-representative event set (too small, "
+                         "incorrect reference period, ...)")
 
         return tc_cc
 


### PR DESCRIPTION
The goal of this pull request is to update the Knutson climate change function for tropical cyclone track ensembles. In the previous implementations, the frequency changes were applied directly to the frequency distributions, whereas the Knutson paper factors are meant to act on the cumulative distributions. 

For example, for the NorthPacific basin, the criteria are
Cat 0-5 : -34.5%
Cat 1-5 : -31.6%
Cat 3-5 : -16.9
Cat 4-5 : 1 (change not statistically significant)

The current algorithm multiplies the frequency of the tracks of all storms of category 3-5 by -16.9%, 1-2 by -31.6%, and all storms of category 0 by -34.5%.

The new implementation applies the changes one after the other. Here, storms of categories 4-5 are untouched. Frequencies of storms cat 3 are multiplied by a factor (math below) such that the cumulative frequencies of cat 3 to 5 change by -16.9%. Then, the frequencies of category 1-2 are multiply by a factor such that the new frequencies (with updated cat 3 freqs) from cat 1-5 change by -31.6%. And analogolously for cat 0. 