### PR TITLE
Let Exposures.concat set category_id

### DIFF
--- a/climada/entity/exposures/base.py
+++ b/climada/entity/exposures/base.py
@@ -891,15 +891,15 @@ class Exposures():
             u_coord.write_raster(file_name, raster, meta)
 
     @staticmethod
-    def concat(exposures_list, category_ids=None):
+    def concat(exposures_list, category_id_list=None):
         """Concatenates Exposures or DataFrame objects to one Exposures object.
 
         Parameters
         ----------
         exposures_list : list of Exposures or DataFrames
             The list must not be empty with the first item supposed to be an Exposures object.
-        category_ids : list of str or int, optional
-            If provided, the value of the category_id column in each input exposure is set to the corresponding value
+        category_id_list : list of str or int, optional
+            If provided, each input exposure's category_id column is set to the corresponding value
             in this list. The list must be of the same length as exposures_list. Default None.
 
         Returns
@@ -917,10 +917,10 @@ class Exposures():
             ex.gdf if isinstance(ex, Exposures) else ex
             for ex in exposures_list
         ]
-        if category_ids:
-            if not isinstance(category_ids, list):
+        if category_id_list:
+            if not isinstance(category_id_list, list):
                 raise TypeError("category_ids must be a list")
-            df_list = [gdf.assign(category_id=category_ids[i]) for i, gdf in enumerate(df_list)]
+            df_list = [gdf.assign(category_id=category_id_list[i]) for i, gdf in enumerate(df_list)]
 
         crss = [
             ex.crs for ex in exposures_list

--- a/climada/entity/exposures/test/test_base.py
+++ b/climada/entity/exposures/test/test_base.py
@@ -346,7 +346,7 @@ class TestConcat(unittest.TestCase):
         self.assertEqual(catexp.crs, 'epsg:3395')
         self.assertEqual(np.unique(catexp.gdf['category_id']), np.array([1]))
 
-        catexp = Exposures.concat([self.dummy, self.dummy, self.dummy], category_ids=["a", "b", "c"])
+        catexp = Exposures.concat([self.dummy, self.dummy, self.dummy], category_id_list=["a", "b", "c"])
         self.assertListEqual(np.unique(catexp.gdf['category_id']), np.array(["a", "b", "c"]))
 
     def test_concat_fail(self):
@@ -355,9 +355,9 @@ class TestConcat(unittest.TestCase):
         with self.assertRaises(TypeError):
             Exposures.concat([self.dummy, self.dummy.gdf, self.dummy.gdf.values, self.dummy])
         with self.assertRaises(TypeError):
-            Exposures.concat([self.dummy, self.dummy, self.dummy], category_ids="abc")
+            Exposures.concat([self.dummy, self.dummy, self.dummy], category_id_list="abc")
         with self.assertRaises(IndexError):
-            Exposures.concat([self.dummy, self.dummy, self.dummy], category_ids=["a"])
+            Exposures.concat([self.dummy, self.dummy, self.dummy], category_id_list=["a"])
 
 
 class TestGeoDFFuncs(unittest.TestCase):

--- a/climada/entity/exposures/test/test_base.py
+++ b/climada/entity/exposures/test/test_base.py
@@ -329,6 +329,7 @@ class TestConcat(unittest.TestCase):
         exp.gdf['latitude'] = np.linspace(min_lat, max_lat, 10)
         exp.gdf['longitude'] = np.linspace(min_lon, max_lon, 10)
         exp.gdf['region_id'] = np.ones(10)
+        exp.gdf['category_id'] = np.ones(10)
         exp.gdf['impf_TC'] = np.ones(10)
         exp.ref_year = 2015
         exp.value_unit = 'XSD'
@@ -340,15 +341,23 @@ class TestConcat(unittest.TestCase):
         self.dummy.check()
 
         catexp = Exposures.concat([self.dummy, self.dummy.gdf, pd.DataFrame(self.dummy.gdf.values, columns=self.dummy.gdf.columns), self.dummy])
-        self.assertEqual(self.dummy.gdf.shape, (10,5))
-        self.assertEqual(catexp.gdf.shape, (40,5))
+        self.assertEqual(self.dummy.gdf.shape, (10, 6))
+        self.assertEqual(catexp.gdf.shape, (40, 6))
         self.assertEqual(catexp.crs, 'epsg:3395')
+        self.assertEqual(np.unique(catexp.gdf['category_id']), np.array([1]))
+
+        catexp = Exposures.concat([self.dummy, self.dummy, self.dummy], category_ids=["a", "b", "c"])
+        self.assertListEqual(np.unique(catexp.gdf['category_id']), np.array(["a", "b", "c"]))
 
     def test_concat_fail(self):
         """Test failing concat function with fake data."""
 
         with self.assertRaises(TypeError):
             Exposures.concat([self.dummy, self.dummy.gdf, self.dummy.gdf.values, self.dummy])
+        with self.assertRaises(TypeError):
+            Exposures.concat([self.dummy, self.dummy, self.dummy], category_ids="abc")
+        with self.assertRaises(IndexError):
+            Exposures.concat([self.dummy, self.dummy, self.dummy], category_ids=["a"])
 
 
 class TestGeoDFFuncs(unittest.TestCase):

--- a/climada/entity/exposures/test/test_base.py
+++ b/climada/entity/exposures/test/test_base.py
@@ -347,7 +347,7 @@ class TestConcat(unittest.TestCase):
         self.assertEqual(np.unique(catexp.gdf['category_id']), np.array([1]))
 
         catexp = Exposures.concat([self.dummy, self.dummy, self.dummy], category_id_list=["a", "b", "c"])
-        self.assertListEqual(np.unique(catexp.gdf['category_id']), np.array(["a", "b", "c"]))
+        self.assertSetEqual(set(catexp.gdf['category_id']), {"a", "b", "c"})
 
     def test_concat_fail(self):
         """Test failing concat function with fake data."""


### PR DESCRIPTION
This is for discussion! Here I'm suggesting an extra parameter for the `Exposures.concat` method.

My use case is this: I'm reading in multiple fractional land cover files into a single Exposures object, with one file per land use type. I'd like to concatenate these exposures and specify their `category_id` in the same command. By adding the `category_id_list` parameter to `Exposures.concat` this is easily done.

As an example, if I'm reading in grassland.tiff and wetland.tiff to `exp_list`, I'd like to be able to run
```
exp = Exposures.concat(exp_list, category_id_list=['grassland', 'wetland'])
```

**Pros:**
- Allows for quick reading and combination of files. 

**Cons:**
- The `concat` method now does two things: edits geodataframes and combines them. You're not supposed to do that.

**Possible changes**
- This could be more flexible if we let the user assign values to _any_ column, not just category_id. We could use a dictionary to do this, e.g. `{"category_id": layers_list}` 