### PR TITLE
Suppress PerformanceWarning when writing Exposures to HDF5

### DIFF
--- a/climada/entity/exposures/test/test_base.py
+++ b/climada/entity/exposures/test/test_base.py
@@ -237,7 +237,13 @@ class TestIO(unittest.TestCase):
         exp_df.value_unit = 'XSD'
 
         file_name = DATA_DIR.joinpath('test_hdf5_exp.h5')
-        exp_df.write_hdf5(file_name)
+
+        # pd.errors.PerformanceWarning should be suppressed. Therefore, make sure that
+        # PerformanceWarning would result in test failure here
+        import warnings
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", category=pd.errors.PerformanceWarning)
+            exp_df.write_hdf5(file_name)
 
         exp_read = Exposures.from_hdf5(file_name)
 


### PR DESCRIPTION
This PR suppresses the `pandas.errors.PerformanceWarning` when writing an `Exposures` instance to HDF5. The unit test was adapted to fail if such a warning would be issued.

Fixes #410.