### PR TITLE
TCTracks.generate_centroids

### DIFF
--- a/climada/hazard/base.py
+++ b/climada/hazard/base.py
@@ -1070,6 +1070,8 @@ class Hazard():
         self.clear()
         hf_data = h5py.File(file_name, 'r')
         for (var_name, var_val) in self.__dict__.items():
+            if var_name != 'tag' and var_name not in hf_data.keys():
+                continue
             if var_name == 'centroids':
                 self.centroids.read_hdf5(hf_data.get(var_name))
             elif var_name == 'tag':

--- a/climada/hazard/tc_tracks.py
+++ b/climada/hazard/tc_tracks.py
@@ -56,6 +56,7 @@ import climada.util.coordinates as u_coord
 from climada.util.constants import EARTH_RADIUS_KM, SYSTEM_DIR, DEF_CRS
 from climada.util.files_handler import get_file_names, download_ftp
 import climada.util.plot as u_plot
+from climada.hazard import Centroids
 import climada.hazard.tc_tracks_synth
 
 LOGGER = logging.getLogger(__name__)
@@ -1214,6 +1215,29 @@ class TCTracks():
     def extent(self):
         """Exact extent of trackset as tuple, no buffer."""
         return self.get_extent(deg_buffer=0.0)
+
+    def generate_centroids(self, res_deg, buffer_deg):
+        """Generate gridded centroids within padded bounds of tracks
+
+        Parameters
+        ----------
+        res_deg : float
+            Resolution in degrees.
+        buffer_deg : float
+            Buffer around tracks in degrees.
+
+        Returns
+        -------
+        centroids : Centroids
+            Centroids instance.
+        """
+        bounds = self.get_bounds(deg_buffer=buffer_deg)
+        lat = np.arange(bounds[1] + 0.5 * res_deg, bounds[3], res_deg)
+        lon = np.arange(bounds[0] + 0.5 * res_deg, bounds[2], res_deg)
+        lon, lat = [ar.ravel() for ar in np.meshgrid(lon, lat)]
+        centroids = Centroids()
+        centroids.set_lat_lon(lat, lon)
+        return centroids
 
     def plot(self, axis=None, figsize=(9, 13), legend=True, adapt_fontsize=True, **kwargs):
         """Track over earth. Historical events are blue, probabilistic black.

--- a/climada/hazard/test/test_tc_tracks.py
+++ b/climada/hazard/test/test_tc_tracks.py
@@ -576,6 +576,20 @@ class TestFuncs(unittest.TestCase):
         np.testing.assert_array_almost_equal(tc_track.get_bounds(deg_buffer=0.1), bounds_buf)
         np.testing.assert_array_almost_equal(tc_track.extent, extent)
 
+    def test_generate_centroids(self):
+        """Test centroids generation feature."""
+        storms = ['1988169N14259', '2002073S16161', '2002143S07157']
+        tc_track = tc.TCTracks()
+        tc_track.read_ibtracs_netcdf(storm_id=storms, provider=["usa", "bom"])
+        cen = tc_track.generate_centroids(10, 1)
+        cen_bounds = (157.585022, -19.200001, 257.585022, 10.799999)
+        self.assertEqual(cen.size, 44)
+        self.assertEqual(np.unique(cen.lat).size, 4)
+        self.assertEqual(np.unique(cen.lon).size, 11)
+        np.testing.assert_array_equal(np.diff(np.unique(cen.lat)), 10)
+        np.testing.assert_array_equal(np.diff(np.unique(cen.lon)), 10)
+        np.testing.assert_array_almost_equal(cen.total_bounds, cen_bounds)
+
     def test_interp_track_pass(self):
         """Interpolate track to min_time_step. Compare to MATLAB reference."""
         tc_track = tc.TCTracks()


### PR DESCRIPTION
Originally, this change was part of #245 (now moved to https://github.com/CLIMADA-project/climada_petals/pull/2).

This adds a method `generate_centroids` to the `TCTracks` class that returns a Centroids object covering the region affected by the TC tracks with the specified resolution.