### PR TITLE
Save impact matrices in CostBenefit calculations?

### DIFF
--- a/climada/engine/cost_benefit.py
+++ b/climada/engine/cost_benefit.py
@@ -752,14 +752,14 @@ class CostBenefit():
             Default: average annual impact (aggregated).
         save_imp : bool, optional
             activate if Impact of each measure is
-            saved. Default: False.
+            saved. Also saves impact matrix. Default: False.
         """
         impact_meas = dict()
 
         # compute impact without measures
         LOGGER.debug('%s impact with no measure.', when)
         imp_tmp = Impact()
-        imp_tmp.calc(exposures, imp_fun_set, hazard)
+        imp_tmp.calc(exposures, imp_fun_set, hazard, save_imp)
         impact_meas[NO_MEASURE] = dict()
         impact_meas[NO_MEASURE]['cost'] = (0, 0)
         impact_meas[NO_MEASURE]['risk'] = risk_func(imp_tmp)
@@ -771,7 +771,7 @@ class CostBenefit():
         # compute impact for each measure
         for measure in meas_set.get_measure(hazard.tag.haz_type):
             LOGGER.debug('%s impact of measure %s.', when, measure.name)
-            imp_tmp, risk_transf = measure.calc_impact(exposures, imp_fun_set, hazard)
+            imp_tmp, risk_transf = measure.calc_impact(exposures, imp_fun_set, hazard, save_imp)
             impact_meas[measure.name] = dict()
             impact_meas[measure.name]['cost'] = (measure.cost, measure.risk_transf_cost_factor)
             impact_meas[measure.name]['risk'] = risk_func(imp_tmp)

--- a/climada/entity/measures/base.py
+++ b/climada/entity/measures/base.py
@@ -121,7 +121,7 @@ class Measure():
         u_check.size(2, self.mdd_impact, 'Measure.mdd_impact')
         u_check.size(2, self.paa_impact, 'Measure.paa_impact')
 
-    def calc_impact(self, exposures, imp_fun_set, hazard):
+    def calc_impact(self, exposures, imp_fun_set, hazard, save_mat=False):
         """
         Apply measure and compute impact and risk transfer of measure
         implemented over inputs.
@@ -134,6 +134,8 @@ class Measure():
             impact function set instance
         hazard : climada.hazard.Hazard
             hazard instance
+        save_mat : bool
+            save the calculated Impact's impact matrix. Passed to Impact.calc
 
         Returns
         -------
@@ -142,7 +144,7 @@ class Measure():
         """
 
         new_exp, new_impfs, new_haz = self.apply(exposures, imp_fun_set, hazard)
-        return self._calc_impact(new_exp, new_impfs, new_haz)
+        return self._calc_impact(new_exp, new_impfs, new_haz, save_mat)
 
     def apply(self, exposures, imp_fun_set, hazard):
         """
@@ -180,7 +182,7 @@ class Measure():
 
         return new_exp, new_impfs, new_haz
 
-    def _calc_impact(self, new_exp, new_impfs, new_haz):
+    def _calc_impact(self, new_exp, new_impfs, new_haz, save_mat=False):
         """Compute impact and risk transfer of measure implemented over inputs.
 
         Parameters
@@ -191,6 +193,8 @@ class Measure():
             impact function set once measure applied
         new_haz  : climada.hazard.Hazard
             hazard once measure applied
+        save_mat : bool
+            save the calculated Impact's impact matrix. Passed to Impact.calc
 
         Returns
         -------
@@ -198,7 +202,9 @@ class Measure():
         """
         from climada.engine.impact import Impact
         imp = Impact()
-        imp.calc(new_exp, new_impfs, new_haz)
+        imp.calc(new_exp, new_impfs, new_haz, save_mat)
+        if self.risk_transf_attach == 0 and self.risk_transf_cover == 0:
+            return imp, Impact()
         return imp.calc_risk_transfer(self.risk_transf_attach, self.risk_transf_cover)
 
     def _change_all_hazard(self, hazard):


### PR DESCRIPTION
### The issue

The `CostBenefit.calc` method takes a parameter `save_imp`. When True the method saves the Impact object for every impact calculation it makes (which is several). These Impact objects don't have impact matrices saved. I'd like to change things so that they do.

**Reasons not to save the impact matrix**
- Large cost-benefit calculations with multiple adaptation measures create several Impact objects. Storing them all in memory will crash analyses on machines with smaller RAM. With a large enough hazard and exposure this is most of us.

**Reasons to save the impact matrix**
- Many of my favourite things to do with the Impact objects require an impact matrix. In particular, if you want to plot maps of impacts with different adaptation measures applied, you need the impact matrix.

**An alternate solution**
- Make the method more flexible: have two parameters `save_imp` and `save_mat` which let you choose whether to save the Impact and, if so, whether to save its impact matrix.

### This pull request

CostBenefit calculates its impacts using the `Measure.calc_impact` method. If we want it to save the impact matrix, we need to update this method to take a `save_mat` parameter and pass it to `Impact.calc`. I think it makes sense to implement this regardless of everything else in the pull request, and is done in commit 51d3d9fdfa1fe6bc10c4254e5d0266d21ea2a434 for easy cherry picking.

The next commit 7ac95cd582a1279cc6a74894486b899e7808f5b7 updates `CostBenefit` to save impact matrices when the `save_imp` parameter is True.

Finally, one outstanding issue is when risk transfer is involved. When risk transfer parameters are defined the impact calculation `Measure.calc_impact` also calls `Impact.calc_risk_transfer` which always returns an impact object with a 0 x 0 impact matrix. I don't know the risk transfer codebase so well, so I haven't changed anything here.