### PR TITLE
Writing hdf5 centr files with data of None type 

### DIFF
--- a/climada/hazard/centroids/centr.py
+++ b/climada/hazard/centroids/centr.py
@@ -1116,6 +1116,9 @@ class Centroids():
         else:
             data = file_data
         str_dt = h5py.special_dtype(vlen=str)
+        if 'nodata' in self.meta.keys():
+            if self.meta['nodata'] is None:
+                self.meta['nodata'] = 'None'
         for centr_name, centr_val in self.__dict__.items():
             if isinstance(centr_val, np.ndarray):
                 data.create_dataset(centr_name, data=centr_val, compression="gzip")


### PR DESCRIPTION
Changes proposed in this PR:
When trying to write a hdf5 file where the centroids are created from a raster meta file, and this centr.meta info contains a `None` type value (e.g. in {'nodata' : None}, a `TypeError` is thrown: 

```
  File "/Users/evelynm/climada_python/climada/hazard/base.py", line 1158, in write_hdf5
    self.centroids.write_hdf5(hf_data.create_group(var_name))

  File "/Users/evelynm/climada_python/climada/hazard/centroids/centr.py", line 1127, in write_hdf5
    centr_meta.create_dataset(key, (1,), data=value, dtype=type(value))

  File "/Users/evelynm/opt/anaconda3/envs/climada_env/lib/python3.8/site-packages/h5py/_hl/group.py", line 149, in create_dataset
    dsid = dataset.make_new_dset(group, shape, dtype, data, name, **kwds)

  File "/Users/evelynm/opt/anaconda3/envs/climada_env/lib/python3.8/site-packages/h5py/_hl/dataset.py", line 91, in make_new_dset
    tid = h5t.py_create(dtype, logical=1)

  File "h5py/h5t.pyx", line 1663, in h5py.h5t.py_create

  File "h5py/h5t.pyx", line 1687, in h5py.h5t.py_create

  File "h5py/h5t.pyx", line 1747, in h5py.h5t.py_create

TypeError: Object dtype dtype('O') has no native HDF5 equivalent
```


The fix is somewhat non-elegant, as it checks only for that specific case now. 
Perhaps one needs to deal with `None` values more generically, and also make sure when reading them back in, they are encoded back properly. But perhaps that's not everywhere an issue.

