### PR TITLE
Bugfix/unsequa helper

### DIFF
--- a/climada/engine/unsequa/input_var.py
+++ b/climada/engine/unsequa/input_var.py
@@ -633,8 +633,8 @@ def _haz_uncfunc(HE, HI, HF, haz, n_ev):
     haz_tmp = copy.deepcopy(haz)
     if HE is not None:
         rng = np.random.RandomState(int(HE))
-        event_names = list(rng.choice(haz_tmp.event_name, int(n_ev)))
-        haz_tmp = haz_tmp.select(event_names=event_names)
+        event_id = list(rng.choice(haz_tmp.event_id, int(n_ev)))
+        haz_tmp = haz_tmp.select(event_id=event_id)
     if HI is not None:
         haz_tmp.intensity = haz_tmp.intensity.multiply(HI)
     if HF is not None:

--- a/climada/hazard/base.py
+++ b/climada/hazard/base.py
@@ -665,8 +665,8 @@ class Hazard():
             raise KeyError("Variable not in Excel file: " + str(var_err)) from var_err
         return haz
 
-    def select(self, event_names=None, date=None, orig=None, reg_id=None,
-               extent=None, reset_frequency=False):
+    def select(self, event_names=None, event_id=None, date=None, orig=None,
+               reg_id=None, extent=None, reset_frequency=False):
         """Select events matching provided criteria
 
         The frequency of events may need to be recomputed (see `reset_frequency`)!
@@ -675,6 +675,8 @@ class Hazard():
         ----------
         event_names : list of str, optional
             Names of events.
+        event_id : list of int, optional
+            Id of events. Default is None.
         date : array-like of length 2 containing str or int, optional
             (initial date, final date) in string ISO format ('2011-01-02') or datetime
             ordinal integer.
@@ -717,7 +719,7 @@ class Hazard():
         if isinstance(orig, bool):
             sel_ev &= (self.orig.astype(bool) == orig)
             if not np.any(sel_ev):
-                LOGGER.info('No hazard with %s tracks.', str(orig))
+                LOGGER.info('No hazard with %s original events.', str(orig))
                 return None
 
         # filter events based on name
@@ -731,6 +733,15 @@ class Hazard():
                 LOGGER.info('No hazard with name %s', name)
                 return None
             sel_ev = sel_ev[new_sel]
+
+        # filter events based on id
+        if isinstance(event_id, list):
+            # preserves order of event_id
+            sel_ev = np.array([
+                np.argwhere(self.event_id == n)[0,0]
+                for n in event_id
+                if n in self.event_id[sel_ev]
+                ])
 
         # filter centroids
         sel_cen = self.centroids.select_mask(reg_id=reg_id, extent=extent)

--- a/climada/hazard/test/test_base.py
+++ b/climada/hazard/test/test_base.py
@@ -294,6 +294,29 @@ class TestSelect(unittest.TestCase):
         self.assertIsInstance(sel_haz.intensity, sparse.csr_matrix)
         self.assertIsInstance(sel_haz.fraction, sparse.csr_matrix)
 
+    def test_select_event_id(self):
+        """Test select historical events."""
+        haz = dummy_hazard()
+        sel_haz = haz.select(event_id=[4, 1])
+
+        self.assertTrue(np.array_equal(sel_haz.centroids.coord, haz.centroids.coord))
+        self.assertEqual(sel_haz.tag, haz.tag)
+        self.assertEqual(sel_haz.units, haz.units)
+        self.assertTrue(np.array_equal(sel_haz.event_id, np.array([4, 1])))
+        self.assertTrue(np.array_equal(sel_haz.date, np.array([4, 1])))
+        self.assertTrue(np.array_equal(sel_haz.orig, np.array([True, True])))
+        self.assertTrue(np.array_equal(sel_haz.frequency, np.array([0.2, 0.1])))
+        self.assertTrue(np.array_equal(sel_haz.fraction.toarray(),
+                                       np.array([[0.3, 0.2, 0.0],
+                                                 [0.02, 0.03, 0.04]])))
+        self.assertTrue(np.array_equal(sel_haz.intensity.toarray(),
+                                       np.array([[5.3, 0.2, 1.3],
+                                                 [0.2, 0.3, 0.4]])))
+        self.assertEqual(sel_haz.event_name, ['ev4', 'ev1'])
+        self.assertIsInstance(sel_haz, Hazard)
+        self.assertIsInstance(sel_haz.intensity, sparse.csr_matrix)
+        self.assertIsInstance(sel_haz.fraction, sparse.csr_matrix)
+
     def test_select_orig_pass(self):
         """Test select historical events."""
         haz = dummy_hazard()


### PR DESCRIPTION
Fix a bug when events are sub-sampled by name which might not be unique. Events are now sub-sampled by id. For this, the method `hazard.select` now allows for `event_id` selection.