### PR TITLE
Add instructions for committing Jupyter Notebook changes

### DIFF
--- a/doc/guide/Guide_Git_Development.ipynb
+++ b/doc/guide/Guide_Git_Development.ipynb
@@ -725,8 +725,17 @@
     "- Don't commit anything containing passwords or authentication credentials or tokens. (These are annoying to remove from the Git history.) Contact the team if you need to manage authorisations within the code.\n",
     "- Don't commit anything that can be created by the CLIMADA code itself\n",
     "\n",
-    "If files like this are going to be present for other users as well, add them to the repository's `.gitignore`."
-   ]
+    "If files like this are going to be present for other users as well, add them to the repository's `.gitignore`.",
+    "\n",
+    "#### Jupyter Notebook metadata\n",
+    "\n",
+    "Git compares file versions by text tokens. Jupyter Notebooks typically contain a lot of metadata, along with binary data like image files. Simply re-running a notebook can change this metadata, which will be reported as file changes by Git. This causes excessive Diff reports that cannot be reviewed conveniently.\n",
+    "\n",
+    "To avoid committing changes of unrelated metadata, open Jupyter Notebooks in a text editor instead of your browser renderer. When committing changes, make sure that you indeed only commit things you *did* change, and revert any changes to metadata that are not related to your code updates.\n",
+    "\n",
+    "Several code editors use plugins to render Jupyter Notebooks. Here we collect the instructions to inspect Jupyter Notebooks as plain text when using them:\n",
+    "- **VSCode**: Open the Jupyter Notebook. Then open the internal command prompt (`Ctrl` + `Shift` + `P` or `Cmd` + `Shift` + `P` on macOS) and type/select 'View: Reopen Editor with Text Editor'"
+]
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
This adds a section to the "Git Development" tutorial on how to avoid excessive Git Diffs when changing Jupyter Notebook files. When editing Jupyter Notebooks through a renderer, metadata or entire image files that is/are unrelated to the actual code changes might be modified. Git reports these modifications as changes, which are hard to read as soon as they are committed. The only remedy I see for now is to open the notebooks with a text editor and modify the code then. Of course, the overall layout of the notebooks makes this very inconvenient.

I am unsure if this is the right place to put this information. Suggestions on how to convey this informatin clearly are very welcome!

As a side note, I found [ReviewNB](https://www.reviewnb.com/), a plugin for GitHub that might ease these problems.