### PR TITLE
read_ibtracs_netcdf: raise exception for invalid storm ids

### DIFF
--- a/climada/hazard/tc_tracks.py
+++ b/climada/hazard/tc_tracks.py
@@ -348,7 +348,7 @@ class TCTracks():
         storm_id : str or list of str, optional
             IBTrACS ID of the storm, e.g. 1988234N13299, [1988234N13299, 1989260N11316].
         year_range : tuple (min_year, max_year), optional
-            Year range to filter track selection. Default: (1980, 2018)
+            Year range to filter track selection. Default: None.
         basin : str, optional
             If given, select storms that have at least one position in the specified basin. This
             allows analysis of a given basin, but also means that basin-specific track sets should
@@ -447,8 +447,6 @@ class TCTracks():
                                  ", ..." if len(non_existing_sids) > 5  else ".")
                 storm_id_encoded = list(np.array(storm_id_encoded)[~non_existing_mask])
             match &= ibtracs_ds.sid.isin(storm_id_encoded)
-        else:
-            year_range = year_range if year_range else (1980, 2018)
         if year_range is not None:
             years = ibtracs_ds.sid.str.slice(0, 4).astype(int)
             match &= (years >= year_range[0]) & (years <= year_range[1])

--- a/climada/hazard/tc_tracks.py
+++ b/climada/hazard/tc_tracks.py
@@ -434,17 +434,17 @@ class TCTracks():
                 [re.match(r"[12][0-9]{6}[NS][0-9]{5}", s) is None for s in storm_id])
             if invalid_mask.any():
                 invalid_sids = list(np.array(storm_id)[invalid_mask])
-                LOGGER.warning("The following given IDs are invalid: %s%s",
-                               ", ".join(invalid_sids[:5]),
-                               ", ..." if len(invalid_sids) > 5  else ".")
+                raise ValueError("The following given IDs are invalid: %s%s",
+                                 ", ".join(invalid_sids[:5]),
+                                 ", ..." if len(invalid_sids) > 5  else ".")
                 storm_id = list(np.array(storm_id)[~invalid_mask])
             storm_id_encoded = [i.encode() for i in storm_id]
             non_existing_mask = ~np.isin(storm_id_encoded, ibtracs_ds.sid.values)
             if np.count_nonzero(non_existing_mask) > 0:
                 non_existing_sids = list(np.array(storm_id)[non_existing_mask])
-                LOGGER.warning("The following given IDs are not in IBTrACS: %s%s",
-                               ", ".join(non_existing_sids[:5]),
-                               ", ..." if len(non_existing_sids) > 5  else ".")
+                raise ValueError("The following given IDs are not in IBTrACS: %s%s",
+                                 ", ".join(non_existing_sids[:5]),
+                                 ", ..." if len(non_existing_sids) > 5  else ".")
                 storm_id_encoded = list(np.array(storm_id_encoded)[~non_existing_mask])
             match &= ibtracs_ds.sid.isin(storm_id_encoded)
         else:

--- a/climada/hazard/test/test_tc_tracks.py
+++ b/climada/hazard/test/test_tc_tracks.py
@@ -50,12 +50,26 @@ class TestIbtracs(unittest.TestCase):
     """Test reading and model of TC from IBTrACS files"""
 
     def test_raw_ibtracs_empty_pass(self):
-        """Test reading empty/invalid/non-existing TC from IBTrACS files"""
+        """Test reading empty TC from IBTrACS files"""
         tc_track = tc.TCTracks()
         tc_track.read_ibtracs_netcdf(
-            provider='usa', storm_id=['1988234N13299', 'INVALID', '1988234N13298'])
+            provider='usa', storm_id='1988234N13299')
         self.assertEqual(tc_track.size, 0)
         self.assertEqual(tc_track.get_track(), [])
+
+    def test_raw_ibtracs_invalid_pass(self):
+        """Test reading invalid/non-existing TC from IBTrACS files"""
+        tc_track = tc.TCTracks()
+        with self.assertRaises(ValueError) as cm:
+            tc_track.read_ibtracs_netcdf(storm_id='INVALID')
+        self.assertIn("IDs are invalid", str(cm.exception))
+        self.assertIn("INVALID", str(cm.exception))
+
+        tc_track = tc.TCTracks()
+        with self.assertRaises(ValueError) as cm:
+            tc_track.read_ibtracs_netcdf(storm_id='1988234N13298')
+        self.assertIn("IDs are not in IBTrACS", str(cm.exception))
+        self.assertIn("1988234N13298", str(cm.exception))
 
     def test_write_read_pass(self):
         """Test writting and reading netcdf4 TCTracks instances"""


### PR DESCRIPTION
The `storm_id` parameter of `read_ibtracs_netcdf` refers to a unique identifier in IBTrACS. Users that specify this parameter are dealing with non-fuzzy information and will most certainly expect to have the correct ID in their hands. Still, the users are only warned in the log output, which might go unnoticed by many users.

With this PR, I propose to raise an exception whenever we find that a user-specified ID is invalid (or non-existing).

What do you think?

As an example why a user might end up specifying a wrong ID: The user might have the ID from a different source and the source might be old or in a strange format. IBTrACS IDs change from time to time, especially for events in the last 2-3 years. Furthermore, if the source contains encoding errors, the specified ID might contain invalid (maybe invisible) characters such as whitespace. In both cases, users might be able to determine the correct IDs manually - but only if they notice that there are invalid IDs in the first place. If a long list of IDs is specified, a few missing IDs will easily go unnoticed.