### PR TITLE
HDFStore always initialize with explicit mode

### DIFF
--- a/climada/engine/unsequa/unc_output.py
+++ b/climada/engine/unsequa/unc_output.py
@@ -1013,7 +1013,7 @@ class UncOutput():
         save_path = save_path.with_suffix('.hdf5')
 
         LOGGER.info('Writing %s', save_path)
-        store = pd.HDFStore(save_path)
+        store = pd.HDFStore(save_path, mode='w')
         for (var_name, var_val) in self.__dict__.items():
             if isinstance(var_val, pd.DataFrame):
                 store.put(var_name, var_val, format='fixed', complevel=9)
@@ -1058,7 +1058,7 @@ class UncOutput():
         unc_data = UncOutput(pd.DataFrame())
 
         LOGGER.info('Reading %s', filename)
-        store = pd.HDFStore(filename)
+        store = pd.HDFStore(filename, mode='r')
         for var_name in store.keys():
             setattr(unc_data, var_name[1:], store.get(var_name))
         unc_data.samples_df.attrs = store.get_storer('/samples_df').attrs.metadata

--- a/climada/entity/exposures/base.py
+++ b/climada/entity/exposures/base.py
@@ -764,8 +764,8 @@ class Exposures():
         file_name : str
             (path and) file name to write to.
         """
-        LOGGER.info('Writting %s', file_name)
-        store = pd.HDFStore(file_name)
+        LOGGER.info('Writing %s', file_name)
+        store = pd.HDFStore(file_name, mode='w')
         pandas_df = pd.DataFrame(self.gdf)
         for col in pandas_df.columns:
             if str(pandas_df[col].dtype) == "geometry":
@@ -809,7 +809,7 @@ class Exposures():
         LOGGER.info('Reading %s', file_name)
         if not Path(file_name).is_file():
             raise FileNotFoundError(str(file_name))
-        with pd.HDFStore(file_name) as store:
+        with pd.HDFStore(file_name, mode='r') as store:
             metadata = store.get_storer('exposures').attrs.metadata
             # in previous versions of CLIMADA and/or geopandas, the CRS was stored in '_crs'/'crs'
             crs = metadata.get('crs', metadata.get('_crs'))


### PR DESCRIPTION
Changes proposed in this PR:
- explicitly set the mode for `pandas.HDFStore` everywhere to 'w' or 'r'. The default is 'a' which causes files to continuously grow in size when `write_hdf5` is called for the same file again.

This PR fixes issue #457

### Pull Request Checklist

- [x] Correct target branch selected (if unsure, select `develop`)
- [x] Source branch up-to-date with target branch
- [ ] Docs updated
- [ ] Tests updated
- [x] Tests passing
- [x] No new linter issues
