### PR TITLE
Make curl default, and manual the alternative fail-back

### DIFF
--- a/doc/tutorial/climada_installation_step_by_step.ipynb
+++ b/doc/tutorial/climada_installation_step_by_step.ipynb
@@ -67,9 +67,7 @@
    "id": "129b2b0c-380b-4888-867b-ab4ccbda28cc",
    "metadata": {},
    "source": [
-    "- Download the [_Conda_ environment specifications for CLIMADA](https://github.com/CLIMADA-project/climada_python/blob/main/requirements/env_climada.yml) from the GitHub repository\\\n",
-    "you can do it manually, by clicking on the link above, then on [Raw] and then saving the page that opens as env_climada.yml into the `climada_workspace` foldern \\\n",
-    "alternatively just execute this command line:"
+    "- Download the [_Conda_ environment specifications for CLIMADA](https://github.com/CLIMADA-project/climada_python/blob/main/requirements/env_climada.yml) from the GitHub repository. This can be done using the command below. In case this fails, you can alternatively do it manually, by clicking on the link above, then on [Raw] and then saving the page that opens as env_climada.yml into the `climada_workspace` folder."
    ]
   },
   {


### PR DESCRIPTION
Changes proposed in this PR:
- Small change in the installation step-by-step guide to use by default curl to get the .yml file.

### Pull Request Checklist

- [ x] Correct target branch selected (if unsure, select `develop`)
- [ x] Source branch up-to-date with target branch
- [ x] Docs updated
- [ x] Tests updated
- [ x] Tests passing
- [ x] No new linter issues
