### PR TITLE
Implement TropCyclone.from_track without __dict__

### DIFF
--- a/climada/hazard/base.py
+++ b/climada/hazard/base.py
@@ -1399,16 +1399,27 @@ class Hazard():
     def append(self, *others):
         """Append the events and centroids to this hazard object.
 
-        All of the given hazards must be of the same type as self. The centroids of all hazards
-        must have the same CRS.
+        All of the given hazards must be of the same type and use the same units as self. The
+        centroids of all hazards must have the same CRS.
 
-        The centroids of all hazards are combined together. All raster centroids are converted to
-        points and raster data is discarded.
+        The following kinds of object attributes are processed:
+
+        - All centroids are combined together using `Centroids.union`.
+
+        - Lists, 1-dimensional arrays (NumPy) and sparse CSR matrices (SciPy) are concatenated.
+        Sparse matrices are concatenated along the first (vertical) axis.
+
+        - All `tag` attributes are appended to `self.tag`.
+
+        For any other type of attribute: A ValueError is raised if an attribute of that name is
+        not defined in all of the non-empty hazards at least. However, there is no check that the
+        attribute value is identical among the given hazard objects. The initial attribute value of
+        `self` will not be modified.
 
         Note: Each of the hazard's `centroids` attributes might be modified in place in the sense
         that missing properties are added, but existing ones are not overwritten. In case of raster
         centroids, conversion to point centroids is applied so that raster information (meta) is
-        lost.
+        lost. For more information, see `Centroids.union`.
 
         Parameters
         ----------
@@ -1417,11 +1428,12 @@ class Hazard():
 
         Raises
         ------
-        TypeError
+        TypeError, ValueError
 
         See Also
         --------
-        Hazard.concat: concatenate 2 or more hazards
+        Hazard.concat : concatenate 2 or more hazards
+        Centroids.union : combine centroids
         """
         if len(others) == 0:
             return
@@ -1495,30 +1507,24 @@ class Hazard():
         """
         Concatenate events of several hazards of same type.
 
-        Centroids of all hazards must either all be rasters with the same
-        resolution, or all be points.
-
-        The centroids of all hazards are combined together.
-        All raster centroids are converted to points and raster data
-        is discarded.
+        This function creates a new hazard of the same class as the first hazard in the given list
+        and then applies the `append` method. Please refer to the docs of `Hazard.append` for
+        caveats and limitations of the concatenation procedure.
 
         Parameters
         ----------
-        haz_list: list of climada.hazard.Hazard objects
+        haz_list : list of climada.hazard.Hazard objects
             Hazard instances of the same hazard type (subclass).
 
         Returns
         -------
-        haz_concat: instance of climada.hazard.Hazard
+        haz_concat : instance of climada.hazard.Hazard
             This will be of the same type (subclass) as all the hazards in `haz_list`.
-
-        Raises
-        ------
-        ValueError
 
         See Also
         --------
-        hazard.centroids.Centroids.union: combine centroids
+        Hazard.append : append hazards to a hazard in place
+        Centroids.union : combine centroids
         """
         haz_concat = haz_list[0].__class__()
         haz_concat.tag.haz_type = haz_list[0].tag.haz_type

--- a/climada/hazard/base.py
+++ b/climada/hazard/base.py
@@ -1396,22 +1396,23 @@ class Hazard():
         self.intensity = sparse.csr_matrix(dfr.values[:, 1:num_events + 1].transpose())
         self.fraction = sparse.csr_matrix(np.ones(self.intensity.shape, dtype=float))
 
-    def append(self, *haz_list):
+    def append(self, *others):
         """Append the events and centroids to this hazard object.
 
-        All of the given hazards must be of the same type as self.
-        The centroids of all hazards must have the same CRS.
+        All of the given hazards must be of the same type as self. The centroids of all hazards
+        must have the same CRS.
 
-        The centroids of all hazards are combined together.
-        All raster centroids are converted to points and raster data
-        is discarded.
+        The centroids of all hazards are combined together. All raster centroids are converted to
+        points and raster data is discarded.
 
-        Note: `self.centroids` is modified in place and centroid raster information (meta)
-        is destroyed.
+        Note: Each of the hazard's `centroids` attributes might be modified in place in the sense
+        that missing properties are added, but existing ones are not overwritten. In case of raster
+        centroids, conversion to point centroids is applied so that raster information (meta) is
+        lost.
 
         Parameters
         ----------
-        haz_list : one or more climada.hazard.Hazard objects
+        others : one or more climada.hazard.Hazard objects
             Hazard instances to append to self
 
         Raises
@@ -1422,9 +1423,9 @@ class Hazard():
         --------
         Hazard.concat: concatenate 2 or more hazards
         """
-        if len(haz_list) == 0:
+        if len(others) == 0:
             return
-        haz_list = (self,) + haz_list
+        haz_list = [self] + list(others)
         haz_list_nonempty = [haz for haz in haz_list if haz.size > 0]
 
         for haz in haz_list:

--- a/climada/hazard/base.py
+++ b/climada/hazard/base.py
@@ -1457,7 +1457,7 @@ class Hazard():
 
         units = {haz.units for haz in haz_list if haz.units != ''}
         if len(units) > 1:
-            raise ValueError(f"The hazards use different units: {units}. "
+            raise ValueError(f"The given hazards use different units: {units}. "
                              "The hazards are incompatible and cannot be concatenated.")
         elif len(units) == 0:
             units = {''}
@@ -1502,8 +1502,8 @@ class Hazard():
         self.sanitize_event_ids()
 
 
-    @staticmethod
-    def concat(haz_list):
+    @classmethod
+    def concat(cls, haz_list):
         """
         Concatenate events of several hazards of same type.
 
@@ -1513,6 +1513,12 @@ class Hazard():
 
         For centroids, tags, lists, arrays and sparse matrices, the remarks in `Hazard.append`
         apply. All other attributes are copied from the first object in `haz_list`.
+
+        Note that `Hazard.concat` can be used to concatenate hazards of a subclass. The result's
+        type will be the subclass. However, calling `concat([])` (with an empty list) is equivalent
+        to instantiation without init parameters. So, `Hazard.concat([])` is equivalent to
+        `Hazard()`. If `HazardB` is a subclass of `Hazard`, then `HazardB.concat([])` is equivalent
+        to `HazardB()` (unless `HazardB` overrides the `concat` method).
 
         Parameters
         ----------
@@ -1529,6 +1535,8 @@ class Hazard():
         Hazard.append : append hazards to a hazard in place
         Centroids.union : combine centroids
         """
+        if len(haz_list) == 0:
+            return cls()
         haz_concat = haz_list[0].__class__()
         haz_concat.tag.haz_type = haz_list[0].tag.haz_type
         for attr_name, attr_val in vars(haz_list[0]).items():

--- a/climada/hazard/base.py
+++ b/climada/hazard/base.py
@@ -1439,8 +1439,8 @@ class Hazard():
 
         haz_classes = {type(haz) for haz in haz_list}
         if len(haz_classes) > 1:
-            raise TypeError(f"The given hazards of different classes: {haz_classes}. "
-                             "The hazards are incompatible and cannot be concatenated.")
+            raise TypeError(f"The given hazards are of different classes: {haz_classes}. "
+                            "The hazards are incompatible and cannot be concatenated.")
 
         units = {haz.units for haz in haz_list if haz.units != ''}
         if len(units) > 1:

--- a/climada/hazard/base.py
+++ b/climada/hazard/base.py
@@ -159,6 +159,8 @@ class Hazard():
         ----------
         haz_type : str, optional
             acronym of the hazard type (e.g. 'TC').
+        pool : pathos.pool, optional
+            Pool that will be used for parallel computation when applicable. Default: None
 
         Examples
         --------

--- a/climada/hazard/base.py
+++ b/climada/hazard/base.py
@@ -1511,6 +1511,9 @@ class Hazard():
         and then applies the `append` method. Please refer to the docs of `Hazard.append` for
         caveats and limitations of the concatenation procedure.
 
+        For centroids, tags, lists, arrays and sparse matrices, the remarks in `Hazard.append`
+        apply. All other attributes are copied from the first object in `haz_list`.
+
         Parameters
         ----------
         haz_list : list of climada.hazard.Hazard objects
@@ -1528,7 +1531,11 @@ class Hazard():
         """
         haz_concat = haz_list[0].__class__()
         haz_concat.tag.haz_type = haz_list[0].tag.haz_type
-        haz_concat.units = haz_list[0].units
+        for attr_name, attr_val in vars(haz_list[0]).items():
+            # only copy simple attributes like "units" to save memory
+            if not (isinstance(attr_val, (list, np.ndarray, sparse.csr.csr_matrix))
+                    or attr_name in ["tag", "centroids"]):
+                setattr(haz_concat, attr_name, copy.deepcopy(attr_val))
         haz_concat.append(*haz_list)
         return haz_concat
 

--- a/climada/hazard/tc_tracks.py
+++ b/climada/hazard/tc_tracks.py
@@ -1430,7 +1430,7 @@ class TCTracks():
                 lon[lon < 0] += 360
 
             time_step = pd.tseries.frequencies.to_offset(pd.Timedelta(hours=time_step_h)).freqstr
-            track_int = track.resample(time=time_step, keep_attrs=True, skipna=True)\
+            track_int = track.resample(time=time_step, skipna=True)\
                              .interpolate('linear')
             track_int['basin'] = track.basin.resample(time=time_step).nearest()
             track_int['time_step'][:] = time_step_h

--- a/climada/hazard/test/test_base.py
+++ b/climada/hazard/test/test_base.py
@@ -925,15 +925,15 @@ class TestReaderExcel(unittest.TestCase):
         self.assertEqual(hazard.event_name[50], 'event051')
         self.assertEqual(hazard.event_name[-1], 'event100')
 
-        self.assertEqual(hazard.frequency.dtype, np.float)
+        self.assertEqual(hazard.frequency.dtype, float)
         self.assertEqual(hazard.frequency.shape, (n_events,))
         self.assertEqual(hazard.frequency[0], 0.01)
         self.assertEqual(hazard.frequency[n_events - 2], 0.001)
 
-        self.assertEqual(hazard.intensity.dtype, np.float)
+        self.assertEqual(hazard.intensity.dtype, float)
         self.assertEqual(hazard.intensity.shape, (n_events, n_centroids))
 
-        self.assertEqual(hazard.fraction.dtype, np.float)
+        self.assertEqual(hazard.fraction.dtype, float)
         self.assertEqual(hazard.fraction.shape, (n_events, n_centroids))
         self.assertEqual(hazard.fraction[0, 0], 1)
         self.assertEqual(hazard.fraction[10, 19], 1)
@@ -966,15 +966,15 @@ class TestReaderMat(unittest.TestCase):
         self.assertEqual(hazard.event_id.dtype, int)
         self.assertEqual(hazard.event_id.shape, (n_events,))
 
-        self.assertEqual(hazard.frequency.dtype, np.float)
+        self.assertEqual(hazard.frequency.dtype, float)
         self.assertEqual(hazard.frequency.shape, (n_events,))
 
-        self.assertEqual(hazard.intensity.dtype, np.float)
+        self.assertEqual(hazard.intensity.dtype, float)
         self.assertEqual(hazard.intensity.shape, (n_events, n_centroids))
         self.assertEqual(hazard.intensity[12, 46], 12.071393519949979)
         self.assertEqual(hazard.intensity[13676, 49], 17.228323602220616)
 
-        self.assertEqual(hazard.fraction.dtype, np.float)
+        self.assertEqual(hazard.fraction.dtype, float)
         self.assertEqual(hazard.fraction.shape, (n_events, n_centroids))
         self.assertEqual(hazard.fraction[8454, 98], 1)
         self.assertEqual(hazard.fraction[85, 54], 0)

--- a/climada/hazard/test/test_trop_cyclone.py
+++ b/climada/hazard/test/test_trop_cyclone.py
@@ -65,9 +65,8 @@ class TestReader(unittest.TestCase):
         tc_track.data = tc_track.data[:1]
 
         for metric in ["equirect", "geosphere"]:
-            tc_haz = TropCyclone()
-            tc_haz.set_from_tracks(tc_track, centroids=CENTR_TEST_BRB, model='H08',
-                                   store_windfields=True, metric=metric)
+            tc_haz = TropCyclone.from_tracks(tc_track, centroids=CENTR_TEST_BRB, model='H08',
+                                             store_windfields=True, metric=metric)
 
             self.assertEqual(tc_haz.tag.haz_type, 'TC')
             self.assertEqual(tc_haz.tag.description, '')
@@ -125,8 +124,7 @@ class TestReader(unittest.TestCase):
         tc_track.data = tc_track.data[:1]
 
         for model in ["H08", "H10", "H1980"]:
-            tc_haz = TropCyclone()
-            tc_haz.set_from_tracks(tc_track, centroids=CENTR_TEST_BRB, model=model)
+            tc_haz = TropCyclone.from_tracks(tc_track, centroids=CENTR_TEST_BRB, model=model)
             np.testing.assert_array_almost_equal(
                 tc_haz.intensity[0, intensity_idx].toarray()[0], intensity_values[model])
             for idx, val in zip(intensity_idx, intensity_values[model]):
@@ -134,11 +132,10 @@ class TestReader(unittest.TestCase):
                     self.assertEqual(tc_haz.intensity[0, idx], 0)
 
     def test_set_one_file_pass(self):
-        """Test set function set_from_tracks with one input."""
+        """Test from_tracks with one input."""
         tc_track = TCTracks()
         tc_track.read_processed_ibtracs_csv(TEST_TRACK_SHORT)
-        tc_haz = TropCyclone()
-        tc_haz.set_from_tracks(tc_track, CENTR_TEST_BRB)
+        tc_haz = TropCyclone.from_tracks(tc_track, centroids=CENTR_TEST_BRB)
         tc_haz.check()
 
         self.assertEqual(tc_haz.tag.haz_type, 'TC')
@@ -163,11 +160,10 @@ class TestReader(unittest.TestCase):
         self.assertEqual(tc_haz.intensity.nonzero()[0].size, 0)
 
     def test_two_files_pass(self):
-        """Test set function set_from_tracks with two ibtracs."""
+        """Test from_tracks with two ibtracs."""
         tc_track = TCTracks()
         tc_track.read_processed_ibtracs_csv([TEST_TRACK_SHORT, TEST_TRACK_SHORT])
-        tc_haz = TropCyclone()
-        tc_haz.set_from_tracks(tc_track, CENTR_TEST_BRB)
+        tc_haz = TropCyclone.from_tracks(tc_track, centroids=CENTR_TEST_BRB)
         tc_haz.remove_duplicates()
         tc_haz.check()
 

--- a/climada/hazard/trop_cyclone.py
+++ b/climada/hazard/trop_cyclone.py
@@ -54,6 +54,9 @@ CENTR_NODE_MAX_DIST_KM = 300
 CENTR_NODE_MAX_DIST_DEG = 5.5
 """Maximum distance between centroid and TC track node in degrees"""
 
+DEF_INTENSITY_THRES = 17.5
+"""Wind speeds (in m/s) below this threshold are stored as 0 if no other threshold is specified."""
+
 MODEL_VANG = {'H08': 0, 'H1980': 1, 'H10': 2}
 """Enumerate different symmetric wind field models."""
 
@@ -99,7 +102,7 @@ class TropCyclone(Hazard):
         'SP' Southern Pacific
         'SA' South Atlantic
     """
-    intensity_thres = 17.5
+    intensity_thres = DEF_INTENSITY_THRES
     """intensity threshold for storage in m/s"""
 
     vars_opt = Hazard.vars_opt.union({'category'})
@@ -117,9 +120,19 @@ class TropCyclone(Hazard):
         else:
             self.pool = None
 
-    def set_from_tracks(self, tracks, centroids=None, description='',
-                        model='H08', ignore_distance_to_coast=False,
-                        store_windfields=False, metric="equirect"):
+    def set_from_tracks(self, *args, **kwargs):
+        """This function is deprecated, use TropCyclone.from_tracks instead."""
+        LOGGER.warning("The use of TropCyclone.set_from_tracks is deprecated."
+                       "Use TropCyclone.from_tracks instead.")
+        if "intensity_thres" not in kwargs:
+            # some users modify the threshold attribute before calling `set_from_tracks`
+            kwargs["intensity_thres"] = self.intensity_thres
+        self.__dict__ = TropCyclone.from_tracks(*args, **kwargs).__dict__
+
+    @staticmethod
+    def from_tracks(tracks, centroids=None, pool=None, description='', model='H08',
+                    ignore_distance_to_coast=False, store_windfields=False, metric="equirect",
+                    intensity_thres=DEF_INTENSITY_THRES):
         """
         Clear and fill with windfields from specified tracks.
 
@@ -162,6 +175,8 @@ class TropCyclone(Hazard):
               large distances and high latitudes.
             * "geosphere": Exact spherical distance. Much more accurate at all distances, but slow.
             Default: "equirect".
+        intensity_thres : float, optional
+            Wind speeds (in m/s) below this threshold are stored as 0. Default: 17.5
 
         Raises
         ------
@@ -197,15 +212,16 @@ class TropCyclone(Hazard):
 
         LOGGER.info('Mapping %s tracks to %s coastal centroids.', str(tracks.size),
                     str(coastal_idx.size))
-        if self.pool:
-            chunksize = min(num_tracks // self.pool.ncpus, 1000)
-            tc_haz = self.pool.map(
-                self._tc_from_track, tracks.data,
+        if pool:
+            chunksize = min(num_tracks // pool.ncpus, 1000)
+            tc_haz = pool.map(
+                TropCyclone.from_single_track, tracks.data,
                 itertools.repeat(centroids, num_tracks),
                 itertools.repeat(coastal_idx, num_tracks),
                 itertools.repeat(model, num_tracks),
                 itertools.repeat(store_windfields, num_tracks),
                 itertools.repeat(metric, num_tracks),
+                itertools.repeat(intensity_thres, num_tracks),
                 chunksize=chunksize)
         else:
             last_perc = 0
@@ -216,16 +232,20 @@ class TropCyclone(Hazard):
                     LOGGER.info("Progress: %d%%", perc)
                     last_perc = perc
                 tc_haz.append(
-                    self._tc_from_track(track, centroids, coastal_idx,
-                                        model=model, store_windfields=store_windfields,
-                                        metric=metric))
+                    TropCyclone.from_single_track(track, centroids, coastal_idx,
+                                                  model=model, store_windfields=store_windfields,
+                                                  metric=metric, intensity_thres=intensity_thres))
             if last_perc < 100:
                 LOGGER.info("Progress: 100%")
-        LOGGER.debug('Append events.')
-        self.__dict__ = TropCyclone.concat([self] + tc_haz).__dict__
+
+        LOGGER.debug('Concatenate events.')
+        haz = TropCyclone.concat(tc_haz)
+        haz.pool = pool
+        haz.intensity_thres = intensity_thres
         LOGGER.debug('Compute frequency.')
-        self.frequency_from_tracks(tracks.data)
-        self.tag.description = description
+        haz.frequency_from_tracks(tracks.data)
+        haz.tag.description = description
+        return haz
 
     def set_climate_scenario_knu(self, ref_year=2050, rcp_scenario=45):
         """
@@ -327,8 +347,7 @@ class TropCyclone(Hazard):
             tr_coord['lat'].append(tr_sel.data[0].lat.values[:-1])
             tr_coord['lon'].append(tr_sel.data[0].lon.values[:-1])
 
-            tc_tmp = TropCyclone()
-            tc_tmp.set_from_tracks(tr_sel, centroids)
+            tc_tmp = TropCyclone.from_tracks(tr_sel, centroids=centroids)
             tc_tmp.event_name = [
                 track.name + ' ' + time.strftime(
                     "%d %h %Y %H:%M",
@@ -379,8 +398,10 @@ class TropCyclone(Hazard):
         ens_size = (self.event_id.size / num_orig) if num_orig > 0 else 1
         self.frequency = np.ones(self.event_id.size) / (year_delta * ens_size)
 
-    def _tc_from_track(self, track, centroids, coastal_idx, model='H08',
-                       store_windfields=False, metric="equirect"):
+    @staticmethod
+    def from_single_track(track, centroids, coastal_idx, model='H08',
+                          store_windfields=False, metric="equirect",
+                          intensity_thres=DEF_INTENSITY_THRES):
         """
         Generate windfield hazard from a single track dataset
 
@@ -402,6 +423,8 @@ class TropCyclone(Hazard):
             Specify an approximation method to use for earth distances: "equirect" (faster) or
             "geosphere" (more accurate). See `dist_approx` function in `climada.util.coordinates`.
             Default: "equirect".
+        intensity_thres : float, optional
+            Wind speeds (in m/s) below this threshold are stored as 0. Default: 17.5
 
         Raises
         ------
@@ -423,7 +446,7 @@ class TropCyclone(Hazard):
         npositions = windfields.shape[0]
 
         intensity = np.linalg.norm(windfields, axis=-1).max(axis=0)
-        intensity[intensity < self.intensity_thres] = 0
+        intensity[intensity < intensity_thres] = 0
         intensity_sparse = sparse.csr_matrix(
             (intensity, reachable_coastal_centr_idx, [0, intensity.size]),
             shape=(1, ncentroids))
@@ -431,6 +454,7 @@ class TropCyclone(Hazard):
 
         new_haz = TropCyclone()
         new_haz.tag = TagHazard(HAZ_TYPE, 'Name: ' + track.name)
+        new_haz.intensity_thres = intensity_thres
         new_haz.intensity = intensity_sparse
         if store_windfields:
             n_reachable_coastal_centr = reachable_coastal_centr_idx.size

--- a/doc/tutorial/1_main_climada.ipynb
+++ b/doc/tutorial/1_main_climada.ipynb
@@ -298,7 +298,7 @@
     "\n",
     "### Hazard footprint\n",
     "\n",
-    "Now we're ready to create our hazard object. This will be a `TropCyclone` class, which inherits from the `Hazard` class, and has the `set_from_tracks` method to create hazard from a `TCTracks` object at given centroids."
+    "Now we're ready to create our hazard object. This will be a `TropCyclone` class, which inherits from the `Hazard` class, and has the `from_tracks` constructor method to create a hazard from a `TCTracks` object at given centroids."
    ]
   },
   {
@@ -376,8 +376,7 @@
    "source": [
     "from climada.hazard import TropCyclone\n",
     "\n",
-    "haz = TropCyclone()\n",
-    "haz.set_from_tracks(tracks, cent)\n",
+    "haz = TropCyclone.from_tracks(tracks, centroids=cent)\n",
     "haz.check()"
    ]
   },

--- a/doc/tutorial/climada_engine_Impact.ipynb
+++ b/doc/tutorial/climada_engine_Impact.ipynb
@@ -575,8 +575,7 @@
    ],
    "source": [
     "# Using the tracks, compute the windspeed at the location of the centroids\n",
-    "tc = TropCyclone()\n",
-    "tc.set_from_tracks(ibtracks_na, centrs)\n",
+    "tc = TropCyclone.from_tracks(ibtracks_na, centroids=centrs)\n",
     "tc.check()"
    ]
   },
@@ -1226,8 +1225,7 @@
     "# compute Hazard in that centroids\n",
     "tr_pnt = TCTracks()\n",
     "tr_pnt.read_ibtracs_netcdf(storm_id='2007314N10093')\n",
-    "tc_pnt = TropCyclone()\n",
-    "tc_pnt.set_from_tracks(tr_pnt, centroids=centr_pnt)\n",
+    "tc_pnt = TropCyclone.from_tracks(tr_pnt, centroids=centr_pnt)\n",
     "tc_pnt.check()\n",
     "ax_pnt = tc_pnt.centroids.plot(c=np.array(tc_pnt.intensity[0,:].todense()).squeeze()) # plot intensity per point\n",
     "ax_pnt.get_figure().colorbar(ax_pnt.collections[0], fraction=0.0175, pad=0.02).set_label('Intensity (m/s)') # add colorbar\n",

--- a/doc/tutorial/climada_hazard_TropCyclone.ipynb
+++ b/doc/tutorial/climada_hazard_TropCyclone.ipynb
@@ -1854,7 +1854,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The `TropCyclone` class is a derived class of [Hazard](climada_hazard_Hazard.ipynb). As such, it contains all the attributes and methods of a `Hazard`. Additionally, it contains the method `set_from_tracks()` to model tropical cyclones from tracks contained in a `TCTracks` instance. \n",
+    "The `TropCyclone` class is a derived class of [Hazard](climada_hazard_Hazard.ipynb). As such, it contains all the attributes and methods of a `Hazard`. Additionally, it comes with the constructor method `from_tracks` to model tropical cyclones from tracks contained in a `TCTracks` instance. \n",
     "\n",
     "When setting tropical cyclones from tracks, the centroids where to map the wind gusts (the hazard intensity) can be provided. If no centroids are provided, the global centroids `GLB_NatID_grid_0360as_adv_2.mat` are used. \n",
     "\n",
@@ -1954,12 +1954,11 @@
     "cent.plot()\n",
     "\n",
     "# construct tropical cyclones\n",
-    "tc_irma = TropCyclone()\n",
-    "tc_irma.set_from_tracks(tr_irma, centroids=cent)\n",
-    "#tc_irma.set_from_tracks(tr_irma) # try without given centroids\n",
+    "tc_irma = TropCyclone.from_tracks(tr_irma, centroids=cent)\n",
+    "# tc_irma = TropCyclone.from_tracks(tr_irma)  # try without given centroids\n",
     "tc_irma.check()\n",
-    "tc_irma.plot_intensity('2017242N16333')      # IRMA\n",
-    "tc_irma.plot_intensity('2017242N16333_gen2') # IRMA's synthetic track 2"
+    "tc_irma.plot_intensity('2017242N16333')  # IRMA\n",
+    "tc_irma.plot_intensity('2017242N16333_gen2')  # IRMA's synthetic track 2"
    ]
   },
   {
@@ -2020,8 +2019,7 @@
    ],
    "source": [
     "# an Irma event-like in 2055 under RCP 4.5:\n",
-    "tc_irma = TropCyclone()\n",
-    "tc_irma.set_from_tracks(tr_irma, centroids=cent)\n",
+    "tc_irma = TropCyclone.from_tracks(tr_irma, centroids=cent)\n",
     "tc_irma_cc = tc_irma.set_climate_scenario_knu(ref_year=2055, rcp_scenario=45)\n",
     "tc_irma_cc.plot_intensity('2017242N16333')"
    ]
@@ -2071,8 +2069,7 @@
     "#centr = Centroids()\n",
     "#centr.set_raster_from_pnt_bounds((lon_min, lat_min, lon_max, lat_max), 0.1)\n",
     "\n",
-    "#tc_haz = TropCyclone(pool) # provide the pool in the constructor   \n",
-    "#tc_haz.set_from_tracks(tc_track, centr)\n",
+    "#tc_haz = TropCyclone.from_tracks(tc_track, centroids=centr, pool=pool)  # provide the pool in the constructor\n",
     "#tc_haz.check()\n",
     "\n",
     "#pool.close()\n",


### PR DESCRIPTION
As noted in a discussion about #268, the use of `__dict__` in `TropCyclone.set_from_tracks` is avoidable. This PR shows how we can avoid it by introducing a static constructor method `TropCyclone.from_tracks`. While `set_from_tracks` is not removed for backwards compatibility, it is deprecated and replaced by `from_tracks` in all of the tutorials.

This PR is based on #271, so make sure to merge that before looking into this one.