### PR TITLE
TCTracks.equal_timestep: fix for non-normalized longitudes

### DIFF
--- a/climada/hazard/tc_tracks.py
+++ b/climada/hazard/tc_tracks.py
@@ -1428,7 +1428,7 @@ class TCTracks():
             method = ['linear', 'quadratic', 'cubic'][min(2, track.time.size - 2)]
 
             # handle change of sign in longitude
-            lon = track.lon.copy()
+            lon = u_coord.lon_normalize(track.lon.copy(), center=0)
             if (lon < -170).any() and (lon > 170).any():
                 # crosses 180 degrees east/west -> use positive degrees east
                 lon[lon < 0] += 360

--- a/climada/hazard/tc_tracks.py
+++ b/climada/hazard/tc_tracks.py
@@ -541,9 +541,12 @@ class TCTracks():
             ibtracs_ds[f'{tc_var}_agency'] = ('storm', selected_ags[preferred_idx.values])
 
             if tc_var == 'lon':
-                # By IBTrACS default, no longitude should be <= -180, but this is not true for some
-                # agencies, so we have to manually enforce this policy:
-                ibtracs_ds[tc_var].values[(ibtracs_ds[tc_var] <= -180).values] += 360
+                # Most IBTrACS longitudes are either normalized to [-180, 180] or to [0, 360], but
+                # some aren't normalized at all, so we have to make sure that the values are okay:
+                lons = ibtracs_ds[tc_var].values.copy()
+                lon_valid_mask = np.isfinite(lons)
+                lons[lon_valid_mask] = u_coord.lon_normalize(lons[lon_valid_mask], center=0.0)
+                ibtracs_ds[tc_var].values[:] = lons
 
                 # Make sure that the longitude is always chosen positive if a track crosses the
                 # antimeridian:

--- a/climada/hazard/test/test_tc_tracks.py
+++ b/climada/hazard/test/test_tc_tracks.py
@@ -623,9 +623,8 @@ class TestFuncs(unittest.TestCase):
                 tc_track.equal_timestep(time_step_h=time_step_h)
 
         # test for tracks with non-normalized longitude
-        tc_track = tc.TCTracks.from_ibtracs_netcdf(provider="nadi", storm_id="2016055S15202")
-        self.assertAlmostEqual(tc_track.data[0].lon.values[0], 203.7, places=1)
-        self.assertAlmostEqual(tc_track.data[0].lon.values[3], -155.7, places=1)
+        tc_track = tc.TCTracks.from_processed_ibtracs_csv(TEST_TRACK)
+        tc_track.data[0].lon.values[1] += 360
         tc_track.equal_timestep(time_step_h=1)
         np.testing.assert_array_less(tc_track.data[0].lon.values, 0)
 

--- a/climada/hazard/test/test_tc_tracks.py
+++ b/climada/hazard/test/test_tc_tracks.py
@@ -622,6 +622,13 @@ class TestFuncs(unittest.TestCase):
             with self.assertRaises(ValueError, msg=msg) as _cm:
                 tc_track.equal_timestep(time_step_h=time_step_h)
 
+        # test for tracks with non-normalized longitude
+        tc_track = tc.TCTracks.from_ibtracs_netcdf(provider="nadi", storm_id="2016055S15202")
+        self.assertAlmostEqual(tc_track.data[0].lon.values[0], 203.7, places=1)
+        self.assertAlmostEqual(tc_track.data[0].lon.values[3], -155.7, places=1)
+        tc_track.equal_timestep(time_step_h=1)
+        np.testing.assert_array_less(tc_track.data[0].lon.values, 0)
+
     def test_interp_origin_pass(self):
         """Interpolate track to min_time_step crossing lat origin"""
         tc_track = tc.TCTracks.from_processed_ibtracs_csv(TEST_TRACK)


### PR DESCRIPTION
I just noticed that there is an entry in IBTrACS where longitude values are in a very strange format. For the storm with IBTrACS ID "2016055S15202", the agency NADI reported longitudinal coordinates jumping from 204.30 to -155.73 and back to 204.20 (see http://ibtracs.unca.edu/index.php?name=v04r00-2016055S15202). When restricting to the official 6-hourly reporting intervals, the problem is not present, but many people make use of the unofficial 3-hourly data.

I never expected that something like this would exist, but now that we know that it exists, we have to make sure that CLIMADA normalizes all longitudinal values before applying interpolation. This PR fixes it. And it might also fix problems with other data sets that we don't know about currently.
