### PR TITLE
Fixed the "wrong-import-order" warning in value_representation.py

### DIFF
--- a/climada/util/value_representation.py
+++ b/climada/util/value_representation.py
@@ -23,8 +23,8 @@ Created on Mon Nov 16 19:21:42 2020
 
 import logging
 import math
-import numpy as np
 import decimal
+import numpy as np
 
 
 LOGGER = logging.getLogger(__name__)


### PR DESCRIPTION
Changes proposed in this PR:
- Changed the order of the imports

This PR fixes this pylint issue:
https://ied-wcr-jenkins.ethz.ch/job/climada_branches/job/develop/817/pylint/type.-939583674/folder.-872054496/source.c2938ba8-41fd-47ca-94ce-bfe5393b9c6a/#27

### Pull Request Checklist

- [x] Correct target branch selected (if unsure, select `develop`)
- [x] Source branch up-to-date with target branch
- [ ] Docs updated: No doc seems to need to be updated
- [ ] Tests updated: No test seems to need to be updated
- [x] Tests passing
- [x] No new linter issues
