### PR TITLE
Fix infinite frequency

### DIFF
--- a/climada/hazard/storm_europe.py
+++ b/climada/hazard/storm_europe.py
@@ -171,7 +171,7 @@ class StormEurope(Hazard):
         haz.event_id = np.arange(1, len(haz.event_id) + 1)
         haz.frequency = np.divide(
             np.ones_like(haz.date),
-            (last_year(haz.date) - first_year(haz.date))
+            np.max([(last_year(haz.date) - first_year(haz.date)), 1])
         )
 
         haz.tag = TagHazard(
@@ -262,6 +262,9 @@ class StormEurope(Hazard):
         Works for MeteoSwiss model output of
         COSMO-1E (11 members, resolution 1.1 km, forecast period 33-45 hours)
         COSMO-2E (21 members, resolution 2.2 km, forecast period 5 days)
+
+        The frequency of all storms is equal to 1/11 and 1/21 for COSMO-1E
+        and COSMO-2E, respectively.
 
         Parameters
         ----------
@@ -383,6 +386,8 @@ class StormEurope(Hazard):
         starting at 00H and 12H. Otherwise the aggregation is inaccurate,
         because of the given file structure with 1-hour, 3-hour and
         6-hour maxima provided.
+
+        The frequency for one event is 1/(number of runs).
 
         Parameters
         ----------

--- a/climada/hazard/storm_europe.py
+++ b/climada/hazard/storm_europe.py
@@ -263,8 +263,8 @@ class StormEurope(Hazard):
         COSMO-1E (11 members, resolution 1.1 km, forecast period 33-45 hours)
         COSMO-2E (21 members, resolution 2.2 km, forecast period 5 days)
 
-        The frequency of all storms is equal to 1/11 and 1/21 for COSMO-1E
-        and COSMO-2E, respectively.
+        The frequency of each event is informed by their probability in the ensemble
+        forecast and is equal to 1/11 or 1/21 for COSMO-1E or COSMO-2E, respectively.
 
         Parameters
         ----------
@@ -387,7 +387,7 @@ class StormEurope(Hazard):
         because of the given file structure with 1-hour, 3-hour and
         6-hour maxima provided.
 
-        The frequency for one event is 1/(number of runs).
+        The frequency for one event is 1/(number of ensemble members)
 
         Parameters
         ----------

--- a/climada/hazard/test/test_storm_europe.py
+++ b/climada/hazard/test/test_storm_europe.py
@@ -47,6 +47,27 @@ class TestReader(unittest.TestCase):
         self.assertEqual(cent.size, 9944)
 
     def test_from_footprints(self):
+        """Test from_footprints constructor, using one small test files"""
+        storms = StormEurope.from_footprints(WS_DEMO_NC[0], description='test_description')
+
+        self.assertEqual(storms.tag.haz_type, 'WS')
+        self.assertEqual(storms.units, 'm/s')
+        self.assertEqual(storms.event_id.size, 1)
+        self.assertEqual(storms.date.size, 1)
+        self.assertEqual(dt.datetime.fromordinal(storms.date[0]).year, 1999)
+        self.assertEqual(dt.datetime.fromordinal(storms.date[0]).month, 12)
+        self.assertEqual(dt.datetime.fromordinal(storms.date[0]).day, 26)
+        self.assertEqual(storms.event_id[0], 1)
+        self.assertEqual(storms.event_name[0], 'Lothar')
+        self.assertIsInstance(storms.intensity,
+                              sparse.csr.csr_matrix)
+        self.assertIsInstance(storms.fraction,
+                              sparse.csr.csr_matrix)
+        self.assertEqual(storms.intensity.shape, (1, 9944))
+        self.assertEqual(storms.fraction.shape, (1, 9944))
+        self.assertEqual(storms.frequency[0], 1.0)
+
+
         """Test from_footprints constructor, using two small test files"""
         storms = StormEurope.from_footprints(WS_DEMO_NC, description='test_description')
 


### PR DESCRIPTION
The method `StormEurope.from_footprints` resulted in a hazard with infinite frequency when reading a single footprint or a set of footprints from the same year.

This fixes the bug by taking as divisor in the frequency as `np.max([(last_year(haz.date) - first_year(haz.date)), 1])`.

In addition, the docstring for `from_cosmoe_file` and `from_icon_grid` were update to make it clear that the frequency is NOT in 1/years, but 1/(number of runs/ensemble members).