### PR TITLE
Remove tests for FutureWarnings

### DIFF
--- a/climada/engine/test/test_impact_data.py
+++ b/climada/engine/test/test_impact_data.py
@@ -20,6 +20,7 @@ Test Impact class.
 """
 import unittest
 import numpy as np
+import warnings
 
 from climada import CONFIG
 from climada.util.constants import DEMO_DIR
@@ -153,6 +154,20 @@ class TestEmdatProcessing(unittest.TestCase):
         self.assertIn('USA', list(df['ISO']))
         self.assertIn('Drought', list(df['Disaster Type']))
         self.assertEqual(2000, df['reference_year'].min())
+
+    def test_emdat_impact_yearlysum_no_futurewarning(self):
+        """Ensure that no FutureWarning is issued"""
+        with warnings.catch_warnings():
+            # Make sure that FutureWarning will cause an error
+            warnings.simplefilter("error", category=FutureWarning)
+            im_d.emdat_impact_yearlysum(
+                EMDAT_TEST_CSV,
+                countries=["Bangladesh", "USA"],
+                hazard="Flood",
+                year_range=(2015, 2017),
+                reference_year=None,
+                imp_str="Total Affected",
+            )
 
     def test_emdat_affected_yearlysum(self):
         """test emdat_impact_yearlysum yearly impact data extraction"""

--- a/climada/engine/test/test_impact_data.py
+++ b/climada/engine/test/test_impact_data.py
@@ -20,7 +20,6 @@ Test Impact class.
 """
 import unittest
 import numpy as np
-import warnings
 
 from climada import CONFIG
 from climada.util.constants import DEMO_DIR
@@ -154,20 +153,6 @@ class TestEmdatProcessing(unittest.TestCase):
         self.assertIn('USA', list(df['ISO']))
         self.assertIn('Drought', list(df['Disaster Type']))
         self.assertEqual(2000, df['reference_year'].min())
-
-    def test_emdat_impact_yearlysum_no_futurewarning(self):
-        """Ensure that no FutureWarning is issued"""
-        with warnings.catch_warnings():
-            # Make sure that FutureWarning will cause an error
-            warnings.simplefilter("error", category=FutureWarning)
-            im_d.emdat_impact_yearlysum(
-                EMDAT_TEST_CSV,
-                countries=["Bangladesh", "USA"],
-                hazard="Flood",
-                year_range=(2015, 2017),
-                reference_year=None,
-                imp_str="Total Affected",
-            )
 
     def test_emdat_affected_yearlysum(self):
         """test emdat_impact_yearlysum yearly impact data extraction"""

--- a/climada/test/test_litpop_integr.py
+++ b/climada/test/test_litpop_integr.py
@@ -21,7 +21,6 @@ Tests on LitPop exposures.
 import unittest
 import numpy as np
 from shapely.geometry import Polygon
-import warnings
 
 from climada.entity.exposures.litpop import litpop as lp
 from climada.entity.exposures.litpop import gpw_population
@@ -33,13 +32,6 @@ from climada import CONFIG
 
 class TestLitPopExposure(unittest.TestCase):
     """Test LitPop exposure data model:"""
-
-    def test_no_future_warning(self):
-        """Test that 'from_countries' does not throw a FutureWarning"""
-        with warnings.catch_warnings():
-            # Make sure that FutureWarning will cause an error
-            warnings.simplefilter("error", category=FutureWarning)
-            lp.LitPop.from_countries("Netherlands")
 
     def test_netherlands150_pass(self):
         """Test from_countries for Netherlands at 150 arcsec, first shape is empty"""


### PR DESCRIPTION
Changes proposed in this PR:
- Remove the tests checking for `FutureWarning`s introduced in #443. One of these causes the integration tests to fail.

I figure it's better to remove these checks altogether. Possible future changes in dependency code might lead to more `FutureWarning`s, at which point our tests would start failing.

This PR fixes issue #449.

### Pull Request Checklist

- [x] Correct target branch selected (if unsure, select `develop`)
- [x] Source branch up-to-date with target branch

~~- [ ] Docs updated~~
- [x] Tests updated
- [ ] Tests passing
- [ ] No new linter issues
