### PR TITLE
Delay calls to tight_layout as much as possible

### DIFF
--- a/climada/engine/forecast.py
+++ b/climada/engine/forecast.py
@@ -472,7 +472,8 @@ class Forecast():
                             color=color[t_i],
                             ha=left_right[t_i])
 
-            plt.subplots_adjust(top=0.8)
+        fig.tight_layout()
+        fig.subplots_adjust(top=0.8)
         return fig, axis_sub
 
     def plot_hist(self, run_datetime=None, save_fig=True, close_fig=False,
@@ -771,7 +772,7 @@ class Forecast():
                             ha=left_right[t_i])
             extent = u_plot._get_borders(coord)
             axis.set_extent((extent), ccrs.PlateCarree())
-
+        fig.tight_layout()
         return fig, axis_sub
 
     def plot_warn_map(self, polygon_file=None,
@@ -1009,6 +1010,7 @@ class Forecast():
 
         extent = u_plot._get_borders(self._impact[haz_ind].coord_exp)
         axis.set_extent((extent), ccrs.PlateCarree())
+        fig.tight_layout()
         return fig, axis
 
     def plot_hexbin_ei_exposure(self, run_datetime=None,

--- a/climada/engine/impact.py
+++ b/climada/engine/impact.py
@@ -806,6 +806,7 @@ class Impact():
             ani = animation.FuncAnimation(fig, run, frames=len(haz_list),
                                           interval=500, blit=False)
             pbar = tqdm(total=len(haz_list))
+            fig.tight_layout()
             ani.save(file_name, writer=writer)
             pbar.close()
 

--- a/climada/entity/exposures/base.py
+++ b/climada/entity/exposures/base.py
@@ -559,6 +559,7 @@ class Exposures():
         imag = axis.imshow(raster_f(raster), **kwargs, origin='upper',
                            extent=(xmin, xmax, ymin, ymax), transform=proj_data)
         plt.colorbar(imag, cax=cbar_ax, label=label)
+        plt.tight_layout()
         plt.draw()
         return axis
 

--- a/climada/hazard/centroids/centr.py
+++ b/climada/hazard/centroids/centr.py
@@ -26,6 +26,7 @@ from pathlib import Path
 import cartopy.crs as ccrs
 import geopandas as gpd
 import h5py
+import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 from pyproj.crs import CRS
@@ -833,6 +834,7 @@ class Centroids():
         axis.set_extent((xmin, xmax, ymin, ymax), crs=proj_data)
         u_plot.add_shapes(axis)
         axis.scatter(self.lon, self.lat, transform=proj_data, **kwargs)
+        plt.tight_layout()
         return axis
 
     def calc_pixels_polygons(self, scheduler=None):

--- a/climada/hazard/tc_tracks.py
+++ b/climada/hazard/tc_tracks.py
@@ -38,6 +38,7 @@ import matplotlib.cm as cm_mp
 from matplotlib.collections import LineCollection
 from matplotlib.colors import BoundaryNorm, ListedColormap
 from matplotlib.lines import Line2D
+import matplotlib.pyplot as plt
 import netCDF4 as nc
 import numba
 import numpy as np
@@ -1268,7 +1269,7 @@ class TCTracks():
                 leg_names.append('Historical')
                 leg_names.append('Synthetic')
             axis.legend(leg_lines, leg_names, loc=0)
-
+        plt.tight_layout()
         return axis
 
     def write_netcdf(self, folder_name):

--- a/climada/hazard/trop_cyclone.py
+++ b/climada/hazard/trop_cyclone.py
@@ -341,6 +341,7 @@ class TropCyclone(Hazard):
             pbar = tqdm(total=idx_plt.size - 2)
             ani = animation.FuncAnimation(fig, run, frames=idx_plt.size - 2,
                                           interval=500, blit=False)
+            fig.tight_layout()
             ani.save(file_name, writer=writer)
             pbar.close()
         return tc_list, tr_coord

--- a/climada/util/plot.py
+++ b/climada/util/plot.py
@@ -229,6 +229,7 @@ def _plot_scattered_data(method, array_sub, geo_coord, var_name, title,
         cbar = plt.colorbar(mappable, cax=cbax, orientation='vertical', extend=extend)
         cbar.set_label(name)
         axis.set_title("\n".join(wrap(tit)))
+    plt.tight_layout()
     return axes
 
 
@@ -324,7 +325,7 @@ def geo_im_from_array(array_sub, coord, var_name, title,
         cbar = plt.colorbar(img, cax=cbax, orientation='vertical')
         cbar.set_label(name)
         axis.set_title("\n".join(wrap(tit)))
-
+    plt.tight_layout()
     return axes
 
 def geo_scatter_categorical(array_sub, geo_coord, var_name, title,
@@ -468,7 +469,6 @@ def make_map(num_sub=1, figsize=(9, 13), proj=ccrs.PlateCarree()):
         except TypeError:
             pass
 
-    fig.tight_layout()
     if num_col > 1:
         fig.subplots_adjust(wspace=0.3)
     if num_row > 1:


### PR DESCRIPTION
Starting with cartopy 0.19.0, when using grid lines, the axis extent is screwed up if `plt.tight_layout` is called before `set_extent` or before other calls restrict the map extent (see #229).

This PR fixes #229 by moving calls to `tight_layout` from the `make_map` function to a later stage of the plotting.

Issue #229 does not apply to cartopy 0.18.0, but even there (and for future versions), it makes sense to always delay calls to `tight_layout` as much as possible to make sure that all artists or axes are already present and configured when margins and paddings are computed.