### PR TITLE
Fixing pylint warnings in forecast.py

### DIFF
--- a/climada/engine/forecast.py
+++ b/climada/engine/forecast.py
@@ -24,7 +24,6 @@ __all__ = ["Forecast"]
 
 import logging
 import datetime as dt
-from pathlib import Path
 import numpy as np
 import matplotlib.pyplot as plt
 from matplotlib.patches import Patch


### PR DESCRIPTION
Changes proposed in this PR:
- Deleted a line to fix a pylint warning of the type "unused-import"

This PR fixes this pyling warning: https://ied-wcr-jenkins.ethz.ch/job/climada_branches/job/main/2/pylint/folder.-989414432/fileName.-1603685587/category.-1505867908/type.847887228/

### Pull Request Checklist

- [x] Correct target branch selected (if unsure, select `develop`)
- [x] Source branch up-to-date with target branch
- [ ] Docs updated: No doc seems to need to be updated
- [ ] Tests updated: No test seems to need to be updated
- [x] Tests passing: All test passed
- [x] No new linter issues
