### PR TITLE
Exposures.read_hdf5: restore CRS

### DIFF
--- a/climada/entity/exposures/base.py
+++ b/climada/entity/exposures/base.py
@@ -678,13 +678,16 @@ class Exposures():
         """
         LOGGER.info('Reading %s', file_name)
         with pd.HDFStore(file_name) as store:
-            self.__init__(store['exposures'])
             metadata = store.get_storer('exposures').attrs.metadata
+            crs = None
+            if 'crs' in metadata:
+                crs = metadata['crs']
+            elif 'meta' in metadata and 'crs' in metadata['meta']:
+                crs = metadata['meta']['crs']
+            self.__init__(store['exposures'], crs=crs)
             for key, val in metadata.items():
                 if key in type(self)._metadata:
                     setattr(self, key, val)
-                if key == 'crs':
-                    self.set_crs(val)
 
     def read_mat(self, file_name, var_names=None):
         """Read MATLAB file and store variables in exposures.

--- a/climada/entity/exposures/base.py
+++ b/climada/entity/exposures/base.py
@@ -251,6 +251,11 @@ class Exposures():
         elif not any([col.startswith(INDICATOR_CENTR) for col in self.gdf.columns]):
             LOGGER.info("%s not set.", INDICATOR_CENTR)
 
+        # check if CRS is consistent
+        if self.crs != self.meta.get('crs'):
+            raise ValueError(f"Inconsistent CRS definition, gdf ({self.crs}) attribute doesn't "
+                             f"match meta ({self.meta.get('crs')}) attribute.")
+
         # check whether geometry corresponds to lat/lon
         try:
             if (self.gdf.geometry.values[0].x != self.gdf.longitude.values[0] or

--- a/climada/entity/exposures/base.py
+++ b/climada/entity/exposures/base.py
@@ -679,11 +679,10 @@ class Exposures():
         LOGGER.info('Reading %s', file_name)
         with pd.HDFStore(file_name) as store:
             metadata = store.get_storer('exposures').attrs.metadata
-            crs = None
-            if 'crs' in metadata:
-                crs = metadata['crs']
-            elif 'meta' in metadata and 'crs' in metadata['meta']:
-                crs = metadata['meta']['crs']
+            # in previous versions of CLIMADA and/or geopandas, the CRS was stored in '_crs'/'crs'
+            crs = metadata.get('crs', metadata.get('_crs'))
+            if crs is None and 'meta' in metadata:
+                crs = metadata['meta'].get('crs')
             self.__init__(store['exposures'], crs=crs)
             for key, val in metadata.items():
                 if key in type(self)._metadata:

--- a/climada/entity/exposures/test/test_base.py
+++ b/climada/entity/exposures/test/test_base.py
@@ -149,8 +149,8 @@ class TestFuncs(unittest.TestCase):
         haz = Hazard('FL')
         haz.set_raster([HAZ_DEMO_FL], window=Window(10, 20, 50, 60))
         exp.assign_centroids(haz)
-        self.assertTrue(np.array_equal(exp.gdf[INDICATOR_CENTR + 'FL'].values,
-                                       np.arange(haz.centroids.size, dtype=int)))
+        np.testing.assert_array_equal(exp.gdf[INDICATOR_CENTR + 'FL'].values,
+                                      np.arange(haz.centroids.size, dtype=int))
 
     def test_assign_large_hazard_subset_pass(self):
         """Test assign_centroids with raster hazard"""
@@ -246,17 +246,17 @@ class TestIO(unittest.TestCase):
         self.assertEqual(exp_df.crs, exp_read.crs)
         self.assertEqual(exp_df.tag.file_name, exp_read.tag.file_name)
         self.assertEqual(exp_df.tag.description, exp_read.tag.description)
-        self.assertTrue(np.array_equal(exp_df.gdf.latitude.values, exp_read.gdf.latitude.values))
-        self.assertTrue(np.array_equal(exp_df.gdf.longitude.values, exp_read.gdf.longitude.values))
-        self.assertTrue(np.array_equal(exp_df.gdf.value.values, exp_read.gdf.value.values))
-        self.assertTrue(np.array_equal(exp_df.gdf.deductible.values, exp_read.gdf.deductible.values))
-        self.assertTrue(np.array_equal(exp_df.gdf.cover.values, exp_read.gdf.cover.values))
-        self.assertTrue(np.array_equal(exp_df.gdf.region_id.values, exp_read.gdf.region_id.values))
-        self.assertTrue(np.array_equal(exp_df.gdf.category_id.values, exp_read.gdf.category_id.values))
-        self.assertTrue(np.array_equal(exp_df.gdf.impf_TC.values, exp_read.gdf.impf_TC.values))
-        self.assertTrue(np.array_equal(exp_df.gdf.centr_TC.values, exp_read.gdf.centr_TC.values))
-        self.assertTrue(np.array_equal(exp_df.gdf.impf_FL.values, exp_read.gdf.impf_FL.values))
-        self.assertTrue(np.array_equal(exp_df.gdf.centr_FL.values, exp_read.gdf.centr_FL.values))
+        np.testing.assert_array_equal(exp_df.gdf.latitude.values, exp_read.gdf.latitude.values)
+        np.testing.assert_array_equal(exp_df.gdf.longitude.values, exp_read.gdf.longitude.values)
+        np.testing.assert_array_equal(exp_df.gdf.value.values, exp_read.gdf.value.values)
+        np.testing.assert_array_equal(exp_df.gdf.deductible.values, exp_read.gdf.deductible.values)
+        np.testing.assert_array_equal(exp_df.gdf.cover.values, exp_read.gdf.cover.values)
+        np.testing.assert_array_equal(exp_df.gdf.region_id.values, exp_read.gdf.region_id.values)
+        np.testing.assert_array_equal(exp_df.gdf.category_id.values, exp_read.gdf.category_id.values)
+        np.testing.assert_array_equal(exp_df.gdf.impf_TC.values, exp_read.gdf.impf_TC.values)
+        np.testing.assert_array_equal(exp_df.gdf.centr_TC.values, exp_read.gdf.centr_TC.values)
+        np.testing.assert_array_equal(exp_df.gdf.impf_FL.values, exp_read.gdf.impf_FL.values)
+        np.testing.assert_array_equal(exp_df.gdf.centr_FL.values, exp_read.gdf.centr_FL.values)
 
         for point_df, point_read in zip(exp_df.gdf.geometry.values, exp_read.gdf.geometry.values):
             self.assertEqual(point_df.x, point_read.x)
@@ -293,7 +293,7 @@ class TestAddSea(unittest.TestCase):
         max_lon = max_lon + sea_coast
         self.assertEqual(np.min(exp_sea.gdf.latitude), min_lat)
         self.assertEqual(np.min(exp_sea.gdf.longitude), min_lon)
-        self.assertTrue(np.array_equal(exp_sea.gdf.value.values[:10], np.arange(0, 1.0e6, 1.0e5)))
+        np.testing.assert_array_equal(exp_sea.gdf.value.values[:10], np.arange(0, 1.0e6, 1.0e5))
         self.assertEqual(exp_sea.ref_year, exp.ref_year)
         self.assertEqual(exp_sea.value_unit, exp.value_unit)
 
@@ -355,8 +355,8 @@ class TestGeoDFFuncs(unittest.TestCase):
         self.assertEqual(exp_copy.value_unit, exp.value_unit)
         self.assertEqual(exp_copy.tag.description, exp.tag.description)
         self.assertEqual(exp_copy.tag.file_name, exp.tag.file_name)
-        self.assertTrue(np.array_equal(exp_copy.gdf.latitude.values, exp.gdf.latitude.values))
-        self.assertTrue(np.array_equal(exp_copy.gdf.longitude.values, exp.gdf.longitude.values))
+        np.testing.assert_array_equal(exp_copy.gdf.latitude.values, exp.gdf.latitude.values)
+        np.testing.assert_array_equal(exp_copy.gdf.longitude.values, exp.gdf.longitude.values)
 
     def test_to_crs_inplace_pass(self):
         """Test to_crs function inplace."""
@@ -392,7 +392,7 @@ class TestGeoDFFuncs(unittest.TestCase):
         in_gpd.ref_year = 2015
         in_exp = Exposures(in_gpd, ref_year=2015)
         self.assertEqual(in_exp.ref_year, 2015)
-        self.assertTrue(np.array_equal(in_exp.gdf.value, np.zeros(10)))
+        np.testing.assert_array_equal(in_exp.gdf.value, np.zeros(10))
 
     def test_error_on_access_item(self):
         """Test error output when trying to access items as in CLIMADA 1.x"""

--- a/climada/entity/exposures/test/test_base.py
+++ b/climada/entity/exposures/test/test_base.py
@@ -228,6 +228,7 @@ class TestIO(unittest.TestCase):
     def test_io_hdf5_pass(self):
         """write and read hdf5"""
         exp_df = Exposures(pd.read_excel(ENT_TEMPLATE_XLS))
+        exp_df.set_crs("epsg:32632")
         exp_df.set_geometry_points()
         exp_df.check()
         # set metadata
@@ -246,17 +247,17 @@ class TestIO(unittest.TestCase):
         self.assertEqual(exp_df.crs, exp_read.crs)
         self.assertEqual(exp_df.tag.file_name, exp_read.tag.file_name)
         self.assertEqual(exp_df.tag.description, exp_read.tag.description)
-        self.assertTrue(np.array_equal(exp_df.gdf.latitude.values,    exp_read.gdf.latitude.values))
-        self.assertTrue(np.array_equal(exp_df.gdf.longitude.values,   exp_read.gdf.longitude.values))
-        self.assertTrue(np.array_equal(exp_df.gdf.value.values,       exp_read.gdf.value.values))
-        self.assertTrue(np.array_equal(exp_df.gdf.deductible.values,  exp_read.gdf.deductible.values))
-        self.assertTrue(np.array_equal(exp_df.gdf.cover.values,       exp_read.gdf.cover.values))
-        self.assertTrue(np.array_equal(exp_df.gdf.region_id.values,   exp_read.gdf.region_id.values))
+        self.assertTrue(np.array_equal(exp_df.gdf.latitude.values, exp_read.gdf.latitude.values))
+        self.assertTrue(np.array_equal(exp_df.gdf.longitude.values, exp_read.gdf.longitude.values))
+        self.assertTrue(np.array_equal(exp_df.gdf.value.values, exp_read.gdf.value.values))
+        self.assertTrue(np.array_equal(exp_df.gdf.deductible.values, exp_read.gdf.deductible.values))
+        self.assertTrue(np.array_equal(exp_df.gdf.cover.values, exp_read.gdf.cover.values))
+        self.assertTrue(np.array_equal(exp_df.gdf.region_id.values, exp_read.gdf.region_id.values))
         self.assertTrue(np.array_equal(exp_df.gdf.category_id.values, exp_read.gdf.category_id.values))
-        self.assertTrue(np.array_equal(exp_df.gdf.impf_TC.values,       exp_read.gdf.impf_TC.values))
-        self.assertTrue(np.array_equal(exp_df.gdf.centr_TC.values,    exp_read.gdf.centr_TC.values))
-        self.assertTrue(np.array_equal(exp_df.gdf.impf_FL.values,       exp_read.gdf.impf_FL.values))
-        self.assertTrue(np.array_equal(exp_df.gdf.centr_FL.values,    exp_read.gdf.centr_FL.values))
+        self.assertTrue(np.array_equal(exp_df.gdf.impf_TC.values, exp_read.gdf.impf_TC.values))
+        self.assertTrue(np.array_equal(exp_df.gdf.centr_TC.values, exp_read.gdf.centr_TC.values))
+        self.assertTrue(np.array_equal(exp_df.gdf.impf_FL.values, exp_read.gdf.impf_FL.values))
+        self.assertTrue(np.array_equal(exp_df.gdf.centr_FL.values, exp_read.gdf.centr_FL.values))
 
         for point_df, point_read in zip(exp_df.gdf.geometry.values, exp_read.gdf.geometry.values):
             self.assertEqual(point_df.x, point_read.x)

--- a/climada/entity/exposures/test/test_base.py
+++ b/climada/entity/exposures/test/test_base.py
@@ -203,6 +203,13 @@ class TestChecker(unittest.TestCase):
         self.assertIn("Inconsistent CRS definition, data doesn't match meta or crs argument",
                       str(cm.exception))
 
+        _expo = Exposures(expo.gdf)
+        _expo.meta['crs'] = 'epsg:4230'
+        with self.assertRaises(ValueError) as cm:
+            _expo.check()
+        self.assertIn("Inconsistent CRS definition, gdf (EPSG:4326) attribute doesn't match "
+                      "meta (epsg:4230) attribute.", str(cm.exception))
+
     def test_error_geometry_fail(self):
         """Wrong exposures definition"""
         expo = good_exposures()
@@ -243,7 +250,9 @@ class TestIO(unittest.TestCase):
 
         self.assertEqual(exp_df.ref_year, exp_read.ref_year)
         self.assertEqual(exp_df.value_unit, exp_read.value_unit)
+        self.assertDictEqual(exp_df.meta, exp_read.meta)
         self.assertEqual(exp_df.crs, exp_read.crs)
+        self.assertEqual(exp_df.gdf.crs, exp_read.gdf.crs)
         self.assertEqual(exp_df.tag.file_name, exp_read.tag.file_name)
         self.assertEqual(exp_df.tag.description, exp_read.tag.description)
         np.testing.assert_array_equal(exp_df.gdf.latitude.values, exp_read.gdf.latitude.values)

--- a/climada/entity/exposures/test/test_base.py
+++ b/climada/entity/exposures/test/test_base.py
@@ -227,8 +227,7 @@ class TestIO(unittest.TestCase):
 
     def test_io_hdf5_pass(self):
         """write and read hdf5"""
-        exp_df = Exposures(pd.read_excel(ENT_TEMPLATE_XLS))
-        exp_df.set_crs("epsg:32632")
+        exp_df = Exposures(pd.read_excel(ENT_TEMPLATE_XLS), crs="epsg:32632")
         exp_df.set_geometry_points()
         exp_df.check()
         # set metadata


### PR DESCRIPTION
When reading HDF5 exposure files, make sure that the CRS is restored correctly. This fixes #243 because it will also correctly handle very old files (generated with old versions of CLIMADA and/or geopandas).