### PR TITLE
Fixes for Natural Earth 5.0.0 compatibility

### DIFF
--- a/climada/engine/impact_data.py
+++ b/climada/engine/impact_data.py
@@ -25,7 +25,6 @@ from pathlib import Path
 import pandas as pd
 import numpy as np
 from cartopy.io import shapereader
-import shapefile
 
 from climada.util.finance import gdp
 from climada.util.constants import DEF_CRS
@@ -952,7 +951,7 @@ def emdat_to_impact(emdat_file_csv, hazard_type_climada, year_range=None, countr
     shp = shapereader.natural_earth(resolution='110m',
                                     category='cultural',
                                     name='admin_0_countries')
-    shp = shapefile.Reader(shp)
+    shp = shapereader.Reader(shp)
     countries_reg_id = list()
     countries_lat = list()
     countries_lon = list()
@@ -964,8 +963,8 @@ def emdat_to_impact(emdat_file_csv, hazard_type_climada, year_range=None, countr
             LOGGER.warning('Country not found in iso_country: %s', cntry)
         cntry_boolean = False
         for rec_i, rec in enumerate(shp.records()):
-            if rec[9].casefold() == cntry.casefold():
-                bbox = shp.shapes()[rec_i].bbox
+            if rec.attributes['ADM0_A3'].casefold() == cntry.casefold():
+                bbox = rec.geometry.bounds
                 cntry_boolean = True
                 break
         if cntry_boolean:

--- a/climada/engine/impact_data.py
+++ b/climada/engine/impact_data.py
@@ -962,7 +962,7 @@ def emdat_to_impact(emdat_file_csv, hazard_type_climada, year_range=None, countr
         except LookupError:
             LOGGER.warning('Country not found in iso_country: %s', cntry)
         cntry_boolean = False
-        for rec_i, rec in enumerate(shp.records()):
+        for rec in shp.records():
             if rec.attributes['ADM0_A3'].casefold() == cntry.casefold():
                 bbox = rec.geometry.bounds
                 cntry_boolean = True

--- a/climada/util/coordinates.py
+++ b/climada/util/coordinates.py
@@ -1414,16 +1414,17 @@ def get_admin1_info(country_names):
     admin1_shapes = dict()
     for country in country_names:
         if isinstance(country, (int, float)):
-            country = f'{int(country):03d}' # transform numerric code to str
-        country = pycountry.countries.lookup(country).alpha_3 # get iso3a code
+            # transform numerric code to str
+            country = f'{int(country):03d}'
+        # get alpha-3 code according to ISO 3166
+        country = pycountry.countries.lookup(country).alpha_3
         admin1_info[country] = list()
         admin1_shapes[country] = list()
         for rec in admin1_recs.records():
-            rec_shp = rec.geometry
-            rec = rec.attributes
-            if rec['adm0_a3'] == country:
-                admin1_info[country].append(rec)
-                admin1_shapes[country].append(rec_shp)
+            rec_attrs = rec.attributes
+            if rec_attrs['adm0_a3'] == country:
+                admin1_info[country].append(rec_attrs)
+                admin1_shapes[country].append(rec.geometry)
         if len(admin1_info[country]) == 0:
             raise LookupError(f'natural_earth records are empty for country {country}')
     return admin1_info, admin1_shapes
@@ -1466,7 +1467,7 @@ def get_admin1_geometries(countries):
     admin1_info, admin1_shapes = get_admin1_info(countries)
     for country in admin1_info.keys():
         # fill admin 1 region names and codes to GDF for single country:
-        gdf_tmp = gpd.GeoDataFrame(columns = gdf.columns)
+        gdf_tmp = gpd.GeoDataFrame(columns=gdf.columns)
         gdf_tmp.admin1_name = [record['name'] for record in admin1_info[country]]
         gdf_tmp.iso_3166_2 = [record['iso_3166_2'] for record in admin1_info[country]]
         # With this initiation of GeoSeries in a list comprehension,

--- a/climada/util/coordinates.py
+++ b/climada/util/coordinates.py
@@ -1423,12 +1423,21 @@ def get_admin1_info(country_names):
         for rec in admin1_recs.records():
             rec_attrs = rec.attributes
             if rec_attrs['adm0_a3'] == country:
-                admin1_info[country].append(rec_attrs)
+                # Fiona wrongly assumes latin-1 encoding by default:
+                # https://github.com/SciTools/cartopy/issues/1282
+                # As a workaround, we encode and decode again:
+                admin1_info[country].append(dict([(x,_from_latin1_to_utf8(y)) for (x,y) in rec_attrs.items()]))
                 admin1_shapes[country].append(rec.geometry)
         if len(admin1_info[country]) == 0:
             raise LookupError(f'natural_earth records are empty for country {country}')
     return admin1_info, admin1_shapes
 
+def _from_latin1_to_utf8(val):
+    try:
+        return val.encode('latin-1').decode('utf-8')
+    except:
+        return val
+    
 def get_admin1_geometries(countries):
     """
     return geometries, names and codes of admin 1 regions in given countries

--- a/climada/util/coordinates.py
+++ b/climada/util/coordinates.py
@@ -46,7 +46,6 @@ import scipy.interpolate
 from shapely.geometry import Polygon, MultiPolygon, Point, box
 import shapely.ops
 import shapely.vectorized
-import shapefile
 from sklearn.neighbors import BallTree
 
 from climada.util.config import CONFIG
@@ -1410,7 +1409,7 @@ def get_admin1_info(country_names):
     admin1_file = shapereader.natural_earth(resolution='10m',
                                             category='cultural',
                                             name='admin_1_states_provinces')
-    admin1_recs = shapefile.Reader(admin1_file)
+    admin1_recs = shapereader.Reader(admin1_file)
     admin1_info = dict()
     admin1_shapes = dict()
     for country in country_names:
@@ -1419,7 +1418,9 @@ def get_admin1_info(country_names):
         country = pycountry.countries.lookup(country).alpha_3 # get iso3a code
         admin1_info[country] = list()
         admin1_shapes[country] = list()
-        for rec, rec_shp in zip(admin1_recs.records(), admin1_recs.shapes()):
+        for rec in admin1_recs.records():
+            rec_shp = rec.geometry
+            rec = rec.attributes
             if rec['adm0_a3'] == country:
                 admin1_info[country].append(rec)
                 admin1_shapes[country].append(rec_shp)

--- a/climada/util/coordinates.py
+++ b/climada/util/coordinates.py
@@ -1480,7 +1480,7 @@ def get_admin1_geometries(countries):
         gdf_tmp.admin1_name = [record['name'] for record in admin1_info[country]]
         gdf_tmp.iso_3166_2 = [record['iso_3166_2'] for record in admin1_info[country]]
         # With this initiation of GeoSeries in a list comprehension,
-        # the ability of geopandas to convert shapefile.Shape to (Multi)Polygon is exploited:
+        # the ability of geopandas to convert shapereader.Shape to (Multi)Polygon is exploited:
         geoseries = gpd.GeoSeries([gpd.GeoSeries(shape).values[0]
                                    for shape in admin1_shapes[country]])
         gdf_tmp.geometry = list(geoseries)

--- a/climada/util/finance.py
+++ b/climada/util/finance.py
@@ -163,9 +163,7 @@ def gdp(cntry_iso, ref_year, shp_file=None, per_capita=False):
         if isinstance(err, requests.exceptions.ConnectionError):
             LOGGER.warning('Internet connection failed while retrieving GDPs.')
         close_year, close_val = nat_earth_adm0(cntry_iso, 'GDP_MD', 'GDP_YEAR', shp_file)
-    finally:
-        LOGGER.info("GDP {} {:d}: {:.3e}.".format(cntry_iso, close_year,
-                                                  close_val))
+    LOGGER.info("GDP {} {:d}: {:.3e}.".format(cntry_iso, close_year, close_val))
 
     return close_year, close_val
 

--- a/climada/util/finance.py
+++ b/climada/util/finance.py
@@ -162,7 +162,7 @@ def gdp(cntry_iso, ref_year, shp_file=None, per_capita=False):
     except (ValueError, IndexError, requests.exceptions.ConnectionError) as err:
         if isinstance(err, requests.exceptions.ConnectionError):
             LOGGER.warning('Internet connection failed while retrieving GDPs.')
-        close_year, close_val = nat_earth_adm0(cntry_iso, 'GDP_MD_EST', 'GDP_YEAR', shp_file)
+        close_year, close_val = nat_earth_adm0(cntry_iso, 'GDP_MD', 'GDP_YEAR', shp_file)
     finally:
         LOGGER.info("GDP {} {:d}: {:.3e}.".format(cntry_iso, close_year,
                                                   close_val))
@@ -231,7 +231,7 @@ def nat_earth_adm0(cntry_iso, info_name, year_name=None, shp_file=None):
     cntry_iso : str
         key = ISO alpha_3 country
     info_name : str
-        attribute to get, e.g. 'GDP_MD_EST', 'INCOME_GRP'.
+        attribute to get, e.g. 'GDP_MD', 'INCOME_GRP'.
     year_name : str, optional
         year name of the info_name in shape file,
         e.g. 'GDP_YEAR'
@@ -263,7 +263,7 @@ def nat_earth_adm0(cntry_iso, info_name, year_name=None, shp_file=None):
     if not close_val:
         raise ValueError("No GDP for country %s found." % cntry_iso)
 
-    if info_name == 'GDP_MD_EST':
+    if info_name == 'GDP_MD':
         close_val *= 1e6
     elif info_name == 'INCOME_GRP':
         close_val = INCOME_GRP_NE_TABLE.get(int(close_val[0]))

--- a/climada/util/plot.py
+++ b/climada/util/plot.py
@@ -578,10 +578,15 @@ def add_populated_places(axis, extent, proj=ccrs.PlateCarree(), fontsize=None):
     for rec, point in zip(shp.records(), shp.geometries()):
         if ext_trans[2][0] < point.x <= ext_trans[0][0]:
             if ext_trans[0][1] < point.y <= ext_trans[1][1]:
-                # Fiona wrongly assumes latin-1 encoding by default:
+                # Without the `*.cpg` file present, the reader wrongly assumes latin-1 encoding:
                 # https://github.com/SciTools/cartopy/issues/1282
-                # As a workaround, we encode and decode again:
-                place_name = rec.attributes['name'].encode("latin-1").decode("utf-8")
+                # https://github.com/SciTools/cartopy/commit/6d787b01e122eea68b67a9b2966e45877755a52d
+                # As a workaround, we encode and decode again, unless this fails which means
+                # that the `*.cpg` is present and the encoding is correct:
+                try:
+                    place_name = rec.attributes['name'].encode("latin-1").decode("utf-8")
+                except UnicodeDecodeError:
+                    place_name = rec.attributes['name']
                 axis.plot(point.x, point.y, color='navy', marker='o',
                           transform=ccrs.PlateCarree(), markerfacecolor='None')
                 axis.text(point.x, point.y, place_name,

--- a/climada/util/test/test_coordinates.py
+++ b/climada/util/test/test_coordinates.py
@@ -864,7 +864,8 @@ class TestGetGeodata(unittest.TestCase):
         self.assertEqual(len(admin1_info['CHE']), 26)
         self.assertEqual(len(admin1_shapes['IDN']), 33)
         self.assertEqual(len(admin1_info['USA']), 51)
-        self.assertEqual(admin1_info['USA'][1]['iso_3166_2'], 'US-ID')
+        # depending on the version of Natural Earth, this is Washington or Idaho:
+        self.assertIn(admin1_info['USA'][1]['iso_3166_2'], ['US-WA', 'US-ID'])
 
     def test_get_admin1_geometries_pass(self):
         """test get_admin1_geometries"""

--- a/climada/util/test/test_coordinates.py
+++ b/climada/util/test/test_coordinates.py
@@ -864,7 +864,7 @@ class TestGetGeodata(unittest.TestCase):
         self.assertEqual(len(admin1_info['CHE']), 26)
         self.assertEqual(len(admin1_shapes['IDN']), 33)
         self.assertEqual(len(admin1_info['USA']), 51)
-        self.assertEqual(admin1_info['USA'][1][4], 'US-WA')
+        self.assertEqual(admin1_info['USA'][1]['iso_3166_2'], 'US-ID')
 
     def test_get_admin1_geometries_pass(self):
         """test get_admin1_geometries"""

--- a/climada/util/test/test_finance.py
+++ b/climada/util/test/test_finance.py
@@ -78,11 +78,11 @@ class TestWBData(unittest.TestCase):
     def test_ne_gdp_aia_2012_pass(self):
         """Test nat_earth_adm0 function Anguilla."""
         ref_year = 2012
-        res_year, res_val = nat_earth_adm0('AIA', 'GDP_MD_EST',
+        res_year, res_val = nat_earth_adm0('AIA', 'GDP_MD',
                                            'GDP_YEAR', SHP_FILE)
 
         ref_year = 2009
-        ref_val = 1.754e+08
+        ref_val = 1.75e+08
         self.assertEqual(res_year, ref_year)
         self.assertEqual(res_val, ref_val)
 


### PR DESCRIPTION
As discussed in #353, some data has changed in Natural Earth 5.0.0 and will cause several problems. Furthermore, this gets rid of `shapefile.Reader` in favor of `shapereader.Reader`.