### PR TITLE
Bugfix/get geometries extent antimeridian

### DIFF
--- a/climada/hazard/test/test_tc_tracks.py
+++ b/climada/hazard/test/test_tc_tracks.py
@@ -905,21 +905,21 @@ class TestFuncs(unittest.TestCase):
         on_land = np.array([False, True, True])
         lon_shift = np.array([-360, 0, 360])
         # ensure both points are considered on land as is
-        self.assertEqual(
+        np.testing.assert_array_equal(
             u_coord.coord_on_land(lat = lat_test, lon = lon_test),
             on_land
         )
         # independently on shifts by 360 degrees in longitude
-        self.assertEqual(
+        np.testing.assert_array_equal(
             u_coord.coord_on_land(lat = lat_test, lon = lon_test + lon_shift),
             on_land
         )
-        self.assertEqual(
+        np.testing.assert_array_equal(
             u_coord.coord_on_land(lat = lat_test, lon = lon_test - lon_shift),
             on_land
         )
         # also when longitude is within correct range
-        self.assertEqual(
+        np.testing.assert_array_equal(
             u_coord.coord_on_land(lat = lat_test, lon = u_coord.lon_normalize(lon_test)),
             on_land
         )

--- a/climada/hazard/test/test_tc_tracks.py
+++ b/climada/hazard/test/test_tc_tracks.py
@@ -897,6 +897,32 @@ class TestFuncs(unittest.TestCase):
         self.assertEqual(sea_land_idx.tolist(), [0,4])
         self.assertEqual(land_sea_idx.tolist(), [2,6])
 
+    def test_track_land_params(self):
+        """Test identification of points on land and distance since landfall"""
+        # 1 pt over the ocean and two points within Fiji, one on each side of the anti-meridian
+        lon_test = np.array([170, 179.18, 180.05])
+        lat_test = np.array([-60, -16.56, -16.85])
+        on_land = np.array([False, True, True])
+        lon_shift = np.array([-360, 0, 360])
+        # ensure both points are considered on land as is
+        self.assertEqual(
+            u_coord.coord_on_land(lat = lat_test, lon = lon_test),
+            on_land
+        )
+        # independently on shifts by 360 degrees in longitude
+        self.assertEqual(
+            u_coord.coord_on_land(lat = lat_test, lon = lon_test + lon_shift),
+            on_land
+        )
+        self.assertEqual(
+            u_coord.coord_on_land(lat = lat_test, lon = lon_test - lon_shift),
+            on_land
+        )
+        # also when longitude is within correct range
+        self.assertEqual(
+            u_coord.coord_on_land(lat = lat_test, lon = u_coord.lon_normalize(lon_test)),
+            on_land
+        )
 
 # Execute Tests
 if __name__ == "__main__":

--- a/climada/util/coordinates.py
+++ b/climada/util/coordinates.py
@@ -647,33 +647,9 @@ def get_land_geometry(country_names=None, extent=None, resolution=10):
     geom : shapely.geometry.multipolygon.MultiPolygon
         Polygonal shape of union.
     """
-    resolution = nat_earth_resolution(resolution)
-    shp_file = shapereader.natural_earth(resolution=resolution,
-                                         category='cultural',
-                                         name='admin_0_countries')
-    reader = shapereader.Reader(shp_file)
-    if (country_names is None) and (extent is None):
-        LOGGER.info("Computing earth's land geometry ...")
-        geom = list(reader.geometries())
-        geom = shapely.ops.unary_union(geom)
-
-    elif country_names:
-        countries = list(reader.records())
-        geom = [country.geometry for country in countries
-                if (country.attributes['ISO_A3'] in country_names) or
-                (country.attributes['WB_A3'] in country_names) or
-                (country.attributes['ADM0_A3'] in country_names)]
-        geom = shapely.ops.unary_union(geom)
-
-    else:
-        extent_poly = Polygon([(extent[0], extent[2]), (extent[0], extent[3]),
-                               (extent[1], extent[3]), (extent[1], extent[2])])
-        geom = []
-        for cntry_geom in reader.geometries():
-            inter_poly = cntry_geom.intersection(extent_poly)
-            if not inter_poly.is_empty:
-                geom.append(inter_poly)
-        geom = shapely.ops.unary_union(geom)
+    geom = get_country_geometries(country_names, extent, resolution)
+    # combine all into a single multipolygon
+    geom = geom.geometry.unary_union
     if not isinstance(geom, MultiPolygon):
         geom = MultiPolygon([geom])
     return geom

--- a/climada/util/coordinates.py
+++ b/climada/util/coordinates.py
@@ -43,7 +43,7 @@ import rasterio.mask
 import rasterio.warp
 import scipy.spatial
 import scipy.interpolate
-from shapely.geometry import MultiPolygon, Point, box
+from shapely.geometry import Polygon, MultiPolygon, Point, box
 import shapely.ops
 import shapely.vectorized
 from sklearn.neighbors import BallTree

--- a/climada/util/coordinates.py
+++ b/climada/util/coordinates.py
@@ -741,11 +741,16 @@ def get_country_geometries(country_names=None, extent=None, resolution=10):
     starts including the projection information. (They are saving a whopping 147 bytes by omitting
     it.) Same goes for UTF.
 
+    If extent is provided, longitude values in 'geom' will all lie within 'extent' longitude
+    range. Therefore setting extent to e.g. [160, 200, -20, 20] will provide longitude values
+    between 160 and 200 degrees.
+
     Parameters
     ----------
     country_names : list, optional
         list with ISO 3166 alpha-3 codes of countries, e.g ['ZWE', 'GBR', 'VNM', 'UZB']
-    extent : tuple (min_lon, max_lon, min_lat, max_lat), optional
+    extent : tuple, optional
+        (min_lon, max_lon, min_lat, max_lat)
         Extent, assumed to be in the same CRS as the natural earth data.
     resolution : float, optional
         10, 50 or 110. Resolution in m. Default: 10m
@@ -777,18 +782,53 @@ def get_country_geometries(country_names=None, extent=None, resolution=10):
     if country_names:
         if isinstance(country_names, str):
             country_names = [country_names]
-        out = out[out.ISO_A3.isin(country_names)]
+        country_mask = np.isin(nat_earth[['ISO_A3', 'WB_A3', 'ADM0_A3']].values, country_names).any(axis=1)
+        out = out[country_mask]
 
     if extent:
-        bbox = Polygon([
-            (extent[0], extent[2]),
-            (extent[0], extent[3]),
-            (extent[1], extent[3]),
-            (extent[1], extent[2])
-        ])
-        bbox = gpd.GeoSeries(bbox, crs=out.crs)
-        bbox = gpd.GeoDataFrame({'geometry': bbox}, crs=out.crs)
+        if extent[1] - extent[0] > 360:
+            raise ValueError(f"longitude extent range is greater than 360: {extent[0]} to {extent[1]}")
+        elif extent[1] < extent[0]:
+            raise ValueError(f"longitude extent at the left ({extent[0]}) is larger than longitude extent at the right ({extent[1]})")
+        # is longitude extent already normalized (i.e., within [-180, +180])? If not, need to be wrapped
+        lon_normalized = extent[0] >= -180 and extent[1] <= 180
+        if lon_normalized:
+            bbox = Polygon([
+                (extent[0], extent[2]),
+                (extent[0], extent[3]),
+                (extent[1], extent[3]),
+                (extent[1], extent[2])
+            ])
+        else:
+            # split the extent box into two boxes both within [-180, +180] in longitude
+            lon_left = np.array([extent[0]])
+            lon_right = np.array([extent[1]])
+            lon_normalize(lon_left)
+            lon_normalize(lon_right)
+            extent_left = (lon_left, 180, extent[2], extent[3])
+            extent_right = (-180, lon_right, extent[2], extent[3])
+            bbox = [
+                Polygon([
+                    (extent_left[0], extent_left[2]),
+                    (extent_left[0], extent_left[3]),
+                    (extent_left[1], extent_left[3]),
+                    (extent_left[1], extent_left[2])
+                ]),
+                Polygon([
+                    (extent_right[0], extent_right[2]),
+                    (extent_right[0], extent_right[3]),
+                    (extent_right[1], extent_right[3]),
+                    (extent_right[1], extent_right[2])
+                ])
+            ]
+            bbox = shapely.ops.unary_union(bbox)
+        bbox = gpd.GeoSeries(bbox, crs=DEF_CRS)
+        bbox = gpd.GeoDataFrame({'geometry': bbox}, crs=DEF_CRS)
         out = gpd.overlay(out, bbox, how="intersection")
+        if ~lon_normalized:
+            lon_mid = 0.5 * (extent[0] + extent[1])
+            # we don't really change the CRS when rewrapping, so we reset the CRS attribute afterwards
+            out = out.to_crs({"proj": "longlat", "lon_wrap": lon_mid}).set_crs(DEF_CRS, allow_override=True)
 
     return out
 

--- a/climada/util/coordinates.py
+++ b/climada/util/coordinates.py
@@ -691,7 +691,7 @@ def coord_on_land(lat, lon, land_geom=None):
                     np.min(lat) - delta_deg,
                     np.max(lat) + delta_deg),
             resolution=10)
-    else:
+    elif not land_geom.is_empty:
         # ensure lon values are within extent of provided land_geom
         land_bounds = land_geom.bounds
         if lons.max() > land_bounds[2] or lons.min() < land_bounds[0]:

--- a/climada/util/test/test_coordinates.py
+++ b/climada/util/test/test_coordinates.py
@@ -859,21 +859,21 @@ class TestGetGeodata(unittest.TestCase):
     def test_get_land_geometry_country_pass(self):
         """get_land_geometry with selected countries."""
         iso_countries = ['DEU', 'VNM']
-        res = u_coord.get_land_geometry(iso_countries, resolution=110)
+        res = u_coord.get_land_geometry(country_names=iso_countries, resolution=10)
         self.assertIsInstance(res, shapely.geometry.multipolygon.MultiPolygon)
         for res, ref in zip(res.bounds, (5.85248986800, 8.56557851800,
                                          109.47242272200, 55.065334377000)):
             self.assertAlmostEqual(res, ref)
 
         iso_countries = ['ESP']
-        res = u_coord.get_land_geometry(iso_countries, resolution=110)
+        res = u_coord.get_land_geometry(country_names=iso_countries, resolution=10)
         self.assertIsInstance(res, shapely.geometry.multipolygon.MultiPolygon)
         for res, ref in zip(res.bounds, (-18.16722571499986, 27.642238674000,
                                          4.337087436000, 43.793443101)):
             self.assertAlmostEqual(res, ref)
 
         iso_countries = ['FRA']
-        res = u_coord.get_land_geometry(iso_countries, resolution=110)
+        res = u_coord.get_land_geometry(country_names=iso_countries, resolution=10)
         self.assertIsInstance(res, shapely.geometry.multipolygon.MultiPolygon)
         for res, ref in zip(res.bounds, (-61.79784094999991, -21.37078215899993,
                                          55.854502800000034, 51.08754088371883)):

--- a/climada/util/test/test_coordinates.py
+++ b/climada/util/test/test_coordinates.py
@@ -859,21 +859,21 @@ class TestGetGeodata(unittest.TestCase):
     def test_get_land_geometry_country_pass(self):
         """get_land_geometry with selected countries."""
         iso_countries = ['DEU', 'VNM']
-        res = u_coord.get_land_geometry(iso_countries, 110)
+        res = u_coord.get_land_geometry(iso_countries, resolution=110)
         self.assertIsInstance(res, shapely.geometry.multipolygon.MultiPolygon)
         for res, ref in zip(res.bounds, (5.85248986800, 8.56557851800,
                                          109.47242272200, 55.065334377000)):
             self.assertAlmostEqual(res, ref)
 
         iso_countries = ['ESP']
-        res = u_coord.get_land_geometry(iso_countries, 110)
+        res = u_coord.get_land_geometry(iso_countries, resolution=110)
         self.assertIsInstance(res, shapely.geometry.multipolygon.MultiPolygon)
         for res, ref in zip(res.bounds, (-18.16722571499986, 27.642238674000,
                                          4.337087436000, 43.793443101)):
             self.assertAlmostEqual(res, ref)
 
         iso_countries = ['FRA']
-        res = u_coord.get_land_geometry(iso_countries, 110)
+        res = u_coord.get_land_geometry(iso_countries, resolution=110)
         self.assertIsInstance(res, shapely.geometry.multipolygon.MultiPolygon)
         for res, ref in zip(res.bounds, (-61.79784094999991, -21.37078215899993,
                                          55.854502800000034, 51.08754088371883)):

--- a/climada/util/test/test_coordinates.py
+++ b/climada/util/test/test_coordinates.py
@@ -958,7 +958,7 @@ class TestGetGeodata(unittest.TestCase):
 
     def test_get_country_geometries_country_norway_pass(self):
         """test correct numeric ISO3 for country Norway"""
-        iso_countries = ['NOR']
+        iso_countries = 'NOR'
         extent = [10, 11, 55, 60]
         res1 = u_coord.get_country_geometries(iso_countries)
         res2 = u_coord.get_country_geometries(extent=extent)
@@ -1002,6 +1002,18 @@ class TestGetGeodata(unittest.TestCase):
         res = u_coord.get_country_geometries(resolution=110)
         self.assertIsInstance(res, gpd.geodataframe.GeoDataFrame)
         self.assertAlmostEqual(res.area[0], 1.639510995900778)
+
+    def test_get_country_geometries_fail(self):
+        """get_country_geometries with offensive parameters"""
+        with self.assertRaises(ValueError) as cm:
+            u_coord.get_country_geometries(extent=(-20,350,0,0))
+        self.assertIn("longitude extent range is greater than 360: -20 to 350",
+                      str(cm.exception))
+        with self.assertRaises(ValueError) as cm:
+            u_coord.get_country_geometries(extent=(350,-20,0,0))
+        self.assertIn("longitude extent at the left (350) is larger "
+                      "than longitude extent at the right (-20)",
+                      str(cm.exception))
 
     def test_country_code_pass(self):
         """Test set_region_id"""

--- a/climada/util/test/test_coordinates.py
+++ b/climada/util/test/test_coordinates.py
@@ -135,25 +135,25 @@ class TestDistance(unittest.TestCase):
         self.assertAlmostEqual(
             7709.827814738594,
             np.sqrt(u_coord._dist_sqr_approx(lats1, lons1, cos_lats1, lats2, lons2)) * ONE_LAT_KM)
-    
+
     def test_geodesic_length_geog(self):
         """Test compute_geodesic_lengths for geographic input crs"""
-        
+
         LINE_PATH = DEMO_DIR.joinpath('nl_rails.gpkg')
         gdf_rails = gpd.read_file(LINE_PATH).to_crs('epsg:4326')
         lengths_geom = u_coord.compute_geodesic_lengths(gdf_rails)
-        
+
         self.assertEqual(len(lengths_geom), len(gdf_rails))
         self.assertTrue(
             np.all(
-                (abs(lengths_geom - gdf_rails['distance'])/lengths_geom < 0.1) | 
+                (abs(lengths_geom - gdf_rails['distance'])/lengths_geom < 0.1) |
                 (lengths_geom - gdf_rails['distance'] < 10)
                 )
             )
 
     def test_geodesic_length_proj(self):
         """Test compute_geodesic_lengths for projected input crs"""
-        
+
         LINE_PATH = DEMO_DIR.joinpath('nl_rails.gpkg')
         gdf_rails = gpd.read_file(LINE_PATH).to_crs('epsg:4326')
         gdf_rails_proj = gpd.read_file(LINE_PATH).to_crs('epsg:4326').to_crs('EPSG:28992')
@@ -163,10 +163,10 @@ class TestDistance(unittest.TestCase):
 
         for len_proj, len_geom in zip(lengths_proj,lengths_geom):
             self.assertAlmostEqual(len_proj, len_geom, 1)
-        
+
         self.assertTrue(
             np.all(
-                (abs(lengths_proj - gdf_rails_proj['distance'])/lengths_proj < 0.1) | 
+                (abs(lengths_proj - gdf_rails_proj['distance'])/lengths_proj < 0.1) |
                 (lengths_proj - gdf_rails_proj['distance'] < 10)
                 )
             )


### PR DESCRIPTION
Changes proposed in this PR:
- Ensure `climada.util.coordinates.get_land_geometry` deals correctly with extent. Previously, if an extent going beyond [-180, +180] range in longitude the geometry would be cut (e.g. passing `extent=(160, 200, -50,50)` would actually return the land geometry only for the extent `(160, 180, -50, 50)`.
- Apply the same correction to `get_country_geometry`.
- Removes the redundancy between these two functions by using the latter in the former.
- Adjust function `coord_on_land` to ensure longitude coordinates are also properly dealt with.

This PR fixes issue #495.

A first test has been implemented but this can be completed.

### Pull Request Checklist

- [x] Correct target branch selected (if unsure, select `develop`)
- [x] Source branch up-to-date with target branch
- [x] Docs updated
- [x] Tests updated
- [x] Tests passing
- [x] No new linter issues
