### PR TITLE
Remove unreachable code in Measure class

### DIFF
--- a/climada/entity/measures/base.py
+++ b/climada/entity/measures/base.py
@@ -140,8 +140,6 @@ class Measure():
             resulting impact and risk transfer of measure
         """
 
-        new_exp, new_ifs, new_haz = self.apply(exposures, imp_fun_set, hazard)
-        return self._calc_impact(new_exp, new_ifs, new_haz)
         new_exp, new_impfs, new_haz = self.apply(exposures, imp_fun_set, hazard)
         return self._calc_impact(new_exp, new_impfs, new_haz)
 


### PR DESCRIPTION
I assume this is a leftover from the grand if -> impf renaming.

The `Measure.calc_impact` method has a return statement part-way through, with the remainder of the code unreachable, and just a repeat of the earlier code with an intermediate variable renamed from `new_ifs` to `new_impfs`.

I assume it's safe to drop this part!