### PR TITLE
Implement Hazard.append/concat without __dict__

### DIFF
--- a/climada/hazard/base.py
+++ b/climada/hazard/base.py
@@ -1399,16 +1399,27 @@ class Hazard():
     def append(self, *others):
         """Append the events and centroids to this hazard object.
 
-        All of the given hazards must be of the same type as self. The centroids of all hazards
-        must have the same CRS.
+        All of the given hazards must be of the same type and use the same units as self. The
+        centroids of all hazards must have the same CRS.
 
-        The centroids of all hazards are combined together. All raster centroids are converted to
-        points and raster data is discarded.
+        The following kinds of object attributes are processed:
+
+        - All centroids are combined together using `Centroids.union`.
+
+        - Lists, 1-dimensional arrays (NumPy) and sparse CSR matrices (SciPy) are concatenated.
+        Sparse matrices are concatenated along the first (vertical) axis.
+
+        - All `tag` attributes are appended to `self.tag`.
+
+        For any other type of attribute: A ValueError is raised if an attribute of that name is
+        not defined in all of the non-empty hazards at least. However, there is no check that the
+        attribute value is identical among the given hazard objects. The initial attribute value of
+        `self` will not be modified.
 
         Note: Each of the hazard's `centroids` attributes might be modified in place in the sense
         that missing properties are added, but existing ones are not overwritten. In case of raster
         centroids, conversion to point centroids is applied so that raster information (meta) is
-        lost.
+        lost. For more information, see `Centroids.union`.
 
         Parameters
         ----------
@@ -1417,11 +1428,12 @@ class Hazard():
 
         Raises
         ------
-        TypeError
+        TypeError, ValueError
 
         See Also
         --------
-        Hazard.concat: concatenate 2 or more hazards
+        Hazard.concat : concatenate 2 or more hazards
+        Centroids.union : combine centroids
         """
         if len(others) == 0:
             return
@@ -1495,30 +1507,24 @@ class Hazard():
         """
         Concatenate events of several hazards of same type.
 
-        Centroids of all hazards must either all be rasters with the same
-        resolution, or all be points.
-
-        The centroids of all hazards are combined together.
-        All raster centroids are converted to points and raster data
-        is discarded.
+        This function creates a new hazard of the same class as the first hazard in the given list
+        and then applies the `append` method. Please refer to the docs of `Hazard.append` for
+        caveats and limitations of the concatenation procedure.
 
         Parameters
         ----------
-        haz_list: list of climada.hazard.Hazard objects
+        haz_list : list of climada.hazard.Hazard objects
             Hazard instances of the same hazard type (subclass).
 
         Returns
         -------
-        haz_concat: instance of climada.hazard.Hazard
+        haz_concat : instance of climada.hazard.Hazard
             This will be of the same type (subclass) as all the hazards in `haz_list`.
-
-        Raises
-        ------
-        ValueError
 
         See Also
         --------
-        hazard.centroids.Centroids.union: combine centroids
+        Hazard.append : append hazards to a hazard in place
+        Centroids.union : combine centroids
         """
         haz_concat = haz_list[0].__class__()
         haz_concat.tag.haz_type = haz_list[0].tag.haz_type

--- a/climada/hazard/base.py
+++ b/climada/hazard/base.py
@@ -1396,22 +1396,23 @@ class Hazard():
         self.intensity = sparse.csr_matrix(dfr.values[:, 1:num_events + 1].transpose())
         self.fraction = sparse.csr_matrix(np.ones(self.intensity.shape, dtype=float))
 
-    def append(self, *haz_list):
+    def append(self, *others):
         """Append the events and centroids to this hazard object.
 
-        All of the given hazards must be of the same type as self.
-        The centroids of all hazards must have the same CRS.
+        All of the given hazards must be of the same type as self. The centroids of all hazards
+        must have the same CRS.
 
-        The centroids of all hazards are combined together.
-        All raster centroids are converted to points and raster data
-        is discarded.
+        The centroids of all hazards are combined together. All raster centroids are converted to
+        points and raster data is discarded.
 
-        Note: `self.centroids` is modified in place and centroid raster information (meta)
-        is destroyed.
+        Note: Each of the hazard's `centroids` attributes might be modified in place in the sense
+        that missing properties are added, but existing ones are not overwritten. In case of raster
+        centroids, conversion to point centroids is applied so that raster information (meta) is
+        lost.
 
         Parameters
         ----------
-        haz_list : one or more climada.hazard.Hazard objects
+        others : one or more climada.hazard.Hazard objects
             Hazard instances to append to self
 
         Raises
@@ -1422,9 +1423,9 @@ class Hazard():
         --------
         Hazard.concat: concatenate 2 or more hazards
         """
-        if len(haz_list) == 0:
+        if len(others) == 0:
             return
-        haz_list = (self,) + haz_list
+        haz_list = [self] + list(others)
         haz_list_nonempty = [haz for haz in haz_list if haz.size > 0]
 
         for haz in haz_list:

--- a/climada/hazard/base.py
+++ b/climada/hazard/base.py
@@ -1457,7 +1457,7 @@ class Hazard():
 
         units = {haz.units for haz in haz_list if haz.units != ''}
         if len(units) > 1:
-            raise ValueError(f"The hazards use different units: {units}. "
+            raise ValueError(f"The given hazards use different units: {units}. "
                              "The hazards are incompatible and cannot be concatenated.")
         elif len(units) == 0:
             units = {''}
@@ -1502,8 +1502,8 @@ class Hazard():
         self.sanitize_event_ids()
 
 
-    @staticmethod
-    def concat(haz_list):
+    @classmethod
+    def concat(cls, haz_list):
         """
         Concatenate events of several hazards of same type.
 
@@ -1513,6 +1513,12 @@ class Hazard():
 
         For centroids, tags, lists, arrays and sparse matrices, the remarks in `Hazard.append`
         apply. All other attributes are copied from the first object in `haz_list`.
+
+        Note that `Hazard.concat` can be used to concatenate hazards of a subclass. The result's
+        type will be the subclass. However, calling `concat([])` (with an empty list) is equivalent
+        to instantiation without init parameters. So, `Hazard.concat([])` is equivalent to
+        `Hazard()`. If `HazardB` is a subclass of `Hazard`, then `HazardB.concat([])` is equivalent
+        to `HazardB()` (unless `HazardB` overrides the `concat` method).
 
         Parameters
         ----------
@@ -1529,6 +1535,8 @@ class Hazard():
         Hazard.append : append hazards to a hazard in place
         Centroids.union : combine centroids
         """
+        if len(haz_list) == 0:
+            return cls()
         haz_concat = haz_list[0].__class__()
         haz_concat.tag.haz_type = haz_list[0].tag.haz_type
         for attr_name, attr_val in vars(haz_list[0]).items():

--- a/climada/hazard/base.py
+++ b/climada/hazard/base.py
@@ -1540,7 +1540,8 @@ class Hazard():
         haz_concat = haz_list[0].__class__()
         haz_concat.tag.haz_type = haz_list[0].tag.haz_type
         for attr_name, attr_val in vars(haz_list[0]).items():
-            # only copy simple attributes like "units" to save memory
+            # to save memory, only copy simple attributes like
+            # "units" that are not explicitly handled by Hazard.append 
             if not (isinstance(attr_val, (list, np.ndarray, sparse.csr.csr_matrix))
                     or attr_name in ["tag", "centroids"]):
                 setattr(haz_concat, attr_name, copy.deepcopy(attr_val))

--- a/climada/hazard/base.py
+++ b/climada/hazard/base.py
@@ -1439,8 +1439,8 @@ class Hazard():
 
         haz_classes = {type(haz) for haz in haz_list}
         if len(haz_classes) > 1:
-            raise TypeError(f"The given hazards of different classes: {haz_classes}. "
-                             "The hazards are incompatible and cannot be concatenated.")
+            raise TypeError(f"The given hazards are of different classes: {haz_classes}. "
+                            "The hazards are incompatible and cannot be concatenated.")
 
         units = {haz.units for haz in haz_list if haz.units != ''}
         if len(units) > 1:

--- a/climada/hazard/base.py
+++ b/climada/hazard/base.py
@@ -1511,6 +1511,9 @@ class Hazard():
         and then applies the `append` method. Please refer to the docs of `Hazard.append` for
         caveats and limitations of the concatenation procedure.
 
+        For centroids, tags, lists, arrays and sparse matrices, the remarks in `Hazard.append`
+        apply. All other attributes are copied from the first object in `haz_list`.
+
         Parameters
         ----------
         haz_list : list of climada.hazard.Hazard objects
@@ -1528,7 +1531,11 @@ class Hazard():
         """
         haz_concat = haz_list[0].__class__()
         haz_concat.tag.haz_type = haz_list[0].tag.haz_type
-        haz_concat.units = haz_list[0].units
+        for attr_name, attr_val in vars(haz_list[0]).items():
+            # only copy simple attributes like "units" to save memory
+            if not (isinstance(attr_val, (list, np.ndarray, sparse.csr.csr_matrix))
+                    or attr_name in ["tag", "centroids"]):
+                setattr(haz_concat, attr_name, copy.deepcopy(attr_val))
         haz_concat.append(*haz_list)
         return haz_concat
 

--- a/climada/hazard/test/test_base.py
+++ b/climada/hazard/test/test_base.py
@@ -925,15 +925,15 @@ class TestReaderExcel(unittest.TestCase):
         self.assertEqual(hazard.event_name[50], 'event051')
         self.assertEqual(hazard.event_name[-1], 'event100')
 
-        self.assertEqual(hazard.frequency.dtype, np.float)
+        self.assertEqual(hazard.frequency.dtype, float)
         self.assertEqual(hazard.frequency.shape, (n_events,))
         self.assertEqual(hazard.frequency[0], 0.01)
         self.assertEqual(hazard.frequency[n_events - 2], 0.001)
 
-        self.assertEqual(hazard.intensity.dtype, np.float)
+        self.assertEqual(hazard.intensity.dtype, float)
         self.assertEqual(hazard.intensity.shape, (n_events, n_centroids))
 
-        self.assertEqual(hazard.fraction.dtype, np.float)
+        self.assertEqual(hazard.fraction.dtype, float)
         self.assertEqual(hazard.fraction.shape, (n_events, n_centroids))
         self.assertEqual(hazard.fraction[0, 0], 1)
         self.assertEqual(hazard.fraction[10, 19], 1)
@@ -966,15 +966,15 @@ class TestReaderMat(unittest.TestCase):
         self.assertEqual(hazard.event_id.dtype, int)
         self.assertEqual(hazard.event_id.shape, (n_events,))
 
-        self.assertEqual(hazard.frequency.dtype, np.float)
+        self.assertEqual(hazard.frequency.dtype, float)
         self.assertEqual(hazard.frequency.shape, (n_events,))
 
-        self.assertEqual(hazard.intensity.dtype, np.float)
+        self.assertEqual(hazard.intensity.dtype, float)
         self.assertEqual(hazard.intensity.shape, (n_events, n_centroids))
         self.assertEqual(hazard.intensity[12, 46], 12.071393519949979)
         self.assertEqual(hazard.intensity[13676, 49], 17.228323602220616)
 
-        self.assertEqual(hazard.fraction.dtype, np.float)
+        self.assertEqual(hazard.fraction.dtype, float)
         self.assertEqual(hazard.fraction.shape, (n_events, n_centroids))
         self.assertEqual(hazard.fraction[8454, 98], 1)
         self.assertEqual(hazard.fraction[85, 54], 0)


### PR DESCRIPTION
As noted in a discussion about #268, the use of `__dict__` in `Hazard.append` is avoidable. This PR shows how we can avoid it while being 100% backwards compatible.

I did some performance improvements, bug fixes and cleanups along the way. 

To avoid the use of `__dict__` in `TropCyclone.set_from_tracks`, see #272.