### PR TITLE
Remove tight_layout from ImpFuncSet tutorial

### DIFF
--- a/doc/tutorial/climada_entity_ImpactFuncSet.ipynb
+++ b/doc/tutorial/climada_entity_ImpactFuncSet.ipynb
@@ -524,7 +524,6 @@
     "print('Read file:', imp_set_xlsx.tag.file_name)\n",
     "imp_set_xlsx.plot()\n",
     "# adjust the plots\n",
-    "plt.tight_layout()\n",
     "plt.subplots_adjust(right=1., top=4., hspace=0.4, wspace=0.4)"
    ]
   },
@@ -614,7 +613,6 @@
     "# plot all the impact functions\n",
     "imp_fun_set_TC.plot()\n",
     "# adjust the plots\n",
-    "plt.tight_layout()\n",
     "plt.subplots_adjust(right=1., top=4., hspace=0.4, wspace=0.4)"
    ]
   }


### PR DESCRIPTION
This change avoids warning about `tight_layout()` not being applied. This has therefore no effect on the output figures.