### PR TITLE
Feature/admin1 geometries

### DIFF
--- a/climada/util/coordinates.py
+++ b/climada/util/coordinates.py
@@ -1139,12 +1139,12 @@ def get_country_code(lat, lon, gridded=False):
         region_id[region_id == -1] = 0
     return region_id
 
-def get_admin1_info(countries):
+def get_admin1_info(country_names):
     """Provide Natural Earth registry info and shape files for admin1 regions
 
     Parameters
     ----------
-    countries : list or str
+    country_names : list or str
         string or list with strings, either ISO3 code or names of countries, e.g.:
         ['ZWE', 'GBR', 'VNM', 'UZB', 'Kenya', '051']
         For example, for Armenia, the following inputs work:
@@ -1157,18 +1157,18 @@ def get_admin1_info(countries):
     admin1_shapes : dict
         Shape according to Natural Earth.
     """
-
-    if isinstance(countries, (str, int, float)):
-        countries = [countries]
-    if not isinstance(countries, list):
-        raise TypeError("Invalid type for input parameter 'countries'")
+    if isinstance(country_names, (str, int, float)):
+        country_names = [country_names]
+    if not isinstance(country_names, list):
+        LOGGER.error("country_names needs to be of type list, str, int or float")
+        raise TypeError("Invalid type for input parameter 'country_names'")
     admin1_file = shapereader.natural_earth(resolution='10m',
                                             category='cultural',
                                             name='admin_1_states_provinces')
     admin1_recs = shapefile.Reader(admin1_file)
     admin1_info = dict()
     admin1_shapes = dict()
-    for country in countries:
+    for country in country_names:
         if isinstance(country, (int, float)):
             country = f'{int(country):03d}' # transform numerric code to str
         country = pycountry.countries.lookup(country).alpha_3 # get iso3a code

--- a/climada/util/coordinates.py
+++ b/climada/util/coordinates.py
@@ -1139,13 +1139,14 @@ def get_country_code(lat, lon, gridded=False):
         region_id[region_id == -1] = 0
     return region_id
 
-def get_admin1_info(country_names):
+def get_admin1_info(countries):
     """Provide Natural Earth registry info and shape files for admin1 regions
 
     Parameters
     ----------
-    country_names : list
-        list with ISO3 names of countries, e.g. ['ZWE', 'GBR', 'VNM', 'UZB']
+    countries : list
+        list with strings, either ISO3 alpha code or names of countries, e.g.:
+        ['ZWE', 'GBR', 'VNM', 'UZB', 'Kenya']
 
     Returns
     -------
@@ -1155,21 +1156,22 @@ def get_admin1_info(country_names):
         Shape according to Natural Earth.
     """
 
-    if isinstance(country_names, str):
-        country_names = [country_names]
+    if isinstance(countries, str):
+        countries = [countries]
     admin1_file = shapereader.natural_earth(resolution='10m',
                                             category='cultural',
                                             name='admin_1_states_provinces')
     admin1_recs = shapefile.Reader(admin1_file)
     admin1_info = dict()
     admin1_shapes = dict()
-    for iso3 in country_names:
-        admin1_info[iso3] = list()
-        admin1_shapes[iso3] = list()
+    for country in countries:
+        country = pycountry.countries.lookup(country).alpha_3 # iso3a code
+        admin1_info[country] = list()
+        admin1_shapes[country] = list()
         for rec, rec_shp in zip(admin1_recs.records(), admin1_recs.shapes()):
-            if rec['adm0_a3'] == iso3:
-                admin1_info[iso3].append(rec)
-                admin1_shapes[iso3].append(rec_shp)
+            if rec['adm0_a3'] == country:
+                admin1_info[country].append(rec)
+                admin1_shapes[country].append(rec_shp)
     return admin1_info, admin1_shapes
 
 def get_resolution_1d(coords, min_resol=1.0e-8):

--- a/climada/util/coordinates.py
+++ b/climada/util/coordinates.py
@@ -1145,8 +1145,10 @@ def get_admin1_info(countries):
     Parameters
     ----------
     countries : list
-        list with strings, either ISO3 alpha code or names of countries, e.g.:
-        ['ZWE', 'GBR', 'VNM', 'UZB', 'Kenya']
+        list with strings, either ISO3 code or names of countries, e.g.:
+        ['ZWE', 'GBR', 'VNM', 'UZB', 'Kenya', "051"]
+        For example for Armenia, the following inputs work:
+            'Armenia', 'ARM', '051'
 
     Returns
     -------
@@ -1165,7 +1167,9 @@ def get_admin1_info(countries):
     admin1_info = dict()
     admin1_shapes = dict()
     for country in countries:
-        country = pycountry.countries.lookup(country).alpha_3 # iso3a code
+        if isinstance(country, (int, float)):
+            country = f'{int(country):03d}' # transform numerric code to str
+        country = pycountry.countries.lookup(country).alpha_3 # get iso3a code
         admin1_info[country] = list()
         admin1_shapes[country] = list()
         for rec, rec_shp in zip(admin1_recs.records(), admin1_recs.shapes()):

--- a/climada/util/coordinates.py
+++ b/climada/util/coordinates.py
@@ -1146,9 +1146,9 @@ def get_admin1_info(countries):
     ----------
     countries : list
         list with strings, either ISO3 code or names of countries, e.g.:
-        ['ZWE', 'GBR', 'VNM', 'UZB', 'Kenya', "051"]
-        For example for Armenia, the following inputs work:
-            'Armenia', 'ARM', '051'
+        ['ZWE', 'GBR', 'VNM', 'UZB', 'Kenya', '051']
+        For example, for Armenia, the following inputs work:
+            'Armenia', 'ARM', '051', 51
 
     Returns
     -------
@@ -1158,7 +1158,7 @@ def get_admin1_info(countries):
         Shape according to Natural Earth.
     """
 
-    if isinstance(countries, str):
+    if isinstance(countries, (str, int, float)):
         countries = [countries]
     admin1_file = shapereader.natural_earth(resolution='10m',
                                             category='cultural',

--- a/climada/util/coordinates.py
+++ b/climada/util/coordinates.py
@@ -1145,10 +1145,10 @@ def get_admin1_info(country_names):
     Parameters
     ----------
     country_names : list or str
-        string or list with strings, either ISO3 code or names of countries, e.g.:
+        string or list with strings, either ISO code or names of countries, e.g.:
         ['ZWE', 'GBR', 'VNM', 'UZB', 'Kenya', '051']
         For example, for Armenia, the following inputs work:
-            'Armenia', 'ARM', '051', 51
+            'Armenia', 'ARM', 'AM', '051', 51
 
     Returns
     -------
@@ -1178,6 +1178,12 @@ def get_admin1_info(country_names):
             if rec['adm0_a3'] == country:
                 admin1_info[country].append(rec)
                 admin1_shapes[country].append(rec_shp)
+    if len(admin1_info) != len(country_names):
+        raise LookupError('Mismatch between country_names and admin1_info.keys(): ' +\
+                          f'{country_names} != {list(admin1_info.keys())}. ' +\
+                          'This could be due to differences in ISO3 code between' +\
+                          'pycountry and natural_earth'
+                          )
     return admin1_info, admin1_shapes
 
 def get_admin1_geometries(countries):
@@ -1188,11 +1194,12 @@ def get_admin1_geometries(countries):
 
     Parameters
     ----------
-    countries : list or str
-        string or list with strings, either ISO3 code or names of countries, e.g.:
+    countries : list or str or int
+        string or list containing strings, either ISO3 code or ISO2 code or names
+        names of countries, e.g.:
         ['ZWE', 'GBR', 'VNM', 'UZB', 'Kenya', '051']
         For example, for Armenia, the following inputs work:
-            'Armenia', 'ARM', '051', 51
+            'Armenia', 'ARM', 'AM', '051', 51
 
     Returns
     -------
@@ -1230,7 +1237,6 @@ def get_admin1_geometries(countries):
         gdf_tmp.iso_3a = country
         gdf = gdf.append(gdf_tmp, ignore_index=True)
     return gdf
-
 
 def get_resolution_1d(coords, min_resol=1.0e-8):
     """Compute resolution of scalar grid

--- a/climada/util/coordinates.py
+++ b/climada/util/coordinates.py
@@ -1220,11 +1220,7 @@ def get_admin1_geometries(countries):
         gdf_tmp = gpd.GeoDataFrame(columns = gdf.columns)
         gdf_tmp.admin1_name = [record['name'] for record in admin1_info[country]]
         gdf_tmp.iso_3166_2 = [record['iso_3166_2'] for record in admin1_info[country]]
-        geoseries = gpd.GeoSeries()
-        for shape in admin1_shapes[country]:
-            # fill shape into GeoSeries,
-            # this automatically transforms shape to Polygon object:
-            geoseries = geoseries.append(gpd.GeoSeries(shape))
+       geoseries = gpd.GeoSeries([gpd.Geoseries(shape) for shape in admin1_shapes[country]])
         gdf_tmp.geometry = list(geoseries)
         # fill columns with country identifiers (admin 0):
         gdf_tmp.iso_3n = pycountry.countries.lookup(country).numeric

--- a/climada/util/coordinates.py
+++ b/climada/util/coordinates.py
@@ -894,7 +894,7 @@ def assign_coordinates(coords, coords_to_assign, method="NN", distance="haversin
 
     if not coords.any():
         return np.array([])
-    elif not coords_to_assign.any():
+    if not coords_to_assign.any():
         return -np.ones(coords.shape[0]).astype(int)
     coords = coords.astype('float64')
     coords_to_assign = coords_to_assign.astype('float64')

--- a/climada/util/coordinates.py
+++ b/climada/util/coordinates.py
@@ -1220,7 +1220,10 @@ def get_admin1_geometries(countries):
         gdf_tmp = gpd.GeoDataFrame(columns = gdf.columns)
         gdf_tmp.admin1_name = [record['name'] for record in admin1_info[country]]
         gdf_tmp.iso_3166_2 = [record['iso_3166_2'] for record in admin1_info[country]]
-       geoseries = gpd.GeoSeries([gpd.Geoseries(shape) for shape in admin1_shapes[country]])
+        # With this initiation of GeoSeries in a list comprehension, 
+        # the ability of geopandas to convert shapefile.Shape to (Multi)Polygon is exploited:
+        geoseries = gpd.GeoSeries([gpd.GeoSeries(shape).values[0] 
+                                   for shape in admin1_shapes[country]])
         gdf_tmp.geometry = list(geoseries)
         # fill columns with country identifiers (admin 0):
         gdf_tmp.iso_3n = pycountry.countries.lookup(country).numeric

--- a/climada/util/test/test_coordinates.py
+++ b/climada/util/test/test_coordinates.py
@@ -576,9 +576,10 @@ class TestGetGeodata(unittest.TestCase):
 
     def test_get_admin1_info_pass(self):
         """test get_admin1_info()"""
-        country_names = ['CHE', 'Indonesia', 'USA']
+        country_names = ['CHE', 'Indonesia', '840', 51]
         admin1_info, admin1_shapes = u_coord.get_admin1_info(country_names)
-        self.assertEqual(len(admin1_info), 3)
+        self.assertEqual(len(admin1_info), 4)
+        self.assertListEqual(list(admin1_info.keys()), ['CHE', 'IDN', 'USA', 'ARM'])
         self.assertEqual(len(admin1_info['CHE']), len(admin1_shapes['CHE']))
         self.assertEqual(len(admin1_info['CHE']), 26)
         self.assertEqual(len(admin1_shapes['IDN']), 33)

--- a/climada/util/test/test_coordinates.py
+++ b/climada/util/test/test_coordinates.py
@@ -592,6 +592,7 @@ class TestGetGeodata(unittest.TestCase):
         gdf = u_coord.get_admin1_geometries(countries)
         self.assertEqual(len(gdf.iso_3a.unique()), 4) # 4 countries
         self.assertEqual(gdf.loc[gdf.iso_3a=='CHE'].shape[0], 26) # 26 cantons in CHE
+        self.assertEqual(gdf.shape[0], 121) # 121 admin 1 regions in the 4 countries
         self.assertIn('ARM', gdf.iso_3a.values) # Armenia (region_id 051)
         self.assertIn('756', gdf.iso_3n.values) # Switzerland (region_id 756)
         self.assertIn('CH-AI', gdf.iso_3166_2.values) # canton in CHE

--- a/climada/util/test/test_coordinates.py
+++ b/climada/util/test/test_coordinates.py
@@ -586,6 +586,30 @@ class TestGetGeodata(unittest.TestCase):
         self.assertEqual(len(admin1_info['USA']), 51)
         self.assertEqual(admin1_info['USA'][1][4], 'US-WA')
 
+    def test_get_admin1_geometries_pass(self):
+        """test get_admin1_geometries"""
+        countries = ['CHE', 'Indonesia', '840', 51]
+        gdf = u_coord.get_admin1_geometries(countries)
+        self.assertEqual(len(gdf.iso_3a.unique()), 4) # 4 countries
+        self.assertEqual(gdf.loc[gdf.iso_3a=='CHE'].shape[0], 26) # 26 cantons in CHE
+        self.assertIn('ARM', gdf.iso_3a.values) # Armenia (region_id 051)
+        self.assertIn('756', gdf.iso_3n.values) # Switzerland (region_id 756)
+        self.assertIn('CH-AI', gdf.iso_3166_2.values) # canton in CHE
+        self.assertIn('Sulawesi Tengah', gdf.admin1_name.values) # region in Indonesia
+        self.assertIsInstance(gdf.loc[gdf.iso_3166_2 == 'CH-AI'].geometry.values[0],
+                              shapely.geometry.MultiPolygon)
+        self.assertIsInstance(gdf.loc[gdf.admin1_name == 'Sulawesi Tengah'].geometry.values[0],
+                              shapely.geometry.MultiPolygon)
+        self.assertIsInstance(gdf.loc[gdf.admin1_name == 'Valais'].geometry.values[0],
+                              shapely.geometry.Polygon)
+
+    def test_get_admin1_geometries_fail(self):
+        """test get_admin1_geometries wrong input"""
+        # non existing country:
+        self.assertRaises(LookupError, u_coord.get_admin1_geometries, ["FantasyLand"])
+        # wrong variable type for 'countries', e.g. Polygon:
+        self.assertRaises(TypeError, u_coord.get_admin1_geometries, shapely.geometry.Polygon())
+
 class TestRasterMeta(unittest.TestCase):
     def test_is_regular_pass(self):
         """Test is_regular function."""

--- a/climada/util/test/test_coordinates.py
+++ b/climada/util/test/test_coordinates.py
@@ -577,7 +577,7 @@ class TestGetGeodata(unittest.TestCase):
     def test_get_admin1_info_pass(self):
         """test get_admin1_info()"""
         country_names = ['CHE', 'Indonesia', '840', 51]
-        admin1_info, admin1_shapes = u_coord.get_admin1_info(country_names)
+        admin1_info, admin1_shapes = u_coord.get_admin1_info(country_names=country_names)
         self.assertEqual(len(admin1_info), 4)
         self.assertListEqual(list(admin1_info.keys()), ['CHE', 'IDN', 'USA', 'ARM'])
         self.assertEqual(len(admin1_info['CHE']), len(admin1_shapes['CHE']))
@@ -589,7 +589,7 @@ class TestGetGeodata(unittest.TestCase):
     def test_get_admin1_geometries_pass(self):
         """test get_admin1_geometries"""
         countries = ['CHE', 'Indonesia', '840', 51]
-        gdf = u_coord.get_admin1_geometries(countries)
+        gdf = u_coord.get_admin1_geometries(countries=countries)
         self.assertEqual(len(gdf.iso_3a.unique()), 4) # 4 countries
         self.assertEqual(gdf.loc[gdf.iso_3a=='CHE'].shape[0], 26) # 26 cantons in CHE
         self.assertEqual(gdf.shape[0], 121) # 121 admin 1 regions in the 4 countries

--- a/climada/util/test/test_coordinates.py
+++ b/climada/util/test/test_coordinates.py
@@ -576,7 +576,7 @@ class TestGetGeodata(unittest.TestCase):
 
     def test_get_admin1_info_pass(self):
         """test get_admin1_info()"""
-        country_names = ['CHE', 'IDN', 'USA']
+        country_names = ['CHE', 'Indonesia', 'USA']
         admin1_info, admin1_shapes = u_coord.get_admin1_info(country_names)
         self.assertEqual(len(admin1_info), 3)
         self.assertEqual(len(admin1_info['CHE']), len(admin1_shapes['CHE']))


### PR DESCRIPTION
- Add function `get_admin1_geometries` returning GDF with geometries of admin 1 regions within given countries.
- Adds flexibility to existing function `get_admin1_info` with regard to country identifier provided.

(I have not added the functionality to extract the geometry of a single admin 1 region in here - but this could be added with a wrapper function.)