### PR TITLE
Make stricter check when using  raster approach to assign centroids

### DIFF
--- a/climada/entity/exposures/base.py
+++ b/climada/entity/exposures/base.py
@@ -390,7 +390,9 @@ class Exposures():
                     str(self.gdf.shape[0]), str(hazard.centroids.size))
         if not u_coord.equal_crs(self.crs, hazard.centroids.crs):
             raise ValueError('Set hazard and exposure to same CRS first!')
-        if hazard.centroids.meta:
+        if hazard.centroids.meta and \
+                hazard.centroids.meta['height'] and \
+                hazard.centroids.size == hazard.centroids.meta['height'] * hazard.centroids.meta['width']:
             assigned = u_coord.assign_grid_points(
                 self.gdf.longitude.values, self.gdf.latitude.values,
                 hazard.centroids.meta['width'], hazard.centroids.meta['height'],

--- a/climada/entity/exposures/base.py
+++ b/climada/entity/exposures/base.py
@@ -391,7 +391,7 @@ class Exposures():
         if not u_coord.equal_crs(self.crs, hazard.centroids.crs):
             raise ValueError('Set hazard and exposure to same CRS first!')
         if hazard.centroids.meta and \
-                hazard.centroids.meta['height'] and \
+                'height' in hazard.centroids.meta and \
                 hazard.centroids.size == hazard.centroids.meta['height'] * hazard.centroids.meta['width']:
             assigned = u_coord.assign_grid_points(
                 self.gdf.longitude.values, self.gdf.latitude.values,

--- a/climada/entity/exposures/base.py
+++ b/climada/entity/exposures/base.py
@@ -392,7 +392,7 @@ class Exposures():
             raise ValueError('Set hazard and exposure to same CRS first!')
         if hazard.centroids.meta and \
                 'height' in hazard.centroids.meta and \
-                hazard.centroids.size == hazard.centroids.meta['height'] * hazard.centroids.meta['width']:
+                hazard.centroids.lat.size == hazard.centroids.meta['height'] * hazard.centroids.meta['width']:
             assigned = u_coord.assign_grid_points(
                 self.gdf.longitude.values, self.gdf.latitude.values,
                 hazard.centroids.meta['width'], hazard.centroids.meta['height'],


### PR DESCRIPTION
In `Exposures.assign_centroids`, the first thing the method tries involves rasters, since this is fast. It decides this is possible if the Hazard's centroids have a `meta` property.

However a `Centroids` object having a `meta` isn't equivalent to it being a complete raster. For example, `Centroids.union` creates a `Centroids` object with a its `meta` as `{}`, and calling `Hazard.lat_lon_to_meta` will create a `meta` for its centroids, regardless of whether the Centroids are defined at every grid point of the implied raster (side thought: is this correct behaviour?)

I've improved the check so that it makes sure that the number of centroids matches the number of grid cells defined by the meta.