### PR TITLE
Fixed some pylint warnings in calibration_opt.py

### DIFF
--- a/climada/engine/calibration_opt.py
+++ b/climada/engine/calibration_opt.py
@@ -20,19 +20,19 @@ Impact function calibration functionalities:
     Optimization and manual calibration
 """
 
-import numpy as np
-import pandas as pd
 import datetime as dt
 import copy
+import itertools
+import logging
+import numpy as np
+import pandas as pd
 from scipy import interpolate
 from scipy.optimize import minimize
-import itertools
 
 from climada.engine import Impact
 from climada.entity import ImpactFuncSet, ImpfTropCyclone, impact_funcs
 from climada.engine.impact_data import emdat_impact_yearlysum, emdat_impact_event
 
-import logging
 LOGGER = logging.getLogger(__name__)
 
 

--- a/climada/engine/calibration_opt.py
+++ b/climada/engine/calibration_opt.py
@@ -111,7 +111,7 @@ def calib_instance(hazard, exposure, impact_func, df_out=pd.DataFrame(),
             raise ValueError('adding simulated impacts to reported impacts not'
                              ' yet implemented. use yearly_impact=True or run'
                              ' without init_impact_data.')
-    if not return_cost == 'False':
+    if return_cost != 'False':
         df_out = calib_cost_calc(df_out, return_cost)
     return df_out
 


### PR DESCRIPTION
Changes proposed in this PR:
- Fixed the pylint warning "unneeded-not"
- Fixed the pylint warnings "wrong-import-order"


This PR fixes these pylint warnings:
https://ied-wcr-jenkins.ethz.ch/job/climada_branches/job/develop/817/pylint/type.1287284756/source.4d9c0b27-97a4-4f0b-b9f6-03f3d6a70a7e/#114
https://ied-wcr-jenkins.ethz.ch/job/climada_branches/job/develop/817/pylint/type.-939583674/folder.-989414432/

### Pull Request Checklist

- [x] Correct target branch selected (if unsure, select `develop`)
- [x] Source branch up-to-date with target branch
- [ ] Docs updated: No doc seems to need to be updated
- [ ] Tests updated: No test seems to need to be updated
- [x] Tests passing
- [x] No new linter issues
