### PR TITLE
Add pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,14 @@
+Changes proposed in this PR:
+- 
+- 
+
+This PR fixes issue #
+
+### Pull Request Checklist
+
+- [ ] Correct target branch selected (if unsure, select `develop`)
+- [ ] Source branch up-to-date with target branch
+- [ ] Docs updated
+- [ ] Tests updated
+- [ ] Tests passing
+- [ ] No new linter issues


### PR DESCRIPTION
This PR adds a pull request template. When creating a pull request, users can choose a template to fill instead of writing a description from scratch. This helps contributors to provide useful information for reviewers and ensures that assignees perform all tasks to make the merge successful.

Comments and suggestions are welcome!

Note: The target branch is `main` because GitHub only applies PR or issue templates present in the default repository branch.

See #439 for the original suggestion and details.