### PR TITLE
hazard.Hazard.from_raster: call the constructor without haz_type

### DIFF
--- a/climada/hazard/base.py
+++ b/climada/hazard/base.py
@@ -277,9 +277,16 @@ class Hazard():
         if files_fraction is not None and len(files_intensity) != len(files_fraction):
             raise ValueError('Number of intensity files differs from fraction files: %s != %s'
                              % (len(files_intensity), len(files_fraction)))
-        if haz_type is None:
-            haz_type = cls().tag.haz_type
-        haz = cls(haz_type, pool)
+
+        if haz_type and cls is Hazard:
+            haz = cls(haz_type=haz_type, pool=pool)
+        else:
+            haz = cls(pool=pool)
+        
+        if haz_type and cls is not Hazard:
+            LOGGER.warn("haz_type argument ('%s') is ignored, haz_type is determined by class",
+                        haz_type)
+
         haz.tag.file_name = str(files_intensity) + ' ; ' + str(files_fraction)
 
         haz.centroids = Centroids.from_raster_file(

--- a/climada/hazard/base.py
+++ b/climada/hazard/base.py
@@ -278,14 +278,15 @@ class Hazard():
             raise ValueError('Number of intensity files differs from fraction files: %s != %s'
                              % (len(files_intensity), len(files_fraction)))
 
-        if haz_type and cls is Hazard:
-            haz = cls(haz_type=haz_type, pool=pool)
+        if haz_type is not None:
+            try:
+                haz = cls(haz_type=haz_type, pool=pool)
+            except TypeError:
+                haz = cls(pool=pool)
+                LOGGER.warn("haz_type argument ('%s') is ignored, haz_type is determined by class",
+                            haz_type)
         else:
             haz = cls(pool=pool)
-        
-        if haz_type and cls is not Hazard:
-            LOGGER.warn("haz_type argument ('%s') is ignored, haz_type is determined by class",
-                        haz_type)
 
         haz.tag.file_name = str(files_intensity) + ' ; ' + str(files_fraction)
 


### PR DESCRIPTION
This PR fixes issue https://github.com/CLIMADA-project/climada_petals/issues/15.