### PR TITLE
Fixing the pylint warnings in centr.py

### DIFF
--- a/climada/hazard/centroids/centr.py
+++ b/climada/hazard/centroids/centr.py
@@ -705,7 +705,7 @@ class Centroids():
         ValueError
         """
         # restrict to non-empty centroids
-        cent_list = [c for c in (self,) + others if c.size > 0 or c.meta]
+        cent_list = [c for c in (self,) + others if c.size > 0 or c.meta] # pylint: disable=no-member
         if len(cent_list) == 0 or len(others) == 0:
             return copy.deepcopy(self)
 


### PR DESCRIPTION
Changes proposed in this PR:
- Ignored two pylint warnings of the type "no-member" seem to be wrong

This PR fixes these pylint issues: https://ied-wcr-jenkins.ethz.ch/job/climada_branches/job/main/2/pylint/fileName.-1333324472/category.67232232/

### Pull Request Checklist

- [x] Correct target branch selected (if unsure, select `develop`)
- [x] Source branch up-to-date with target branch
- [ ] Docs updated: No doc seems to need to be updated
- [ ] Tests updated: No test seems to need to be updated
- [x] Tests passing
- [x] No new linter issues
