### PR TITLE
Feature/hazard change cent drop duplicates

### DIFF
--- a/climada/hazard/base.py
+++ b/climada/hazard/base.py
@@ -1734,16 +1734,21 @@ class Hazard():
                 self.centroids.lon, self.centroids.lat,
                 centroids.meta['width'], centroids.meta['height'],
                 centroids.meta['transform'])
+            if -1 in new_cent_idx:
+                raise ValueError("At least one hazard centroid is out of"
+                                 "the raster defined by centroids.meta."
+                                 " Please choose a larger raster.")
         else:
             new_cent_idx = u_coord.assign_coordinates(
                 self.centroids.coord, centroids.coord, threshold=threshold
             )
+            if -1 in new_cent_idx:
+                raise ValueError("At least one hazard centroid is at a larger "
+                                 f"distance than the given threshold {threshold} "
+                                 "from the given centroids. Please choose a "
+                                 "larger threshold or enlarge the centroids")
 
-        if -1 in new_cent_idx:
-            raise ValueError("At least one hazard centroid is at a larger "
-                             f"distance than the given threshold {threshold} "
-                             "from the given centroids. Please choose a "
-                             "larger threshold or enlarge the centroids")
+
 
         if np.unique(new_cent_idx).size < new_cent_idx.size:
             raise ValueError("At least two hazard centroids are mapped to the same "

--- a/climada/hazard/base.py
+++ b/climada/hazard/base.py
@@ -1729,9 +1729,15 @@ class Hazard():
         haz_new_cent.centroids = centroids
 
         # indices for mapping matrices onto common centroids
-        new_cent_idx = u_coord.assign_coordinates(
-            self.centroids.coord, centroids.coord, threshold=threshold
-        )
+        if centroids.meta:
+            new_cent_idx = u_coord.assign_grid_points(
+                self.centroids.lon, self.centroids.lat,
+                centroids.meta['width'], centroids.meta['height'],
+                centroids.meta['transform'])
+        else:
+            new_cent_idx = u_coord.assign_coordinates(
+                self.centroids.coord, centroids.coord, threshold=threshold
+            )
 
         if -1 in new_cent_idx:
             raise ValueError("At least one hazard centroid is at a larger "

--- a/climada/hazard/test/test_base.py
+++ b/climada/hazard/test/test_base.py
@@ -846,8 +846,8 @@ class TestAppend(unittest.TestCase):
         with self.assertRaises(ValueError):
              Hazard.concat([haz1, haz4])
 
-    def test_change_centroids_pass(self):
-        """Set new new centroids for hazard"""
+    def test_change_centroids(self):
+        """Set new centroids for hazard"""
         cent1 = Centroids()
         cent1.lat, cent1.lon = np.array([0, 1]), np.array([0, -1])
         cent1.on_land = np.array([True, True])
@@ -888,6 +888,37 @@ class TestAppend(unittest.TestCase):
         with self.assertRaises(ValueError) as cm:
             haz_1.change_centroids(cent3, threshold=100)
         self.assertIn('two hazard centroids are mapped to the same centroids', str(cm.exception))
+
+        """Test Drop duplicates"""
+        haz_4 = haz_1.change_centroids(cent3, drop_duplicates=True)
+        self.assertTrue(np.array_equal(haz_4.intensity.toarray(),
+                               np.array([[0.2, 0.]])))
+        self.assertTrue(np.array_equal(haz_4.fraction.toarray(),
+                               np.array([[0.02, 0.]])))
+        self.assertTrue(np.array_equal(haz_4.event_id, np.array([1])))
+        self.assertTrue(np.array_equal(haz_4.event_name, ['ev1']))
+        self.assertTrue(np.array_equal(haz_4.orig, [True]))
+        self.assertEqual(haz_4.tag.description, 'Description 1')
+
+
+    def test_change_centroids_raster(self):
+        """Set new centroids for hazard"""
+        cent1 = Centroids()
+        cent1.lat, cent1.lon = np.array([0, 1]), np.array([0, -1])
+        cent1.on_land = np.array([True, True])
+
+        haz_1 = Hazard('TC')
+        haz_1.tag.file_name = 'file1.mat'
+        haz_1.tag.description = 'Description 1'
+        haz_1.centroids = cent1
+        haz_1.event_id = np.array([1])
+        haz_1.event_name = ['ev1']
+        haz_1.date = np.array([1])
+        haz_1.orig = np.array([True])
+        haz_1.frequency = np.array([1.0])
+        haz_1.fraction = sparse.csr_matrix([[0.02, 0.03]])
+        haz_1.intensity = sparse.csr_matrix([[0.2, 0.3]])
+        haz_1.units = 'm/s'
 
 
         """Test with raster centroids"""

--- a/climada/hazard/test/test_base.py
+++ b/climada/hazard/test/test_base.py
@@ -880,6 +880,7 @@ class TestAppend(unittest.TestCase):
         self.assertTrue(np.array_equal(haz_2.orig, [True]))
         self.assertEqual(haz_2.tag.description, 'Description 1')
 
+        """Test error for projection"""
         cent3 = Centroids()
         cent3.lat, cent3.lon = np.array([0.5, 3]), np.array([-0.5, 3])
         cent3.on_land = np.array([True, True, False])
@@ -887,6 +888,24 @@ class TestAppend(unittest.TestCase):
         with self.assertRaises(ValueError) as cm:
             haz_1.change_centroids(cent3, threshold=100)
         self.assertIn('two hazard centroids are mapped to the same centroids', str(cm.exception))
+
+
+        """Test with raster centroids"""
+        cent4 = Centroids.from_pnt_bounds(points_bounds=(-1, 0, 0, 1), res=1)
+        cent4.lat, cent1.lon = np.array([0, 1]), np.array([0, -1])
+        cent4.on_land = np.array([True, True])
+
+        haz_4 = haz_1.change_centroids(cent4)
+
+        self.assertTrue(np.array_equal(haz_4.intensity.toarray(),
+                               np.array([[0.3, 0.0, 0.0, 0.2]])))
+        self.assertTrue(np.array_equal(haz_4.fraction.toarray(),
+                               np.array([[0.03, 0.0, 0.0, 0.02]])))
+        self.assertTrue(np.array_equal(haz_4.event_id, np.array([1])))
+        self.assertTrue(np.array_equal(haz_4.event_name, ['ev1']))
+        self.assertTrue(np.array_equal(haz_4.orig, [True]))
+        self.assertEqual(haz_4.tag.description, 'Description 1')
+
 
 class TestStats(unittest.TestCase):
     """Test return period statistics"""


### PR DESCRIPTION
This PR introduces the `drop_duplicates` option of the `Hazard.change_centroids` method as a new feature.
The feature was originally proposed in PR #356 but held back for release 3.1.