### PR TITLE
Fixed the pylint warning "no-else-return" in centr.py

### DIFF
--- a/climada/hazard/centroids/centr.py
+++ b/climada/hazard/centroids/centr.py
@@ -1203,7 +1203,7 @@ class Centroids():
         """Get CRS of raster or vector."""
         if self.meta:
             return self.meta['crs']
-        elif self.geometry.crs:
+        if self.geometry.crs:
             return self.geometry.crs
         return DEF_CRS
 


### PR DESCRIPTION
Changes proposed in this PR:
- Changed a "ifelse" after "return" to "if"

This PR fixes this pylint warning: https://ied-wcr-jenkins.ethz.ch/job/climada_branches/job/develop/817/pylint/type.1256717880/

### Pull Request Checklist

- [x] Correct target branch selected (if unsure, select `develop`)
- [x] Source branch up-to-date with target branch
- [ ] Docs updated: No doc seems to need to be updated.
- [ ] Tests updated: No test seems to need to be updated.
- [x] Tests passing
- [x] No new linter issues
