### PR TITLE
from_ibtracs_netcdf: store selected agency for each track variable

### DIFF
--- a/climada/hazard/tc_tracks.py
+++ b/climada/hazard/tc_tracks.py
@@ -1025,7 +1025,7 @@ class TCTracks():
 
         if land_params:
             extent = self.get_extent()
-            land_geom = u_coord.get_land_geometry(extent, resolution=10)
+            land_geom = u_coord.get_land_geometry(extent=extent, resolution=10)
         else:
             land_geom = None
 

--- a/climada/hazard/test/test_tc_tracks.py
+++ b/climada/hazard/test/test_tc_tracks.py
@@ -117,7 +117,9 @@ class TestIbtracs(unittest.TestCase):
         self.assertEqual(track_ds.sid, '2017242N16333')
         self.assertEqual(track_ds.name, 'IRMA')
         self.assertEqual(track_ds.orig_event_flag, True)
-        self.assertEqual(track_ds.data_provider, 'ibtracs_official_3h_mixed')
+        self.assertEqual(track_ds.data_provider,
+                         'ibtracs_mixed:lat(official_3h),lon(official_3h),wind(official_3h),'
+                         'pres(official_3h),rmw(official_3h),poci(official_3h),roci(official_3h)')
         self.assertEqual(track_ds.category, 5)
 
     def test_ibtracs_with_provider(self):
@@ -134,7 +136,9 @@ class TestIbtracs(unittest.TestCase):
         tc_track = tc.TCTracks.from_ibtracs_netcdf(storm_id=storm_id)
         track_ds = tc_track.get_track()
         self.assertEqual(track_ds.time.size, 35)
-        self.assertEqual(track_ds.data_provider, 'ibtracs_official_3h_mixed')
+        self.assertEqual(track_ds.data_provider,
+                         'ibtracs_mixed:lat(official_3h),lon(official_3h),wind(official_3h),'
+                         'pres(official_3h),rmw(usa),poci(usa),roci(usa)')
         self.assertAlmostEqual(track_ds.lat.values[-1], 31.40, places=5)
         self.assertAlmostEqual(track_ds.central_pressure.values[-1], 980, places=5)
 
@@ -157,7 +161,9 @@ class TestIbtracs(unittest.TestCase):
         track_ds = tc_track.get_track()
         # less time steps are discarded, leading to a larger total size
         self.assertEqual(track_ds.time.size, 99)
-        self.assertEqual(track_ds.data_provider, 'ibtracs_official_3h_mixed')
+        self.assertEqual(track_ds.data_provider,
+                         'ibtracs_mixed:lat(official_3h),lon(official_3h),wind(official_3h),'
+                         'pres(official_3h),rmw(usa),poci(usa),roci(usa)')
         self.assertAlmostEqual(track_ds.lat.values[44], 33.30, places=5)
         self.assertAlmostEqual(track_ds.central_pressure.values[44], 976, places=5)
         self.assertAlmostEqual(track_ds.central_pressure.values[42], 980, places=5)


### PR DESCRIPTION
This PR makes sure that the data source (provider/reporting agency) of each track and variable generated in `TCTracks.from_ibtracs_netcdf` is stored so that users can better understand where a particular time series came from. The information is stored in the `data_provider` attribute of each track.

Example: `ibtracs_mixed:lat(official_3h),lon(official_3h),wind(official_3h),pres(official_3h),rmw(usa),poci(usa),roci(usa)` means that latitude, longitude, max. wind and min. pressure have been taken from the officially reporting agency while the radius of maximum wind, the environmental pressure and the storm radius have been taken from the `usa` agency.