### PR TITLE
Suggest using data API for LitPop exposures

### DIFF
--- a/doc/tutorial/climada_entity_LitPop.ipynb
+++ b/doc/tutorial/climada_entity_LitPop.ipynb
@@ -29,6 +29,8 @@
     "\n",
     "*Note*: All required data except for the population data from Gridded Population of the World (GPW) is downloaded automatically when an `LitPop.set_*` method is called.\n",
     "\n",
+    "**Warning**: Processing the data for the first time can take up huge amounts of RAM (>10 GB), depending on country or region size. Consider using the [wrapper function](climada_util_api_client.ipynb#The-wrapper-functions-client.get_litpop_default()) of the data API to download readily computed LitPop exposure data for default values ($n = m = 1$) on demand.\n",
+    "\n",
     "#### Nightlight intensity\n",
     "Black Marble annual composite of the VIIRS day-night band (Grayscale) at 15 arcsec resolution is downloaded from the NASA Earth Observatory: https://earthobservatory.nasa.gov/Features/NightLights (available for 2012 and 2016 at 15 arcsec resolution (~500m)).\n",
     "The first time a nightlight image is used, it is downloaded and stored locally. This might take some time.\n",
@@ -48,7 +50,9 @@
     "\n",
     "### Downloading existing LitPop asset exposure data\n",
     "\n",
-    "Readily computed LitPop asset exposure data based on $Lit^1Pop^1$ for 224 countries, distributing produced capital / non-financial wealth of 2014 at a resolution of 30 arcsec can be downloaded from the ETH Research Repository: https://doi.org/10.3929/ethz-b-000331316.\n",
+    "The easiest way to download existing data is using the [wrapper function](climada_util_api_client.ipynb#The-wrapper-functions-client.get_litpop_default()) of the data API.\n",
+    "\n",
+    "Readily computed LitPop asset exposure data based on $Lit^1Pop^1$ for 224 countries, distributing produced capital / non-financial wealth of 2014 at a resolution of 30 arcsec can also be downloaded from the ETH Research Repository: https://doi.org/10.3929/ethz-b-000331316.\n",
     "The dataset contains gridded data for more than 200 countries as CSV files."
    ]
   },

--- a/doc/tutorial/climada_entity_LitPop.ipynb
+++ b/doc/tutorial/climada_entity_LitPop.ipynb
@@ -29,7 +29,7 @@
     "\n",
     "*Note*: All required data except for the population data from Gridded Population of the World (GPW) is downloaded automatically when an `LitPop.set_*` method is called.\n",
     "\n",
-    "**Warning**: Processing the data for the first time can take up huge amounts of RAM (>10 GB), depending on country or region size. Consider using the [wrapper function](climada_util_api_client.ipynb#The-wrapper-functions-client.get_litpop_default()) of the data API to download readily computed LitPop exposure data for default values ($n = m = 1$) on demand.\n",
+    "**Warning**: Processing the data for the first time can take up huge amounts of RAM (>10 GB), depending on country or region size. Consider using the [wrapper function](climada_util_api_client.ipynb#The-wrapper-functions-client.get_litpop_default()) of the [data API](climada_util_api_client.ipynb) to download readily computed LitPop exposure data for default values ($n = m = 1$) on demand.\n",
     "\n",
     "#### Nightlight intensity\n",
     "Black Marble annual composite of the VIIRS day-night band (Grayscale) at 15 arcsec resolution is downloaded from the NASA Earth Observatory: https://earthobservatory.nasa.gov/Features/NightLights (available for 2012 and 2016 at 15 arcsec resolution (~500m)).\n",
@@ -50,7 +50,7 @@
     "\n",
     "### Downloading existing LitPop asset exposure data\n",
     "\n",
-    "The easiest way to download existing data is using the [wrapper function](climada_util_api_client.ipynb#The-wrapper-functions-client.get_litpop_default()) of the data API.\n",
+    "The easiest way to download existing data is using the [wrapper function](climada_util_api_client.ipynb#The-wrapper-functions-client.get_litpop_default()) of the [data API](climada_util_api_client.ipynb).\n",
     "\n",
     "Readily computed LitPop asset exposure data based on $Lit^1Pop^1$ for 224 countries, distributing produced capital / non-financial wealth of 2014 at a resolution of 30 arcsec can also be downloaded from the ETH Research Repository: https://doi.org/10.3929/ethz-b-000331316.\n",
     "The dataset contains gridded data for more than 200 countries as CSV files."


### PR DESCRIPTION
Add warning that computing LitPop exposures may require excessive amounts of RAM. Suggest using the data API instead.

~~*Note*: I have trouble building the docs locally, so I cannot tell yet if everything works out.~~ *Edit: Looks good on my local build now*

Closes #426