### PR TITLE
Correcting the markdown of Guide_Euler

### DIFF
--- a/doc/guide/Guide_Euler.ipynb
+++ b/doc/guide/Guide_Euler.ipynb
@@ -285,7 +285,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### <a id=\"conf3\"> 4. Adjust the Climada configuration </a>\n",
+    "### 4. <a id=\"conf3\"> Adjust the Climada configuration </a>\n",
     "\n",
     "See [Adjust the Climada configuration](#conf) above."
    ]
@@ -391,7 +391,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## <a id=\"Rm\"> Conda Deinstallation </a>"
+    "## <a id=\"Rm\">Conda Deinstallation</a>"
    ]
   },
   {

--- a/doc/guide/Guide_Euler.ipynb
+++ b/doc/guide/Guide_Euler.ipynb
@@ -285,7 +285,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### 4. <a id=\"conf3\"> Adjust the Climada configuration </a>\n",
+    "### <a id=\"conf3\"> 4. Adjust the Climada configuration </a>\n",
     "\n",
     "See [Adjust the Climada configuration](#conf) above."
    ]
@@ -391,7 +391,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## <a id=\"Rm\">Conda Deinstallation</a>"
+    "## <a id=\"Rm\"> Conda Deinstallation </a>"
    ]
   },
   {


### PR DESCRIPTION
Changes proposed in this PR:
- The version of Guide_Euler on readthedocs shows some titles in a strange way. Tried to fix that by changing the markdown

This PR doesn't fix any existing issues

### Pull Request Checklist

- [x] Correct target branch selected (if unsure, select `develop`)
- [x] Source branch up-to-date with target branch
- [ ] Docs updated: No doc seems to need to be updated
- [ ] Tests updated: No test seems to need to be updated
- [x] Tests passing
- [x] No new linter issues
