### PR TITLE
HDF5 file IO for TCTracks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,7 @@ climada/engine/test/data/test_imp_mat.npz
 climada/engine/test/data/test.xlsx
 climada/entity/impact_funcs/test/data/test_write.xlsx
 climada/hazard/test/data/tc_tracks_nc/*
+climada/hazard/test/data/tc_tracks.h5
 climada/hazard/test/data/test_centr.h5
 climada/hazard/test/data/test_haz.h5
 climada/test/data/1988234N13299.nc

--- a/climada/hazard/tc_tracks.py
+++ b/climada/hazard/tc_tracks.py
@@ -1264,7 +1264,7 @@ class TCTracks():
         tr.data = data
         return tr
 
-    def write_hdf5(self, file_name, complevel=4):
+    def write_hdf5(self, file_name, complevel=5):
         """Write TC tracks in NetCDF4-compliant HDF5 format.
 
         Parameters
@@ -1272,8 +1272,8 @@ class TCTracks():
         file_name: str or Path
             Path to a new HDF5 file. If it exists already, the file is overwritten.
         complevel : int
-            Specifies a compression level (0-9) for the gzip compression of the data.
-            A value of 0 or None disables compression. Default: 4
+            Specifies a compression level (0-9) for the zlib compression of the data.
+            A value of 0 or None disables compression. Default: 5
         """
         # initialise the data set with the size information
         xr.Dataset(attrs={'size': self.size}).to_netcdf(file_name, mode="w", format="NetCDF4")
@@ -1288,7 +1288,8 @@ class TCTracks():
 
             # change dtype from bool to int to be NetCDF4-compliant
             track.attrs['orig_event_flag'] = int(track.attrs['orig_event_flag'])
-            track.to_netcdf(file_name, mode="a", group=f"track{i}")
+            encoding = {var: dict(zlib=True, complevel=complevel) for var in track.data_vars}
+            track.to_netcdf(file_name, mode="a", group=f"track{i}", encoding=encoding)
             track.attrs['orig_event_flag'] = bool(track.attrs['orig_event_flag'])
 
         if last_perc != 100:

--- a/climada/hazard/tc_tracks.py
+++ b/climada/hazard/tc_tracks.py
@@ -1264,15 +1264,15 @@ class TCTracks():
         return tr
 
     def write_hdf(self, file_name, complevel=5):
-        """Write TC tracks in hdf5 format.
+        """Write TC tracks in HDF5 format.
 
         Parameters
         ----------
-        file_name: str
-            File name to write, with h5 format
+        file_name: str or Path
+            Path to a new HDF5 file. If it exists already, the file is overwritten.
         complevel : int
             Specifies a compression level (0-9) for the data.
-            A value of 0 or None disables compression. Default: None
+            A value of 0 or None disables compression. Default: 5
         """
         with pd.HDFStore(file_name, mode="w", complevel=complevel) as store:
             attr_keys = sorted(set.union(*[set(d.attrs.keys()) for d in self.data]))
@@ -1283,17 +1283,17 @@ class TCTracks():
 
     @classmethod
     def from_hdf(cls, file_name):
-        """Create new TCTracks object from hdf5 file
+        """Create new TCTracks object from HDF5 file
 
         Parameters
         ----------
-        file_name : str
-            File name of a file that has been generated with `TCTracks.write_hdf`.
+        file_name : str or Path
+            Path to a file that has been generated with `TCTracks.write_hdf`.
 
         Returns
         -------
         tracks : TCTracks
-            TCTracks with data from the given hdf5 file.
+            TCTracks with data from the given HDF5 file.
         """
         data = []
         with pd.HDFStore(file_name, mode="r") as store:

--- a/climada/hazard/tc_tracks.py
+++ b/climada/hazard/tc_tracks.py
@@ -151,6 +151,13 @@ EMANUEL_RMW_CORR_FACTOR = 2.0
 """Kerry Emanuel track files in this list require a correction: The radius of
     maximum wind (rmstore) needs to be multiplied by factor 2."""
 
+STORM_1MIN_WIND_FACTOR = 0.88
+"""Scaling factor used in Bloemendaal et al. (2020) to convert 1-minute sustained wind speeds to
+10-minute sustained wind speeds.
+
+Bloemendaal et al. (2020): Generation of a global synthetic tropical cyclone hazard
+dataset using STORM. Scientific Data 7(1): 40."""
+
 class TCTracks():
     """Contains tropical cyclone tracks.
 
@@ -969,7 +976,7 @@ class TCTracks():
         tracks_df['wind'] *= (1 * ureg.meter / ureg.second).to(ureg.knot).magnitude
 
         # convert from 10-minute to 1-minute sustained winds, see Bloemendaal et al. (2020)
-        tracks_df['wind'] /= 0.88
+        tracks_df['wind'] /= STORM_1MIN_WIND_FACTOR
 
         # conversion to absolute times
         tracks_df['time'] = tracks_df['time_start'] + tracks_df['time_delta']

--- a/climada/hazard/tc_tracks.py
+++ b/climada/hazard/tc_tracks.py
@@ -1277,12 +1277,23 @@ class TCTracks():
         """
         with h5py.File(file_name, 'w') as store:
             store.create_dataset('size', (), dtype=int, data=self.size)
+
+            LOGGER.info('Writing %d tracks to %s', self.size, file_name)
+            last_perc = 0
             for i, tr in enumerate(self.data):
+                perc = 100 * i / self.size
+                if perc - last_perc >= 10:
+                    LOGGER.info("Progress: %d%%", perc)
+                    last_perc = perc
+
                 tr['basin'] = tr['basin'].astype('<U2')
                 tr_bytes = tr.to_netcdf()
                 store.create_dataset(
                     f'track{i}', (1,), dtype=f'|S{len(tr_bytes)}', data=[tr_bytes],
                     compression='gzip', compression_opts=complevel)
+
+            if last_perc != 100:
+                LOGGER.info("Progress: 100%")
 
     @classmethod
     def from_hdf(cls, file_name):

--- a/climada/hazard/tc_tracks.py
+++ b/climada/hazard/tc_tracks.py
@@ -1288,8 +1288,8 @@ class TCTracks():
             Specifies a compression level (0-9) for the zlib compression of the data.
             A value of 0 or None disables compression. Default: 5
         """
+        # change dtype from bool to int to be NetCDF4-compliant, this is undone later
         for i, track in enumerate(self.data):
-            # change dtype from bool to int to be NetCDF4-compliant
             track.attrs['orig_event_flag'] = int(track.attrs['orig_event_flag'])
         try:
             encoding = {
@@ -1300,6 +1300,7 @@ class TCTracks():
             LOGGER.info('Writing %d tracks to %s', self.size, file_name)
             _xr_to_netcdf_multi(file_name, ds_dict, encoding=encoding)
         finally:
+            # ensure to undo the temporal change of dtype from above
             for i, track in enumerate(self.data):
                 track.attrs['orig_event_flag'] = bool(track.attrs['orig_event_flag'])
 

--- a/climada/hazard/tc_tracks.py
+++ b/climada/hazard/tc_tracks.py
@@ -869,8 +869,8 @@ class TCTracks():
 
             # add tracks one by one
             last_perc = 0
-            for i_track in chaz_ds.id_no:
-                perc = 100 * len(data) / chaz_ds.id_no.size
+            for cnt, i_track in enumerate(chaz_ds.id_no):
+                perc = 100 * cnt / chaz_ds.id_no.size
                 if perc - last_perc >= 10:
                     LOGGER.info("Progress: %d%%", perc)
                     last_perc = perc
@@ -920,6 +920,8 @@ class TCTracks():
 
             https://doi.org/10.4121/uuid:82c1dc0d-5485-43d8-901a-ce7f26cda35d
 
+        Wind speeds are converted to 1-minute sustained winds by dividing by 0.88.
+
         Parameters
         ----------
         path : str
@@ -956,10 +958,16 @@ class TCTracks():
         # a bug in the data causes some storm tracks to be double-listed:
         tracks_df = tracks_df.drop_duplicates(subset=["year", "tc_num", "time_delta"])
 
-        # conversion of units and time
+        # conversion of units
         tracks_df['rmw'] *= (1 * ureg.kilometer).to(ureg.nautical_mile).magnitude
         tracks_df['wind'] *= (1 * ureg.meter / ureg.second).to(ureg.knot).magnitude
+
+        # convert from 10-minute to 1-minute sustained winds
+        tracks_df['wind'] /= 0.88
+
+        # conversion to absolute times
         tracks_df['time'] = tracks_df['time_start'] + tracks_df['time_delta']
+
         tracks_df = tracks_df.drop(
             labels=['time_start', 'time_delta', 'landfall', 'dist_to_land'], axis=1)
 

--- a/climada/hazard/tc_tracks.py
+++ b/climada/hazard/tc_tracks.py
@@ -1301,6 +1301,7 @@ class TCTracks():
         data = []
         with h5py.File(file_name, 'r') as store:
             size = store.get('size')[()]
+            LOGGER.info('Reading %d tracks from %s', size, file_name)
             for i in range(size):
                 tr_ds = store.get(f'track{i}')
                 tr_bytes = tr_ds[0].ljust(int(str(tr_ds.dtype)[2:]), b'\x00')

--- a/climada/hazard/test/test_tc_tracks.py
+++ b/climada/hazard/test/test_tc_tracks.py
@@ -308,6 +308,26 @@ class TestIO(unittest.TestCase):
             self.assertEqual(tr.basin.shape, tr.time.shape)
             np.testing.assert_array_equal(tr.basin, "SP")
 
+    def test_hdf_io(self):
+        """Test writting and reading hdf5 TCTracks instances"""
+        path = DATA_DIR.joinpath("tc_tracks.h5")
+        tc_track = tc.TCTracks.from_ibtracs_netcdf(
+            provider='usa', year_range=(1993, 1994), basin='EP', estimate_missing=True)
+        tc_track.write_hdf(path)
+        tc_read = tc.TCTracks.from_hdf(path)
+
+        self.assertEqual(len(tc_track.data), len(tc_read.data))
+        for tr, tr_read in zip(tc_track.data, tc_read.data):
+            self.assertEqual(set(tr.attrs.keys()), set(tr_read.attrs.keys()))
+            self.assertEqual(set(tr.variables), set(tr_read.variables))
+            self.assertEqual(set(tr.coords), set(tr_read.coords))
+            for key in tr.attrs.keys():
+                self.assertEqual(tr.attrs[key], tr_read.attrs[key])
+            for v in tr.variables:
+                self.assertEqual(tr[v].dtype, tr_read[v].dtype)
+                np.testing.assert_array_equal(tr[v].values, tr_read[v].values)
+            self.assertEqual(tr.sid, tr_read.sid)
+
     def test_from_processed_ibtracs_csv(self):
         tc_track = tc.TCTracks.from_processed_ibtracs_csv(TEST_TRACK)
 

--- a/climada/hazard/test/test_tc_tracks.py
+++ b/climada/hazard/test/test_tc_tracks.py
@@ -308,13 +308,14 @@ class TestIO(unittest.TestCase):
             self.assertEqual(tr.basin.shape, tr.time.shape)
             np.testing.assert_array_equal(tr.basin, "SP")
 
-    def test_hdf_io(self):
+    def test_hdf5_io(self):
         """Test writting and reading hdf5 TCTracks instances"""
         path = DATA_DIR.joinpath("tc_tracks.h5")
         tc_track = tc.TCTracks.from_ibtracs_netcdf(
             provider='usa', year_range=(1993, 1994), basin='EP', estimate_missing=True)
-        tc_track.write_hdf(path)
-        tc_read = tc.TCTracks.from_hdf(path)
+        tc_track.write_hdf5(path)
+        tc_read = tc.TCTracks.from_hdf5(path)
+        path.unlink()
 
         self.assertEqual(len(tc_track.data), len(tc_read.data))
         for tr, tr_read in zip(tc_track.data, tc_read.data):
@@ -373,6 +374,7 @@ class TestIO(unittest.TestCase):
         self.assertEqual(tc_track.data[0].central_pressure_unit, 'mb')
         self.assertEqual(tc_track.data[0].sid, '1')
         self.assertEqual(tc_track.data[0].name, '1')
+        self.assertEqual(tc_track.data[0].basin.dtype, '<U2')
         self.assertTrue(np.all([np.all(d.basin == 'N') for d in tc_track.data]))
         self.assertEqual(tc_track.data[0].category, 3)
 
@@ -415,6 +417,7 @@ class TestIO(unittest.TestCase):
         self.assertEqual(tc_track_G.data[0].central_pressure_unit, 'mb')
         self.assertEqual(tc_track_G.data[0].sid, '0')
         self.assertEqual(tc_track_G.data[0].name, '0')
+        self.assertEqual(tc_track_G.data[0].basin.dtype, '<U2')
         np.testing.assert_array_equal(tc_track_G.data[0].basin, 'NI')
         self.assertEqual(tc_track_G.data[0].category, 0)
 

--- a/climada/hazard/test/test_tc_tracks.py
+++ b/climada/hazard/test/test_tc_tracks.py
@@ -456,7 +456,7 @@ class TestIO(unittest.TestCase):
         self.assertEqual(tc_track.data[0].lon[3], 245.3)
         self.assertEqual(tc_track.data[0].lat[4], 11.9)
         self.assertEqual(tc_track.data[0].time_step[3], 3)
-        self.assertEqual(tc_track.data[0].max_sustained_wind[2], 37.127429805615556)
+        self.assertEqual(tc_track.data[0].max_sustained_wind[2], 42.19026114274495)
         self.assertEqual(tc_track.data[0].radius_max_wind[5], 19.07407454551836)
         self.assertEqual(tc_track.data[0].central_pressure[1], 999.4)
         self.assertTrue(np.all(tc_track.data[0].time.dt.year == 1980))


### PR DESCRIPTION
For Hazard and Exposure objects, CLIMADA comes with handy methods to read and write to/from HDF5 files. For `TCTracks` objects, users have to either use pickle (whick has its own issues) or the `write_netcdf` functionality.

The problem with the NetCDF IO is that all tracks are stored in separate files. On many setups, especially with network file systems, the access times for many small files can be extremely bad.

That's why this PR adds IO methods `write_hdf` and `from_hdf` for `TCTracks`, in line with the corresponding functionality for Hazard and Exposure objects. All tracks are stored in a single hdf5 file.