### PR TITLE
Fixed the pylint warning "no-else-raise" in hazard\base.py

### DIFF
--- a/climada/hazard/base.py
+++ b/climada/hazard/base.py
@@ -1621,7 +1621,7 @@ class Hazard():
         if len(units) > 1:
             raise ValueError(f"The given hazards use different units: {units}. "
                              "The hazards are incompatible and cannot be concatenated.")
-        elif len(units) == 0:
+        if len(units) == 0:
             units = {''}
         self.units = units.pop()
 


### PR DESCRIPTION
Changes proposed in this PR:
- Change the "elif" after "raise" to "if"

This PR fixes the pylint warning:
https://ied-wcr-jenkins.ethz.ch/job/climada_branches/job/develop/817/pylint/type.-929421852/

### Pull Request Checklist

- [x] Correct target branch selected (if unsure, select `develop`)
- [x] Source branch up-to-date with target branch
- [ ] Docs updated: No doc seems to need to be updated
- [ ] Tests updated: No test seems to need to be updated
- [ ] Tests passing
- [ ] No new linter issues
