### PR TITLE
Use pandas.concat in favor of pandas.DataFrame.append

### DIFF
--- a/climada/engine/impact_data.py
+++ b/climada/engine/impact_data.py
@@ -765,7 +765,7 @@ def emdat_impact_yearlysum(emdat_file_csv, countries=None, hazard=None, year_ran
             if '000 US' in imp_str:  # EM-DAT damages provided in '000 USD
                 data_out.loc[cnt, 'impact'] = data_out.loc[cnt, 'impact'] * 1e3
                 data_out.loc[cnt, 'impact_scaled'] = data_out.loc[cnt, 'impact_scaled'] * 1e3
-        out = out.append(data_out)
+        out = pd.concat([out, data_out])
     out = out.reset_index(drop=True)
     return out
 

--- a/climada/engine/test/test_impact_data.py
+++ b/climada/engine/test/test_impact_data.py
@@ -20,6 +20,7 @@ Test Impact class.
 """
 import unittest
 import numpy as np
+import warnings
 
 from climada import CONFIG
 from climada.util.constants import DEMO_DIR
@@ -153,6 +154,20 @@ class TestEmdatProcessing(unittest.TestCase):
         self.assertIn('USA', list(df['ISO']))
         self.assertIn('Drought', list(df['Disaster Type']))
         self.assertEqual(2000, df['reference_year'].min())
+
+    def test_emdat_impact_yearlysum_no_futurewarning(self):
+        """Ensure that no FutureWarning is issued"""
+        with warnings.catch_warnings():
+            # Make sure that FutureWarning will cause an error
+            warnings.simplefilter("error", category=FutureWarning)
+            im_d.emdat_impact_yearlysum(
+                EMDAT_TEST_CSV,
+                countries=["Bangladesh", "USA"],
+                hazard="Flood",
+                year_range=(2015, 2017),
+                reference_year=None,
+                imp_str="Total Affected",
+            )
 
     def test_emdat_affected_yearlysum(self):
         """test emdat_impact_yearlysum yearly impact data extraction"""

--- a/climada/entity/exposures/litpop/litpop.py
+++ b/climada/entity/exposures/litpop/litpop.py
@@ -618,7 +618,7 @@ class LitPop(Exposures):
                                f' country {iso3a}.')
                 continue
             total_population += meta_tmp['total_population']
-            litpop_gdf = litpop_gdf.append(gdf_tmp)
+            litpop_gdf = pd.concat([litpop_gdf, gdf_tmp])
         litpop_gdf.crs = meta_tmp['crs']
 
         # set total value for disaggregation if not provided:

--- a/climada/test/test_litpop_integr.py
+++ b/climada/test/test_litpop_integr.py
@@ -21,6 +21,7 @@ Tests on LitPop exposures.
 import unittest
 import numpy as np
 from shapely.geometry import Polygon
+import warnings
 
 from climada.entity.exposures.litpop import litpop as lp
 from climada.entity.exposures.litpop import gpw_population
@@ -32,6 +33,13 @@ from climada import CONFIG
 
 class TestLitPopExposure(unittest.TestCase):
     """Test LitPop exposure data model:"""
+
+    def test_no_future_warning(self):
+        """Test that 'from_countries' does not throw a FutureWarning"""
+        with warnings.catch_warnings():
+            # Make sure that FutureWarning will cause an error
+            warnings.simplefilter("error", category=FutureWarning)
+            lp.LitPop.from_countries("Netherlands")
 
     def test_netherlands150_pass(self):
         """Test from_countries for Netherlands at 150 arcsec, first shape is empty"""


### PR DESCRIPTION
`pandas.DataFrame.append` is deprecated, which causes a `FutureWarning`.

Changes proposed in this PR:
- Use `pandas.concat` instead of `pandas.DataFrame.append`.
- Update tests to check that `FutureWarning` is not issued anymore.

This resolves the `FutureWarnings` wrt. `append` reported in #423, #402, #401

### Pull Request Checklist

- [x] Correct target branch selected (if unsure, select `develop`)
- [x] Source branch up-to-date with target branch
- ~~[ ] Docs updated~~
- [x] Tests updated
- [x] Tests passing
- [x] No new linter issues
