### PR TITLE
Feature/ctx sources deprecation

### DIFF
--- a/climada/engine/impact.py
+++ b/climada/engine/impact.py
@@ -27,6 +27,7 @@ import csv
 import warnings
 import datetime as dt
 from itertools import zip_longest
+import contextily as ctx
 import numpy as np
 from scipy import sparse
 import matplotlib.pyplot as plt
@@ -388,7 +389,7 @@ class Impact():
 
     def plot_basemap_eai_exposure(self, mask=None, ignore_zero=False, pop_name=True,
                                   buffer=0.0, extend='neither', zoom=10,
-                                  url='http://tile.stamen.com/terrain/tileZ/tileX/tileY.png',
+                                  url=ctx.providers.Stamen.Terrain,
                                   axis=None, **kwargs):
         """Plot basemap expected annual impact of each exposure.
 
@@ -409,7 +410,7 @@ class Impact():
         zoom : int, optional
             zoom coefficient used in the satellite image
         url : str, optional
-            image source, e.g. ctx.sources.OSM_C
+            image source, e.g. ctx.providers.OpenStreetMap.Mapnik
         axis : matplotlib.axes._subplots.AxesSubplot, optional
             axis to use
         kwargs : optional
@@ -479,7 +480,7 @@ class Impact():
 
     def plot_basemap_impact_exposure(self, event_id=1, mask=None, ignore_zero=False,
                                      pop_name=True, buffer=0.0, extend='neither', zoom=10,
-                                     url='http://tile.stamen.com/terrain/tileZ/tileX/tileY.png',
+                                     url=ctx.providers.Stamen.Terrain,
                                      axis=None, **kwargs):
         """Plot basemap impact of an event at each exposure.
         Requires attribute imp_mat.
@@ -504,7 +505,7 @@ class Impact():
         zoom : int, optional
             zoom coefficient used in the satellite image
         url : str, optional
-            image source, e.g. ctx.sources.OSM_C
+            image source, e.g. ctx.providers.OpenStreetMap.Mapnik
         axis  : matplotlib.axes._subplots.AxesSubplot, optional axis to use
         kwargs : optional arguments for scatter matplotlib function, e.g.
             cmap='Greys'. Default: 'Wistia'

--- a/climada/entity/exposures/base.py
+++ b/climada/entity/exposures/base.py
@@ -714,7 +714,7 @@ class Exposures():
 
     def plot_basemap(self, mask=None, ignore_zero=False, pop_name=True,
                      buffer=0.0, extend='neither', zoom=10,
-                     url='http://tile.stamen.com/terrain/{z}/{x}/{y}.png',
+                     url=ctx.providers.Stamen.Terrain,
                      axis=None, **kwargs):
         """Scatter points over satellite image using contextily
 
@@ -736,7 +736,7 @@ class Exposures():
          zoom : int, optional
              zoom coefficient used in the satellite image
          url : str, optional
-             image source, e.g. ctx.sources.OSM_C
+             image source, e.g. ctx.providers.OpenStreetMap.Mapnik
          axis : matplotlib.axes._subplots.AxesSubplot, optional
              axis to use
          kwargs : optional

--- a/climada/test/test_plot.py
+++ b/climada/test/test_plot.py
@@ -139,7 +139,7 @@ class TestPlotter(unittest.TestCase):
         myexp.check()
 
         try:
-            myexp.plot_basemap(url=ctx.sources.OSM_A)
+            myexp.plot_basemap(url=ctx.providers.OpenStreetMap.Mapnik)
         except urllib.error.HTTPError:
             self.assertEqual(1, 0)
 

--- a/doc/tutorial/climada_entity_Exposures.ipynb
+++ b/doc/tutorial/climada_entity_Exposures.ipynb
@@ -1556,21 +1556,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2021-06-04 17:07:51,154 - climada.entity.exposures.base - INFO - Setting latitude and longitude attributes.\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/zeliestalhanske/miniconda3/envs/climada_env/lib/python3.8/site-packages/contextily/tile.py:265: FutureWarning: The url format using 'tileX', 'tileY', 'tileZ' as placeholders is deprecated. Please use '{x}', '{y}', '{z}' instead.\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "2021-06-04 17:07:51,154 - climada.entity.exposures.base - INFO - Setting latitude and longitude attributes.\n",
       "2021-06-04 17:07:55,046 - climada.entity.exposures.base - INFO - Setting latitude and longitude attributes.\n",
       "2021-06-04 17:07:55,124 - climada.entity.exposures.base - INFO - Setting latitude and longitude attributes.\n",
       "2021-06-04 17:07:58,604 - climada.entity.exposures.base - INFO - Setting latitude and longitude attributes.\n"
@@ -1604,9 +1590,9 @@
    "source": [
     "# Example 4: plot_basemap method\n",
     "import contextily as ctx\n",
-    "# select the background image from the available ctx.sources\n",
+    "# select the background image from the available ctx.providers\n",
     "ax = exp_templ.plot_basemap(buffer=30000, cmap='brg'); # using open street map\n",
-    "ax = exp_templ.plot_basemap(buffer=30000, url=ctx.sources._T_WATERCOLOR, cmap='brg', zoom=9); # set image zoom"
+    "ax = exp_templ.plot_basemap(buffer=30000, url=ctx.providers.Stamen.Watercolor, cmap='brg', zoom=9); # set image zoom"
    ]
   },
   {

--- a/script/applications/eca_san_salvador/San_Salvador_Adaptacion.ipynb
+++ b/script/applications/eca_san_salvador/San_Salvador_Adaptacion.ipynb
@@ -49,7 +49,7 @@
      "output_type": "stream",
      "text": [
       "/tmp/ipykernel_6587/3558672532.py:11: FutureWarning: The \"contextily.tile_providers\" module is deprecated and will be removed in contextily v1.1. Please use \"contextily.providers\" instead.\n",
-      "  ax = ent_2015.exposures.plot_basemap(s=1, zoom=15, url=ctx.sources.OSM_A, vmax=60000, cmap='autumn')\n"
+      "  ax = ent_2015.exposures.plot_basemap(s=1, zoom=15, url=ctx.providers.OpenStreetMap.Mapnik, vmax=60000, cmap='autumn')\n"
      ]
     },
     {
@@ -134,7 +134,7 @@
     "\n",
     "# Exposures (bienes): los utilizados en el script San Salvador Risk\n",
     "print('Total value in 2015: {:.3e}'.format(ent_2015.exposures.gdf.value.sum()))\n",
-    "ax = ent_2015.exposures.plot_basemap(s=1, zoom=15, url=ctx.sources.OSM_A, vmax=60000, cmap='autumn')\n",
+    "ax = ent_2015.exposures.plot_basemap(s=1, zoom=15, url=ctx.providers.OpenStreetMap.Mapnik, vmax=60000, cmap='autumn')\n",
     "ax.set_title('Exposure 2015')\n",
     "\n",
     "# Impact Functions (funciones de impacto): los utilizados en el script San Salvador Risk\n",
@@ -183,7 +183,7 @@
      "output_type": "stream",
      "text": [
       "/tmp/ipykernel_6587/2982039758.py:13: FutureWarning: The \"contextily.tile_providers\" module is deprecated and will be removed in contextily v1.1. Please use \"contextily.providers\" instead.\n",
-      "  ax = ent_2040.exposures.plot_basemap(s=1, zoom=15, url=ctx.sources.OSM_A, vmax=60000, cmap='autumn')\n"
+      "  ax = ent_2040.exposures.plot_basemap(s=1, zoom=15, url=ctx.providers.OpenStreetMap.Mapnik, vmax=60000, cmap='autumn')\n"
      ]
     },
     {
@@ -234,7 +234,7 @@
     "ent_2040.check() # check values are well set and assignes default values\n",
     "\n",
     "print('Valor total en 2040: {:.3e}'.format(ent_2040.exposures.gdf.value.sum()))\n",
-    "ax = ent_2040.exposures.plot_basemap(s=1, zoom=15, url=ctx.sources.OSM_A, vmax=60000, cmap='autumn')\n",
+    "ax = ent_2040.exposures.plot_basemap(s=1, zoom=15, url=ctx.providers.OpenStreetMap.Mapnik, vmax=60000, cmap='autumn')\n",
     "ax.set_title('Exposure 2040');"
    ]
   },

--- a/script/applications/eca_san_salvador/San_Salvador_Adaptation.ipynb
+++ b/script/applications/eca_san_salvador/San_Salvador_Adaptation.ipynb
@@ -102,7 +102,7 @@
     "\n",
     "# Exposures: the ones we used in San Salvador Risk script\n",
     "print('Total value in 2015: {:.3e}'.format(ent_2015.exposures.gdf.value.sum()))\n",
-    "ax = ent_2015.exposures.plot_basemap(s=1, zoom=15, url=ctx.sources.OSM_A, vmax=60000, cmap='autumn')\n",
+    "ax = ent_2015.exposures.plot_basemap(s=1, zoom=15, url=ctx.providers.OpenStreetMap.Mapnik, vmax=60000, cmap='autumn')\n",
     "ax.set_title('Exposure 2015')\n",
     "\n",
     "# Impact Functions: the ones we used in San Salvador Risk script\n",
@@ -169,7 +169,7 @@
     "ent_2040.check() # check values are well set and assignes default values\n",
     "\n",
     "print('Total value in 2040: {:.3e}'.format(ent_2040.exposures.gdf.value.sum()))\n",
-    "ax = ent_2040.exposures.plot_basemap(s=1, zoom=15, url=ctx.sources.OSM_A, vmax=60000, cmap='autumn')\n",
+    "ax = ent_2040.exposures.plot_basemap(s=1, zoom=15, url=ctx.providers.OpenStreetMap.Mapnik, vmax=60000, cmap='autumn')\n",
     "ax.set_title('Exposure 2040');"
    ]
   },

--- a/script/applications/eca_san_salvador/functions_ss.py
+++ b/script/applications/eca_san_salvador/functions_ss.py
@@ -35,7 +35,7 @@ def plot_salvador_ma():
     ax = shape.plot(figsize=(10, 10), alpha=0.5)
     ax.set_xlim(-9943223.896891385, -9911000.065720687)
     ax.set_ylim(1530712.637786494, 1555600.2891258441)
-    ctx.add_basemap(ax, zoom=12, url=ctx.sources.ST_TERRAIN)
+    ctx.add_basemap(ax, zoom=12, url=ctx.providers.Stamen.Terrain)
     rect = patches.Rectangle((-9931038.907412536, 1536570.51725147), 4354.653554389253,
                               2941.9125608841423, linewidth=1, edgecolor='r', facecolor='none')
     ax.add_patch(rect)
@@ -148,7 +148,7 @@ def plot_exposure_ss(exposures, point=None):
         plt.legend(lines_legend, text_legend, numpoints=1, loc=3, title='AUP housing')
         plt.gca().add_artist(legend1)
 
-    ctx.add_basemap(ax, zoom=15, url=ctx.sources.OSM_C, origin='upper')
+    ctx.add_basemap(ax, zoom=15, url=ctx.providers.OpenStreetMap.Mapnik, origin='upper')
     scale_bar(ax, 0.5, location=(0.93, 0.4), linewidth=2)
     rect = patches.Rectangle((-9931033.307412536, 1536686.51725147), 4345.053554389253,
                               2934.0125608841423, linewidth=2, edgecolor='r', facecolor='none', zorder=200)


### PR DESCRIPTION
Changes proposed in this PR:
- Replace contextily.sources with contextily.providers, as suggested in the deprecation warning of contextily 1.1
- use contextily.providers rather than hard coded urls as default arguments for plotting methods

This PR fixes issue #319

### Pull Request Checklist

- [x] Correct target branch selected (if unsure, select `develop`)
- [x] Source branch up-to-date with target branch
- [x] Docs updated
- [x] Tests updated
- [x] Tests passing
- [x] No new linter issues
