### PR TITLE
Fix/integr tests lp

### DIFF
--- a/climada/entity/exposures/litpop/nightlight.py
+++ b/climada/entity/exposures/litpop/nightlight.py
@@ -394,7 +394,7 @@ def load_nightlight_nasa(bounds, req_files, year):
             continue
         extent = np.int64(np.clip(extent, 0, tile_size[None] - 1))
 
-        im_nl, _ = read_bm_file(SYSTEM_DIR, fname.replace('*', str(year)))
+        im_nl, _ = read_bm_file(SYSTEM_DIR, fname %(year))
         im_nl = np.flipud(im_nl)
         im_nl = sparse.csc.csc_matrix(im_nl)
         im_nl = im_nl[extent[0, 0]:extent[1, 0] + 1, extent[0, 1]:extent[1, 1] + 1]
@@ -438,8 +438,7 @@ def read_bm_file(bm_path, filename):
         del band1
         return arr1, curr_file
     except Exception as err:
-        raise type(err)(f"Failed to import {path}" + str(err)) from err
-
+        raise type(err)(f"Failed to import {path} " + str(err)) from err
 
 def unzip_tif_to_py(file_gz):
     """Unzip image file, read it, flip the x axis, save values as pickle

--- a/climada/entity/exposures/litpop/nightlight.py
+++ b/climada/entity/exposures/litpop/nightlight.py
@@ -30,6 +30,7 @@ import rasterio
 import numpy as np
 import scipy.sparse as sparse
 import matplotlib.pyplot as plt
+from osgeo import gdal
 from PIL import Image
 from shapefile import Shape
 
@@ -359,6 +360,86 @@ def load_nasa_nl_shape_single_tile(geometry, path, layer=0):
                  "transform": transform})
     src.close()
     return out_image[layer,:,:], meta
+
+def load_nightlight_nasa(bounds, req_files, year):
+    """Get nightlight from NASA repository that contain input boundary.
+
+    Note: Legacy for BlackMarble, not required for litpop module
+
+    Parameters:
+        bounds (tuple): min_lon, min_lat, max_lon, max_lat
+        req_files (np.array): array with flags for NASA files needed
+        year (int): nightlight year
+    Returns:
+        nightlight (sparse.csr_matrix), coord_nl (np.array)
+    """
+    # TODO: argument req_files is not used in this function
+
+    coord_min = np.array([-90, -180]) + NASA_RESOLUTION_DEG / 2
+    coord_h = np.full((2,), NASA_RESOLUTION_DEG)
+
+    min_lon, min_lat, max_lon, max_lat = bounds
+    bounds_mat = np.array([[min_lat, min_lon], [max_lat, max_lon]])
+    global_idx = (bounds_mat - coord_min[None]) / coord_h[None]
+    global_idx[0, :] = np.floor(global_idx[0, :])
+    global_idx[1, :] = np.ceil(global_idx[1, :])
+    tile_size = np.array(NASA_TILE_SIZE)
+
+    nightlight = []
+    for idx, fname in enumerate(BM_FILENAMES):
+        tile_coord = np.array([1 - idx % 2, idx // 2])
+        extent = global_idx - (tile_coord * tile_size)[None]
+        if np.any(extent[1, :] < 0) or np.any(extent[0, :] >= NASA_TILE_SIZE):
+            # this tile does not intersect the specified bounds
+            continue
+        extent = np.int64(np.clip(extent, 0, tile_size[None] - 1))
+
+        im_nl, _ = read_bm_file(SYSTEM_DIR, fname.replace('*', str(year)))
+        im_nl = np.flipud(im_nl)
+        im_nl = sparse.csc.csc_matrix(im_nl)
+        im_nl = im_nl[extent[0, 0]:extent[1, 0] + 1, extent[0, 1]:extent[1, 1] + 1]
+        nightlight.append((tile_coord, im_nl))
+
+    tile_coords = np.array([n[0] for n in nightlight])
+    shape = tile_coords.max(axis=0) - tile_coords.min(axis=0) + 1
+    nightlight = np.array([n[1] for n in nightlight]).reshape(shape, order='F')
+    nightlight = sparse.bmat(np.flipud(nightlight), format='csr')
+
+    coord_nl = np.vstack([coord_min, coord_h]).T
+    coord_nl[:, 0] += global_idx[0, :] * coord_h[:]
+
+    return nightlight, coord_nl
+
+
+def read_bm_file(bm_path, filename):
+    """Reads a single NASA BlackMarble GeoTiff and returns the data. Run all required checks first.
+    Parameters
+
+    Note: Legacy for BlackMarble, not required for litpop module
+
+    ----------
+    bm_path : str
+        absolute path where files are stored.
+    filename : str
+        filename of the file to be read.
+    Returns
+    -------
+    arr1 : array
+        Raw BM data
+    curr_file : gdal GeoTiff File
+        Additional info from which coordinates can be calculated.
+    """
+    path = Path(bm_path, filename)
+    try:
+        LOGGER.debug('Importing %s.', path)
+        curr_file = gdal.Open(str(path))
+        band1 = curr_file.GetRasterBand(1)
+        arr1 = band1.ReadAsArray()
+        del band1
+        return arr1, curr_file
+    except Exception as err:
+        raise type(err)(f"Failed to import {path}" + str(err)) from err
+
 
 def unzip_tif_to_py(file_gz):
     """Unzip image file, read it, flip the x axis, save values as pickle

--- a/climada/test/test_litpop_integr.py
+++ b/climada/test/test_litpop_integr.py
@@ -36,19 +36,19 @@ class TestLitPopExposure(unittest.TestCase):
     def test_netherlands150_pass(self):
         """Test set_countries for Netherlands at 150 arcsec, first shape is empty"""
         ent = lp.LitPop()
-        ent.set_countries('Netherlands', res_arcsec=150)
+        ent.set_countries('Netherlands', res_arcsec=150, reference_year=2016)
         self.assertEqual(ent.gdf.shape[0], 2829)
 
     def test_BLM150_pass(self):
         """Test set_countries for BLM at 150 arcsec, 2 data points"""
         ent = lp.LitPop()
-        ent.set_countries('BLM', res_arcsec=150)
+        ent.set_countries('BLM', res_arcsec=150, reference_year=2016)
         self.assertEqual(ent.gdf.shape[0], 2)
 
     def test_Monaco150_pass(self):
         """Test set_countries for Moncao at 150 arcsec, 1 data point"""
         ent = lp.LitPop()
-        ent.set_countries('Monaco', res_arcsec=150)
+        ent.set_countries('Monaco', res_arcsec=150, reference_year=2016)
         self.assertEqual(ent.gdf.shape[0], 1)
 
     def test_switzerland300_pass(self):

--- a/climada/test/test_osm.py
+++ b/climada/test/test_osm.py
@@ -57,7 +57,7 @@ class TestOpenStreetMapModule(unittest.TestCase):
             exposure_high_47_8 = OSM.get_osmstencil_litpop(
                 [47.2, 8.0, 47.3, 8.07], 'CHE', mode,
                 DATA_DIR.joinpath('High_Value_Area_47_8.shp'),
-                DATA_DIR, check_plot=0)
+                DATA_DIR, check_plot=0, reference_year=2016)
             self.assertIsInstance(exposure_high_47_8, Exposures)
             self.assertEqual(len(exposure_high_47_8.gdf.columns), 8)
             self.assertGreater(
@@ -87,7 +87,8 @@ class TestOpenStreetMapModule(unittest.TestCase):
         # With LitPop values
         buildings_47_8_LitPop = OSM.make_osmexposure(DATA_DIR.joinpath('buildings_47_8.shp'),
                                                      country='CHE', mode="LitPop",
-                                                     save_path=DATA_DIR, check_plot=0)
+                                                     save_path=DATA_DIR, check_plot=0,
+                                                     reference_year=2016)
         self.assertIsInstance(buildings_47_8_LitPop, Exposures)
         self.assertEqual(len(buildings_47_8_LitPop.gdf.columns), 12)
         self.assertEqual(


### PR DESCRIPTION
- fix some more integration test fails on jenkins that were caused by call to GPW v4.11 2020 file not saved on jenkins, by setting reference year close to 2015 (2015 file is available on jenkins)
- restored two accidentially deleted `nightlight` functions that are required for `blackmarble` for legacy reasons: `load_nightlight_nasa` and `read_bm_file`.
