### PR TITLE
Fixing a pylint warning in calc_base.py

### DIFF
--- a/climada/engine/unsequa/calc_base.py
+++ b/climada/engine/unsequa/calc_base.py
@@ -71,6 +71,7 @@ class Calc():
                             " is shared among two input variables with"
                             " different distributions."
                             )
+                    # pylint: disable=logging-not-lazy
                     LOGGER.warning(
                         "\n\nThe input parameter %s is shared " +
                         "among at least 2 input variables. Their uncertainty is " +

--- a/climada/engine/unsequa/calc_base.py
+++ b/climada/engine/unsequa/calc_base.py
@@ -71,11 +71,10 @@ class Calc():
                             " is shared among two input variables with"
                             " different distributions."
                             )
-                    # pylint: disable=logging-not-lazy
                     LOGGER.warning(
-                        "\n\nThe input parameter %s is shared " +
-                        "among at least 2 input variables. Their uncertainty is " +
-                        "thus computed with the same samples for this " +
+                        "\n\nThe input parameter %s is shared "
+                        "among at least 2 input variables. Their uncertainty is "
+                        "thus computed with the same samples for this "
                         "input paramter.\n\n", input_param_name
                         )
                 distr_dict[input_param_name] = input_param_func
@@ -257,7 +256,7 @@ class Calc():
         #Import the named submodule from the SALib sample module
         #From the workings of __import__ the use of 'from_list' is necessary
         #c.f. https://stackoverflow.com/questions/2724260/why-does-pythons-import-require-fromlist
-        import importlib
+        import importlib # pylint: disable=import-outside-toplevel
         salib_sampling_method = importlib.import_module(f'SALib.sample.{sampling_method}')
         sample_uniform = salib_sampling_method.sample(
             problem = problem_sa, N = N, **sampling_kwargs)

--- a/climada/engine/unsequa/calc_base.py
+++ b/climada/engine/unsequa/calc_base.py
@@ -76,7 +76,7 @@ class Calc():
                         "among at least 2 input variables. Their uncertainty is " +
                         "thus computed with the same samples for this " +
                         "input paramter.\n\n", input_param_name
-                        )
+                        )# pylint: disable=logging-not-lazy
                 distr_dict[input_param_name] = input_param_func
         return True
 

--- a/climada/engine/unsequa/calc_base.py
+++ b/climada/engine/unsequa/calc_base.py
@@ -76,7 +76,7 @@ class Calc():
                         "among at least 2 input variables. Their uncertainty is " +
                         "thus computed with the same samples for this " +
                         "input paramter.\n\n", input_param_name
-                        )# pylint: disable=logging-not-lazy
+                        )
                 distr_dict[input_param_name] = input_param_func
         return True
 

--- a/climada/engine/unsequa/calc_base.py
+++ b/climada/engine/unsequa/calc_base.py
@@ -76,7 +76,7 @@ class Calc():
                         "among at least 2 input variables. Their uncertainty is " +
                         "thus computed with the same samples for this " +
                         "input paramter.\n\n", input_param_name
-                        )# pylint: disable=logging-not-lazy
+                        ) # pylint: disable=logging-not-lazy
                 distr_dict[input_param_name] = input_param_func
         return True
 

--- a/climada/engine/unsequa/calc_base.py
+++ b/climada/engine/unsequa/calc_base.py
@@ -76,7 +76,7 @@ class Calc():
                         "among at least 2 input variables. Their uncertainty is " +
                         "thus computed with the same samples for this " +
                         "input paramter.\n\n", input_param_name
-                        ) # pylint: disable=logging-not-lazy
+                        )# pylint: disable=logging-not-lazy
                 distr_dict[input_param_name] = input_param_func
         return True
 


### PR DESCRIPTION
Changes proposed in this PR:
- Ignore a pylint warning of the type "logging-not-lazy" that seems to be wrong

This PR fixes this pylint issues: https://ied-wcr-jenkins.ethz.ch/job/climada_branches/job/main/2/pylint/type.-846599972/folder.432435459/source.be1ee691-e7a1-4ae1-ac9a-364dbc27bd5b/#74

### Pull Request Checklist

- [x] Correct target branch selected (if unsure, select `develop`)
- [x] Source branch up-to-date with target branch
- [ ] Docs updated: No doc seems to need to be updated
- [ ] Tests updated: No test seems to need to be updated
- [x] Tests passing: All tests passed
- [x] No new linter issues
