### PR TITLE
TCTracks.read_netcdf: convert legacy basin attribute on the fly

### DIFF
--- a/climada/hazard/tc_tracks.py
+++ b/climada/hazard/tc_tracks.py
@@ -1303,6 +1303,13 @@ class TCTracks():
                 continue
             track = xr.open_dataset(file)
             track.attrs['orig_event_flag'] = bool(track.orig_event_flag)
+            if "basin" in track.attrs:
+                LOGGER.warning("Track data comes with legacy basin attribute. "
+                               "We assume that the track remains in that basin during its "
+                               "whole life time.")
+                basin = track.basin
+                del track.attrs['basin']
+                track['basin'] = ("time", np.full(track.time.size, basin))
             self.data.append(track)
 
 

--- a/climada/hazard/test/test_tc_tracks.py
+++ b/climada/hazard/test/test_tc_tracks.py
@@ -71,20 +71,6 @@ class TestIbtracs(unittest.TestCase):
         self.assertIn("IDs are not in IBTrACS", str(cm.exception))
         self.assertIn("1988234N13298", str(cm.exception))
 
-    def test_write_read_pass(self):
-        """Test writting and reading netcdf4 TCTracks instances"""
-        path = DATA_DIR.joinpath("tc_tracks_nc")
-        path.mkdir(exist_ok=True)
-        tc_track = tc.TCTracks()
-        tc_track.read_ibtracs_netcdf(provider='usa', storm_id='1988234N13299',
-                                     estimate_missing=True)
-        tc_track.write_netcdf(str(path))
-
-        tc_read = tc.TCTracks()
-        tc_read.read_netcdf(str(path))
-
-        self.assertEqual(tc_track.get_track().sid, tc_read.get_track().sid)
-
     def test_penv_rmax_penv_pass(self):
         """read_ibtracs_netcdf"""
         tc_track = tc.TCTracks()
@@ -300,6 +286,31 @@ class TestIbtracs(unittest.TestCase):
 
 class TestIO(unittest.TestCase):
     """Test reading of tracks from files of different formats"""
+    def test_write_read_netcdf(self):
+        """Test writting and reading netcdf4 TCTracks instances"""
+        path = DATA_DIR.joinpath("tc_tracks_nc")
+        path.mkdir(exist_ok=True)
+        tc_track = tc.TCTracks()
+        tc_track.read_ibtracs_netcdf(provider='usa', storm_id='1988234N13299',
+                                     estimate_missing=True)
+        tc_track.write_netcdf(str(path))
+
+        tc_read = tc.TCTracks()
+        tc_read.read_netcdf(str(path))
+
+        self.assertEqual(tc_track.get_track().sid, tc_read.get_track().sid)
+
+    def test_read_legacy_netcdf(self):
+        """Test reading from NetCDF files with legacy basin attributes"""
+        anti_track = tc.TCTracks()
+        # test data set with two tracks:
+        # * 1980052S16155: crosses the antimeridian
+        # * 2018079S09162: close, but doesn't cross antimeridian; has self-intersections
+        anti_track.read_netcdf(TEST_TRACKS_ANTIMERIDIAN)
+
+        for tr in anti_track.data:
+            self.assertEqual(tr.basin.shape, tr.time.shape)
+            np.testing.assert_array_equal(tr.basin, "SP")
 
     def test_read_processed_ibtracs_csv(self):
         tc_track = tc.TCTracks()

--- a/climada/hazard/trop_cyclone.py
+++ b/climada/hazard/trop_cyclone.py
@@ -443,6 +443,8 @@ class TropCyclone(Hazard):
         ])
         new_haz.orig = np.array([track.orig_event_flag])
         new_haz.category = np.array([track.category])
+        # users that pickle TCTracks objects might still have data with the legacy basin attribute,
+        # so we have to deal with it here
         new_haz.basin = [track.basin if isinstance(track.basin, str)
                          else str(track.basin.values[0])]
         return new_haz


### PR DESCRIPTION
Following #254, this PR makes sure that track data that is read in using `TCTracks.read_netcdf` has a basin variable instead of the legacy basin string attribute.