### PR TITLE
Fix bug in get_gridcellarea function in util/coordinates

### DIFF
--- a/climada/util/coordinates.py
+++ b/climada/util/coordinates.py
@@ -323,7 +323,7 @@ def dist_approx(lat1, lon1, lat2, lon2, log=False, normalize=True,
         raise KeyError("Unknown distance approximation method: %s" % method)
     return (dist, vtan) if log else dist
 
-def get_gridcellarea(lat, resolution=0.5, unit='km2'):
+def get_gridcellarea(lat, resolution=0.5, unit='ha'):
     """The area covered by a grid cell is calculated depending on the latitude
         1 degree = ONE_LAT_KM (111.12km at the equator)
         longitudal distance in km = ONE_LAT_KM*resolution*cos(lat)
@@ -337,14 +337,16 @@ def get_gridcellarea(lat, resolution=0.5, unit='km2'):
     resolution: int, optional
         raster resolution in degree (default: 0.5 degree)
     unit: string, optional
-        unit of the output area (default: km2, alternative: m2)
+        unit of the output area (default: ha, alternatives: m2, km2)
 
     """
 
     if unit == 'm2':
         area = (ONE_LAT_KM * resolution)**2 * np.cos(np.deg2rad(lat)) * 1000000
-    else:
+    elif unit == 'km2':
         area = (ONE_LAT_KM * resolution)**2 * np.cos(np.deg2rad(lat))
+    else:
+        area = (ONE_LAT_KM * resolution)**2 * np.cos(np.deg2rad(lat))*100
 
     return area
 

--- a/climada/util/coordinates.py
+++ b/climada/util/coordinates.py
@@ -342,9 +342,9 @@ def get_gridcellarea(lat, resolution=0.5, unit='km2'):
     """
 
     if unit == 'm2':
-        area = (ONE_LAT_KM * resolution)**2 * np.cos(np.deg2rad(lat)) * 100 * 1000000
+        area = (ONE_LAT_KM * resolution)**2 * np.cos(np.deg2rad(lat)) * 1000000
     else:
-        area = (ONE_LAT_KM * resolution)**2 * np.cos(np.deg2rad(lat)) * 100
+        area = (ONE_LAT_KM * resolution)**2 * np.cos(np.deg2rad(lat))
 
     return area
 

--- a/climada/util/test/test_coordinates.py
+++ b/climada/util/test/test_coordinates.py
@@ -206,9 +206,10 @@ class TestFunc(unittest.TestCase):
         resolution = 0.5
         area = u_coord.get_gridcellarea(lat, resolution)
 
-        self.assertAlmostEqual(area[0], 178159.73363005)
-        self.assertAlmostEqual(area[1], 180352.82386516)
+        self.assertAlmostEqual(area[0], 1781.5973363005)
+        self.assertAlmostEqual(area[1], 1803.5282386516)
         self.assertEqual(lat.shape, area.shape)
+        self.assertTrue(area[0] <= 2500)
 
     def test_read_vector_pass(self):
         """Test one columns data"""

--- a/climada/util/test/test_coordinates.py
+++ b/climada/util/test/test_coordinates.py
@@ -206,10 +206,13 @@ class TestFunc(unittest.TestCase):
         resolution = 0.5
         area = u_coord.get_gridcellarea(lat, resolution)
 
-        self.assertAlmostEqual(area[0], 1781.5973363005)
-        self.assertAlmostEqual(area[1], 1803.5282386516)
+        self.assertAlmostEqual(area[0], 178159.73363005)
+        self.assertAlmostEqual(area[1], 180352.82386516)
         self.assertEqual(lat.shape, area.shape)
-        self.assertTrue(area[0] <= 2500)
+        
+        area2 = u_coord.get_gridcellarea(lat, resolution, unit='km2')
+        self.assertAlmostEqual(area2[0], 1781.5973363005)
+        self.assertTrue(area2[0] <= 2500)
 
     def test_read_vector_pass(self):
         """Test one columns data"""


### PR DESCRIPTION
Hello!

I came across an issue with the unit / order of magnitude of this function. 
Assuming that the max grid cell area should be 2500km^2 (50x50km), I am not sure why we had added *100 in the first place - or am I getting mixed up?

Thanks for having a look!

Best, Carmen 