### PR TITLE
Update Hazard.set_raster to from_raster in whole core code

### DIFF
--- a/climada/entity/exposures/test/test_base.py
+++ b/climada/entity/exposures/test/test_base.py
@@ -58,8 +58,7 @@ class TestFuncs(unittest.TestCase):
         """Check that attribute `assigned` is correctly set."""
         np_rand = np.random.RandomState(123456789)
 
-        haz = Hazard('FL')
-        haz.set_raster([HAZ_DEMO_FL], window=Window(10, 20, 50, 60))
+        haz = Hazard.from_raster([HAZ_DEMO_FL], haz_type='FL', window=Window(10, 20, 50, 60))
         haz.raster_to_vector()
         ncentroids = haz.centroids.size
 
@@ -146,8 +145,7 @@ class TestFuncs(unittest.TestCase):
         exp = Exposures()
         exp.set_from_raster(HAZ_DEMO_FL, window=Window(10, 20, 50, 60))
         exp.check()
-        haz = Hazard('FL')
-        haz.set_raster([HAZ_DEMO_FL], window=Window(10, 20, 50, 60))
+        haz = Hazard.from_raster([HAZ_DEMO_FL], haz_type='FL', window=Window(10, 20, 50, 60))
         exp.assign_centroids(haz)
         np.testing.assert_array_equal(exp.gdf[INDICATOR_CENTR + 'FL'].values,
                                       np.arange(haz.centroids.size, dtype=int))
@@ -159,8 +157,7 @@ class TestFuncs(unittest.TestCase):
         exp.gdf.latitude[[0, 1]] = exp.gdf.latitude[[1, 0]]
         exp.gdf.longitude[[0, 1]] = exp.gdf.longitude[[1, 0]]
         exp.check()
-        haz = Hazard('FL')
-        haz.set_raster([HAZ_DEMO_FL])
+        haz = Hazard.from_raster([HAZ_DEMO_FL], haz_type='FL')
         haz.raster_to_vector()
         exp.assign_centroids(haz)
         assigned_centroids = haz.centroids.select(sel_cen=exp.gdf[INDICATOR_CENTR + 'FL'].values)

--- a/climada/hazard/base.py
+++ b/climada/hazard/base.py
@@ -52,21 +52,21 @@ LOGGER = logging.getLogger(__name__)
 
 DEF_VAR_EXCEL = {'sheet_name': {'inten': 'hazard_intensity',
                                 'freq': 'hazard_frequency'
-                               },
+                                },
                  'col_name': {'cen_id': 'centroid_id/event_id',
                               'even_id': 'event_id',
                               'even_dt': 'event_date',
                               'even_name': 'event_name',
                               'freq': 'frequency',
                               'orig': 'orig_event_flag'
-                             },
+                              },
                  'col_centroids': {'sheet_name': 'centroids',
                                    'col_name': {'cen_id': 'centroid_id',
                                                 'lat': 'latitude',
                                                 'lon': 'longitude'
-                                               }
-                                  }
-                }
+                                                }
+                                   }
+                 }
 """Excel variable names"""
 
 DEF_VAR_MAT = {'field_name': 'hazard',
@@ -80,15 +80,16 @@ DEF_VAR_MAT = {'field_name': 'hazard',
                             'comment': 'comment',
                             'datenum': 'datenum',
                             'orig': 'orig_event_flag'
-                           },
+                            },
                'var_cent': {'field_names': ['centroids', 'hazard'],
                             'var_name': {'cen_id': 'centroid_ID',
                                          'lat': 'lat',
                                          'lon': 'lon'
-                                        }
-                           }
-              }
+                                         }
+                            }
+               }
 """MATLAB variable names"""
+
 
 class Hazard():
     """
@@ -133,7 +134,7 @@ class Hazard():
                   'frequency',
                   'intensity',
                   'fraction'
-                 }
+                  }
     """Name of the variables needed to compute the impact. Types: scalar, str,
     list, 1dim np.array of size num_events, scipy.sparse matrix of shape
     num_events x num_centroids, Centroids and Tag."""
@@ -141,7 +142,7 @@ class Hazard():
     vars_def = {'date',
                 'orig',
                 'event_name'
-               }
+                }
     """Name of the variables used in impact calculation whose value is
     descriptive and can therefore be set with default values. Types: scalar,
     string, list, 1dim np.array of size num_events.
@@ -215,11 +216,12 @@ class Hazard():
         self.centroids.check()
         self._check_events()
 
-    def set_raster(self, files_intensity, files_fraction=None, attrs=None,
-                   band=None, src_crs=None, window=False, geometry=False,
-                   dst_crs=False, transform=None, width=None, height=None,
-                   resampling=Resampling.nearest):
-        """Set intensity and fraction to values from raster files
+    @classmethod
+    def from_raster(cls, files_intensity, files_fraction=None, attrs=None,
+                    band=None, haz_type='', pool=None, src_crs=None, window=False,
+                    geometry=False, dst_crs=False, transform=None, width=None,
+                    height=None, resampling=Resampling.nearest):
+        """Create Hazard with intensity and fraction values from raster files
 
         If raster files are masked, the masked values are set to 0.
 
@@ -236,6 +238,10 @@ class Hazard():
             name of Hazard attributes and their values
         band : list(int), optional
             bands to read (starting at 1), default [1]
+        haz_type : str, optional
+            acronym of the hazard type (e.g. 'TC').
+        pool : pathos.pool, optional
+            Pool that will be used for parallel computation when applicable. Default: None
         src_crs : crs, optional
             source CRS. Provide it if error without it.
         window : rasterio.windows.Windows, optional
@@ -253,6 +259,10 @@ class Hazard():
             number of lats for transform
         resampling : rasterio.warp.Resampling, optional
             resampling function used for reprojection to dst_crs
+
+        Return
+        ------
+        Hazard
         """
         if isinstance(files_intensity, (str, pathlib.Path)):
             files_intensity = [files_intensity]
@@ -265,73 +275,82 @@ class Hazard():
         if files_fraction is not None and len(files_intensity) != len(files_fraction):
             raise ValueError('Number of intensity files differs from fraction files: %s != %s'
                              % (len(files_intensity), len(files_fraction)))
-        self.tag.file_name = str(files_intensity) + ' ; ' + str(files_fraction)
+        haz = cls(haz_type, pool)
+        haz.tag.file_name = str(files_intensity) + ' ; ' + str(files_fraction)
 
-        self.centroids = Centroids()
-        if self.pool:
-            chunksize = min(len(files_intensity) // self.pool.ncpus, 1000)
+        haz.centroids = Centroids()
+        if haz.pool:
+            chunksize = min(len(files_intensity) // haz.pool.ncpus, 1000)
             # set first centroids
-            inten_list = [sparse.csr.csr_matrix(self.centroids.set_raster_file(
+            inten_list = [sparse.csr.csr_matrix(haz.centroids.set_raster_file(
                 files_intensity[0], band, src_crs, window, geometry, dst_crs,
                 transform, width, height, resampling))]
-            inten_list += self.pool.map(
-                self.centroids.set_raster_file,
+            inten_list += haz.pool.map(
+                haz.centroids.set_raster_file,
                 files_intensity[1:], itertools.repeat(band), itertools.repeat(src_crs),
                 itertools.repeat(window), itertools.repeat(geometry),
                 itertools.repeat(dst_crs), itertools.repeat(transform),
                 itertools.repeat(width), itertools.repeat(height),
                 itertools.repeat(resampling), chunksize=chunksize)
-            self.intensity = sparse.vstack(inten_list, format='csr')
+            haz.intensity = sparse.vstack(inten_list, format='csr')
             if files_fraction is not None:
-                fract_list = self.pool.map(
-                    self.centroids.set_raster_file,
+                fract_list = haz.pool.map(
+                    haz.centroids.set_raster_file,
                     files_fraction, itertools.repeat(band), itertools.repeat(src_crs),
                     itertools.repeat(window), itertools.repeat(geometry),
                     itertools.repeat(dst_crs), itertools.repeat(transform),
                     itertools.repeat(width), itertools.repeat(height),
                     itertools.repeat(resampling), chunksize=chunksize)
-                self.fraction = sparse.vstack(fract_list, format='csr')
+                haz.fraction = sparse.vstack(fract_list, format='csr')
         else:
             inten_list = []
             for file in files_intensity:
-                inten_list.append(self.centroids.set_raster_file(
+                inten_list.append(haz.centroids.set_raster_file(
                     file, band, src_crs, window, geometry, dst_crs, transform,
                     width, height, resampling))
-            self.intensity = sparse.vstack(inten_list, format='csr')
+            haz.intensity = sparse.vstack(inten_list, format='csr')
             if files_fraction is not None:
                 fract_list = []
                 for file in files_fraction:
-                    fract_list.append(self.centroids.set_raster_file(
+                    fract_list.append(haz.centroids.set_raster_file(
                         file, band, src_crs, window, geometry, dst_crs, transform,
                         width, height, resampling))
-                self.fraction = sparse.vstack(fract_list, format='csr')
+                haz.fraction = sparse.vstack(fract_list, format='csr')
 
         if files_fraction is None:
-            self.fraction = self.intensity.copy()
-            self.fraction.data.fill(1)
+            haz.fraction = haz.intensity.copy()
+            haz.fraction.data.fill(1)
 
         if 'event_id' in attrs:
-            self.event_id = attrs['event_id']
+            haz.event_id = attrs['event_id']
         else:
-            self.event_id = np.arange(1, self.intensity.shape[0] + 1)
+            haz.event_id = np.arange(1, haz.intensity.shape[0] + 1)
         if 'frequency' in attrs:
-            self.frequency = attrs['frequency']
+            haz.frequency = attrs['frequency']
         else:
-            self.frequency = np.ones(self.event_id.size)
+            haz.frequency = np.ones(haz.event_id.size)
         if 'event_name' in attrs:
-            self.event_name = attrs['event_name']
+            haz.event_name = attrs['event_name']
         else:
-            self.event_name = list(map(str, self.event_id))
+            haz.event_name = list(map(str, haz.event_id))
         if 'date' in attrs:
-            self.date = np.array([attrs['date']])
+            haz.date = np.array([attrs['date']])
         else:
-            self.date = np.ones(self.event_id.size)
+            haz.date = np.ones(haz.event_id.size)
         if 'orig' in attrs:
-            self.orig = np.array([attrs['orig']])
+            haz.orig = np.array([attrs['orig']])
         else:
-            self.orig = np.ones(self.event_id.size, bool)
+            haz.orig = np.ones(haz.event_id.size, bool)
         if 'unit' in attrs:
-            self.unit = attrs['unit']
+            haz.unit = attrs['unit']
+
+        return haz
+
+    def set_raster(self, *args, **kwargs):
+        """This function is deprecated, use Hazard.from_raster."""
+        LOGGER.warning("The use of Hazard.set_raster is deprecated."
+                       "Use Hazard.from_raster instead.")
+        self.__dict__ = Hazard.from_raster(*args, **kwargs).__dict__
 
     def set_vector(self, files_intensity, files_fraction=None, attrs=None,
                    inten_name=None, frac_name=None, dst_crs=None):
@@ -437,7 +456,7 @@ class Hazard():
         dst_meta = self.centroids.meta.copy()
         dst_meta.update({'crs': dst_crs, 'transform': transform,
                          'width': width, 'height': height
-                        })
+                         })
         intensity = np.zeros((self.size, dst_meta['height'], dst_meta['width']))
         fraction = np.zeros((self.size, dst_meta['height'], dst_meta['width']))
         kwargs = {'src_transform': self.centroids.meta['transform'],
@@ -505,8 +524,8 @@ class Hazard():
             if i_ev < self.size:
                 points_df[inten_name] = np.asarray(self.intensity[i_ev, :].toarray()).reshape(-1)
             else:
-                points_df[inten_name] = np.asarray(self.fraction[i_ev - self.size, :].toarray()).\
-                reshape(-1)
+                points_df[inten_name] = np.asarray(self.fraction[i_ev - self.size, :].toarray()). \
+                    reshape(-1)
         raster, meta = u_coord.points_to_raster(points_df, val_names,
                                                 crs=self.centroids.geometry.crs,
                                                 scheduler=scheduler)
@@ -658,7 +677,7 @@ class Hazard():
         sel_cen = sel_cen.nonzero()[0]
         for (var_name, var_val) in self.__dict__.items():
             if isinstance(var_val, np.ndarray) and var_val.ndim == 1 \
-                                               and var_val.size > 0:
+                    and var_val.size > 0:
                 setattr(haz, var_name, var_val[sel_ev])
             elif isinstance(var_val, sparse.csr_matrix):
                 setattr(haz, var_name, var_val[sel_ev, :][:, sel_cen])
@@ -974,9 +993,9 @@ class Hazard():
         """
         if not yearrange:
             delta_time = dt.datetime.fromordinal(int(np.max(self.date))).year - \
-                     dt.datetime.fromordinal(int(np.min(self.date))).year + 1
+                         dt.datetime.fromordinal(int(np.min(self.date))).year + 1
         else:
-            delta_time = max(yearrange)-min(yearrange)+1
+            delta_time = max(yearrange) - min(yearrange) + 1
         num_orig = self.orig.nonzero()[0].size
         if num_orig > 0:
             ens_size = self.event_id.size / num_orig
@@ -1016,7 +1035,7 @@ class Hazard():
                          zip(pixel_geom, np.array(variable[i_ev, :].toarray()).reshape(-1))],
                         out_shape=(profile['height'], profile['width']),
                         transform=profile['transform'], fill=0,
-                        all_touched=True, dtype=profile['dtype'],)
+                        all_touched=True, dtype=profile['dtype'], )
                     dst.write(raster.astype(profile['dtype']), i_ev + 1)
 
     def write_hdf5(self, file_name, todense=False):
@@ -1215,8 +1234,8 @@ class Hazard():
             array_val = mat_var[:, centr_pos].toarray()
 
             title = '%s-largest Centroid. %s: (%s, %s)' % \
-                (np.abs(centr_idx), str(centr_pos), coord[centr_pos, 0],
-                 coord[centr_pos, 1])
+                    (np.abs(centr_idx), str(centr_pos), coord[centr_pos, 0],
+                     coord[centr_pos, 1])
         else:
             array_val = np.max(mat_var, axis=1).toarray()
             title = '%s max intensity at each event' % self.tag.haz_type
@@ -1483,7 +1502,7 @@ class Hazard():
         hazcent_in_cent_idx_list = [
             u_coord.assign_coordinates(haz.centroids.coord, centroids.coord, threshold=0)
             for haz in haz_list_nonempty
-            ]
+        ]
 
         # concatenate array and list attributes of non-empty hazards
         for attr_name in attributes:
@@ -1494,9 +1513,9 @@ class Hazard():
                     sparse.csr_matrix(
                         (matrix.data, cent_idx[matrix.indices], matrix.indptr),
                         shape=(matrix.shape[0], centroids.size)
-                        )
+                    )
                     for matrix, cent_idx in zip(attr_val_list, hazcent_in_cent_idx_list)
-                    ], format='csr'))
+                ], format='csr'))
             elif isinstance(attr_val_list[0], np.ndarray) and attr_val_list[0].ndim == 1:
                 setattr(self, attr_name, np.hstack(attr_val_list))
             elif isinstance(attr_val_list[0], list):
@@ -1504,7 +1523,6 @@ class Hazard():
 
         self.centroids = centroids
         self.sanitize_event_ids()
-
 
     @classmethod
     def concat(cls, haz_list):
@@ -1595,7 +1613,7 @@ class Hazard():
         # indices for mapping matrices onto common centroids
         new_cent_idx = u_coord.assign_coordinates(
             self.centroids.coord, centroids.coord, threshold=threshold
-            )
+        )
 
         if -1 in new_cent_idx:
             raise ValueError("At least one hazard centroid is at a larger "
@@ -1616,6 +1634,6 @@ class Hazard():
                     sparse.csr_matrix(
                         (matrix.data, new_cent_idx[matrix.indices], matrix.indptr),
                         shape=(matrix.shape[0], centroids.size)
-                        ))
+                    ))
 
         return haz_new_cent

--- a/climada/hazard/base.py
+++ b/climada/hazard/base.py
@@ -239,7 +239,8 @@ class Hazard():
         band : list(int), optional
             bands to read (starting at 1), default [1]
         haz_type : str, optional
-            acronym of the hazard type (e.g. 'TC'). Default is None.
+            acronym of the hazard type (e.g. 'TC'). Default is None, which will use the 
+            class default ('' for vanilla `Hazard` objects, hard coded in some subclasses)
         pool : pathos.pool, optional
             Pool that will be used for parallel computation when applicable.
             Default: None

--- a/climada/hazard/base.py
+++ b/climada/hazard/base.py
@@ -218,7 +218,7 @@ class Hazard():
 
     @classmethod
     def from_raster(cls, files_intensity, files_fraction=None, attrs=None,
-                    band=None, haz_type='', pool=None, src_crs=None, window=False,
+                    band=None, haz_type=None, pool=None, src_crs=None, window=False,
                     geometry=False, dst_crs=False, transform=None, width=None,
                     height=None, resampling=Resampling.nearest):
         """Create Hazard with intensity and fraction values from raster files
@@ -239,9 +239,10 @@ class Hazard():
         band : list(int), optional
             bands to read (starting at 1), default [1]
         haz_type : str, optional
-            acronym of the hazard type (e.g. 'TC').
+            acronym of the hazard type (e.g. 'TC'). Default is None.
         pool : pathos.pool, optional
-            Pool that will be used for parallel computation when applicable. Default: None
+            Pool that will be used for parallel computation when applicable.
+            Default: None
         src_crs : crs, optional
             source CRS. Provide it if error without it.
         window : rasterio.windows.Windows, optional
@@ -275,6 +276,8 @@ class Hazard():
         if files_fraction is not None and len(files_intensity) != len(files_fraction):
             raise ValueError('Number of intensity files differs from fraction files: %s != %s'
                              % (len(files_intensity), len(files_fraction)))
+        if haz_type is None:
+            haz_type = cls().tag.haz_type
         haz = cls(haz_type, pool)
         haz.tag.file_name = str(files_intensity) + ' ; ' + str(files_fraction)
 

--- a/climada/hazard/test/test_base.py
+++ b/climada/hazard/test/test_base.py
@@ -1056,8 +1056,7 @@ class TestCentroids(unittest.TestCase):
 
     def test_reproject_raster_pass(self):
         """Test reproject_raster reference."""
-        haz_fl = Hazard('FL')
-        haz_fl.set_raster([HAZ_DEMO_FL])
+        haz_fl = Hazard.from_raster([HAZ_DEMO_FL])
         haz_fl.check()
 
         haz_fl.reproject_raster(dst_crs={'init': 'epsg:2202'})
@@ -1076,8 +1075,7 @@ class TestCentroids(unittest.TestCase):
 
     def test_raster_to_vector_pass(self):
         """Test raster_to_vector method"""
-        haz_fl = Hazard('FL')
-        haz_fl.set_raster([HAZ_DEMO_FL])
+        haz_fl = Hazard.from_raster([HAZ_DEMO_FL], haz_type='FL')
         haz_fl.check()
         meta_orig = haz_fl.centroids.meta
         inten_orig = haz_fl.intensity

--- a/climada/test/test_hazard.py
+++ b/climada/test/test_hazard.py
@@ -34,8 +34,8 @@ class TestCentroids(unittest.TestCase):
 
     def test_read_write_raster_pass(self):
         """Test write_raster: Hazard from raster data"""
-        haz_fl = Hazard('FL')
-        haz_fl.set_raster([HAZ_DEMO_FL])
+        haz_fl = Hazard.from_raster([HAZ_DEMO_FL])
+        haz_fl.tag.haz_type = 'FL'
         haz_fl.check()
 
         self.assertEqual(haz_fl.intensity.shape, (1, 1032226))
@@ -44,8 +44,8 @@ class TestCentroids(unittest.TestCase):
 
         haz_fl.write_raster(DATA_DIR.joinpath('test_write_hazard.tif'))
 
-        haz_read = Hazard('FL')
-        haz_read.set_raster([DATA_DIR.joinpath('test_write_hazard.tif')])
+        haz_read = Hazard.from_raster([DATA_DIR.joinpath('test_write_hazard.tif')])
+        haz_fl.tag.haz_type = 'FL'
         self.assertTrue(np.allclose(haz_fl.intensity.toarray(), haz_read.intensity.toarray()))
         self.assertEqual(np.unique(np.array(haz_fl.fraction.toarray())).size, 2)
 
@@ -53,8 +53,7 @@ class TestCentroids(unittest.TestCase):
         """Test set_raster with pool"""
         from pathos.pools import ProcessPool as Pool
         pool = Pool()
-        haz_fl = Hazard('FL', pool)
-        haz_fl.set_raster([HAZ_DEMO_FL])
+        haz_fl = Hazard.from_raster([HAZ_DEMO_FL], haz_type='FL', pool=pool)
         haz_fl.check()
 
         self.assertEqual(haz_fl.intensity.shape, (1, 1032226))
@@ -78,8 +77,7 @@ class TestCentroids(unittest.TestCase):
 
         haz_fl.write_raster(DATA_DIR.joinpath('test_write_hazard.tif'))
 
-        haz_read = Hazard('FL')
-        haz_read.set_raster([DATA_DIR.joinpath('test_write_hazard.tif')])
+        haz_read = Hazard.from_raster([DATA_DIR.joinpath('test_write_hazard.tif')], haz_type='FL')
         self.assertEqual(haz_read.intensity.shape, (1, 9))
         self.assertTrue(np.allclose(np.unique(np.array(haz_read.intensity.toarray())),
                                     np.array([0.0, 0.1, 0.2, 0.5])))
@@ -99,9 +97,9 @@ class TestCentroids(unittest.TestCase):
 
         haz_fl.write_raster(DATA_DIR.joinpath('test_write_hazard.tif'), intensity=False)
 
-        haz_read = Hazard('FL')
-        haz_read.set_raster([DATA_DIR.joinpath('test_write_hazard.tif')],
-                            files_fraction=[DATA_DIR.joinpath('test_write_hazard.tif')])
+        haz_read = Hazard.from_raster([DATA_DIR.joinpath('test_write_hazard.tif')],
+                                      files_fraction=[DATA_DIR.joinpath('test_write_hazard.tif')],
+                                      haz_type='FL')
         self.assertEqual(haz_read.intensity.shape, (1, 9))
         self.assertEqual(haz_read.fraction.shape, (1, 9))
         self.assertTrue(np.allclose(np.unique(np.array(haz_read.fraction.toarray())),

--- a/doc/tutorial/climada_engine_Impact.ipynb
+++ b/doc/tutorial/climada_engine_Impact.ipynb
@@ -1383,13 +1383,12 @@
     "\n",
     "# Initialize hazard object with haz_type = 'FL' (for Flood)\n",
     "hazard_type='FL'\n",
-    "haz_ras = Hazard(haz_type=hazard_type)\n",
     "# Load a previously generated (either with CLIMADA or other means) hazard \n",
     "# from file (HAZ_DEMO_FL) and resample the hazard raster to the exposures' ones\n",
     "# Hint: check how other resampling methods affect to final impact\n",
-    "haz_ras.set_raster([HAZ_DEMO_FL], dst_crs=exp_ras.meta['crs'], transform=exp_ras.meta['transform'],\n",
-    "                   width=exp_ras.meta['width'], height=exp_ras.meta['height'],\n",
-    "                   resampling=Resampling.nearest)\n",
+    "haz_ras = Hazard.from_raster([HAZ_DEMO_FL], haz_type=hazard_type, dst_crs=exp_ras.meta['crs'], transform=exp_ras.meta['transform'],\n",
+    "                             width=exp_ras.meta['width'], height=exp_ras.meta['height'],\n",
+    "                             resampling=Resampling.nearest)\n",
     "haz_ras.intensity[haz_ras.intensity==-9999] = 0 # correct no data values\n",
     "haz_ras.check()\n",
     "haz_ras.plot_intensity(1)\n",
@@ -1704,7 +1703,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -1718,7 +1717,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "version": "3.8.10"
   },
   "latex_envs": {
    "LaTeX_envs_menu_present": true,

--- a/doc/tutorial/climada_hazard_Hazard.ipynb
+++ b/doc/tutorial/climada_hazard_Hazard.ipynb
@@ -69,7 +69,7 @@
     "<a id='Part1'></a> \n",
     "## Part 1: Read hazards from raster data\n",
     "\n",
-    "Raster data can be read in any format accepted by [rasterio](https://rasterio.readthedocs.io/en/stable/) using `Hazard`'s `set_raster()` method. The raster information might refer to the `intensity` or `fraction`of the hazard. Different configuration options such as transforming the coordinates, changing the CRS and reading only a selected area or band are available through the `set_raster()` arguments as follows:"
+    "Raster data can be read in any format accepted by [rasterio](https://rasterio.readthedocs.io/en/stable/) using `Hazard`'s `from_raster()` method. The raster information might refer to the `intensity` or `fraction`of the hazard. Different configuration options such as transforming the coordinates, changing the CRS and reading only a selected area or band are available through the `from_raster()` arguments as follows:"
    ]
   },
   {
@@ -109,9 +109,8 @@
     "from climada.hazard import Hazard\n",
     "from climada.util.constants import HAZ_DEMO_FL\n",
     "\n",
-    "haz_ven = Hazard('FL')\n",
     "# read intensity from raster file HAZ_DEMO_FL and set frequency for the contained event\n",
-    "haz_ven.set_raster([HAZ_DEMO_FL], attrs={'frequency':np.ones(1)/2})\n",
+    "haz_ven = haz_ven.from_raster([HAZ_DEMO_FL], attrs={'frequency':np.ones(1)/2}, haz_type='FL')\n",
     "haz_ven.check()\n",
     "\n",
     "# The masked values of the raster are set to 0\n",
@@ -186,8 +185,7 @@
     "# Solution:\n",
     "\n",
     "# 1. The CRS can be reprojected using dst_crs option\n",
-    "haz = Hazard('FL')\n",
-    "haz.set_raster([HAZ_DEMO_FL], dst_crs={'init':'epsg:2201'}) \n",
+    "haz = Hazard.from_raster([HAZ_DEMO_FL], dst_crs={'init':'epsg:2201'}, haz_type='FL') \n",
     "haz.check()\n",
     "print('\\n Solution 1:')\n",
     "print('centroids CRS:', haz.centroids.crs)\n",
@@ -195,9 +193,10 @@
     "\n",
     "# 2. Transformations of the coordinates can be set using the transform option and Affine \n",
     "from rasterio import Affine\n",
-    "haz = Hazard('FL')\n",
-    "haz.set_raster([HAZ_DEMO_FL], transform=Affine(0.009000000000000341, 0.0, -69.33714959699981, \\\n",
-    "                                               0.0, -0.009000000000000341, 10.42822096697894), height=500, width=501) \n",
+    "haz = Hazard.from_raster([HAZ_DEMO_FL], haz_type='FL',\n",
+    "                         transform=Affine(0.009000000000000341, 0.0, -69.33714959699981, \\\n",
+    "                                          0.0, -0.009000000000000341, 10.42822096697894),\n",
+    "                         height=500, width=501) \n",
     "haz.check()\n",
     "print('\\n Solution 2:')\n",
     "print('raster info:', haz.centroids.meta)\n",
@@ -205,8 +204,7 @@
     "\n",
     "# 3. A partial part of the raster can be loaded using the window or geometry\n",
     "from rasterio.windows import Window\n",
-    "haz = Hazard('FL')\n",
-    "haz.set_raster([HAZ_DEMO_FL], window=Window(10, 10, 20, 30))\n",
+    "haz = Hazard.from_raster([HAZ_DEMO_FL], haz_type='FL', window=Window(10, 10, 20, 30))\n",
     "haz.check()\n",
     "print('\\n Solution 3:')\n",
     "print('raster info:', haz.centroids.meta)\n",
@@ -870,7 +868,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -884,7 +882,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "version": "3.8.10"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Part of the big antipattern hunt.

Update `Hazard.set_raster` to `Hazard.from_raster`

Note: we had to add two NEW parameters to the method: `haz_type` and `pool`. Frequently we found code that initiated a Hazard object with haz_type set in the constructor, and then assigned a pool. To do this in one line, we added the extra parameters.