### PR TITLE
Feature/reassign centr bydflt

### DIFF
--- a/climada/engine/calibration_opt.py
+++ b/climada/engine/calibration_opt.py
@@ -66,26 +66,26 @@ def calib_instance(hazard, exposure, impact_func, df_out=pd.DataFrame(),
             DataFrame with modelled impact written to rows for each year
             or event.
     """
-    IFS = ImpactFuncSet()
-    IFS.append(impact_func)
+    ifs = ImpactFuncSet()
+    ifs.append(impact_func)
     impacts = Impact()
-    impacts.calc(exposure, IFS, hazard, assign_centroids=False)
+    impacts.calc(exposure, ifs, hazard, assign_centroids=False)
     if yearly_impact:  # impact per year
-        IYS = impacts.calc_impact_year_set(all_years=True)
+        iys = impacts.calc_impact_year_set(all_years=True)
         # Loop over whole year range:
         if df_out.empty | df_out.index.shape[0] == 1:
-            for cnt_, year in enumerate(np.sort(list((IYS.keys())))):
+            for cnt_, year in enumerate(np.sort(list((iys.keys())))):
                 if cnt_ > 0:
                     df_out.loc[cnt_] = df_out.loc[0]  # copy info from first row
-                if year in IYS:
-                    df_out.loc[cnt_, 'impact_CLIMADA'] = IYS[year]
+                if year in iys:
+                    df_out.loc[cnt_, 'impact_CLIMADA'] = iys[year]
                 else:
                     df_out.loc[cnt_, 'impact_CLIMADA'] = 0.0
                 df_out.loc[cnt_, 'year'] = year
         else:
-            years_in_common = df_out.loc[df_out['year'].isin(np.sort(list((IYS.keys())))), 'year']
+            years_in_common = df_out.loc[df_out['year'].isin(np.sort(list((iys.keys())))), 'year']
             for cnt_, year in years_in_common.iteritems():
-                df_out.loc[df_out['year'] == year, 'impact_CLIMADA'] = IYS[year]
+                df_out.loc[df_out['year'] == year, 'impact_CLIMADA'] = iys[year]
 
 
     else:  # impact per event
@@ -138,21 +138,21 @@ def init_impf(impf_name_or_instance, param_dict, df_out=pd.DataFrame(index=[0]))
         (index=0) defined with values. The impact function parameters from
         param_dict are represented here.
     """
-    ImpactFunc_final = None
+    impact_func_final = None
     if isinstance(impf_name_or_instance, str):
         if impf_name_or_instance == 'emanuel':
-            ImpactFunc_final = ImpfTropCyclone.from_emanuel_usa(**param_dict)
-            ImpactFunc_final.haz_type = 'TC'
-            ImpactFunc_final.id = 1
+            impact_func_final = ImpfTropCyclone.from_emanuel_usa(**param_dict)
+            impact_func_final.haz_type = 'TC'
+            impact_func_final.id = 1
             df_out['impact_function'] = impf_name_or_instance
     elif isinstance(impf_name_or_instance, impact_funcs.ImpactFunc):
-        ImpactFunc_final = change_impf(impf_name_or_instance, param_dict)
+        impact_func_final = change_impf(impf_name_or_instance, param_dict)
         df_out['impact_function'] = ('given_' +
-                                     ImpactFunc_final.haz_type +
-                                     str(ImpactFunc_final.id))
+                                     impact_func_final.haz_type +
+                                     str(impact_func_final.id))
     for key, val in param_dict.items():
         df_out[key] = val
-    return ImpactFunc_final, df_out
+    return impact_func_final, df_out
 
 def change_impf(impf_instance, param_dict):
     """apply a shifting or a scaling defined in param_dict to the impact
@@ -348,8 +348,8 @@ def calib_all(hazard, exposure, impf_name_or_instance, param_full_dict,
     for param_dict in params_generator:
         print(param_dict)
         df_out = copy.deepcopy(df_impact_data)
-        ImpactFunc_final, df_out = init_impf(impf_name_or_instance, param_dict, df_out)
-        df_out = calib_instance(hazard, exposure, ImpactFunc_final, df_out, yearly_impact)
+        impact_func_final, df_out = init_impf(impf_name_or_instance, param_dict, df_out)
+        df_out = calib_instance(hazard, exposure, impact_func_final, df_out, yearly_impact)
         if df_result is None:
             df_result = copy.deepcopy(df_out)
         else:
@@ -410,8 +410,8 @@ def calib_optimize(hazard, exposure, impf_name_or_instance, param_dict,
         else:
             raise ValueError('other impact data sources not yet implemented.')
     # definie specific function to
-    def specific_calib(x):
-        param_dict_temp = dict(zip(param_dict.keys(), x))
+    def specific_calib(values):
+        param_dict_temp = dict(zip(param_dict.keys(), values))
         print(param_dict_temp)
         return calib_instance(hazard, exposure,
                               init_impf(impf_name_or_instance, param_dict_temp)[0],
@@ -429,8 +429,8 @@ def calib_optimize(hazard, exposure, impf_name_or_instance, param_dict,
                 {'type': 'ineq', 'fun': lambda x: x[1]}]
 
 
-    x0 = list(param_dict.values())
-    res = minimize(specific_calib, x0,
+    values = list(param_dict.values())
+    res = minimize(specific_calib, values,
                    # bounds=bounds,
                    # bounds=((0.0, np.inf), (0.0, np.inf), (0.0, 1.0)),
                    constraints=cons,

--- a/climada/engine/calibration_opt.py
+++ b/climada/engine/calibration_opt.py
@@ -69,7 +69,7 @@ def calib_instance(hazard, exposure, impact_func, df_out=pd.DataFrame(),
     IFS = ImpactFuncSet()
     IFS.append(impact_func)
     impacts = Impact()
-    impacts.calc(exposure, IFS, hazard)
+    impacts.calc(exposure, IFS, hazard, assign_centroids=False)
     if yearly_impact:  # impact per year
         IYS = impacts.calc_impact_year_set(all_years=True)
         # Loop over whole year range:
@@ -333,6 +333,7 @@ def calib_all(hazard, exposure, impf_name_or_instance, param_full_dict,
     # prepare hazard and exposure
     region_ids = list(np.unique(exposure.region_id))
     hazard_type = hazard.tag.haz_type
+    exposure.assign_centroids(hazard)
     # prepare impact data
     if isinstance(impact_data_source, pd.DataFrame):
         df_impact_data = impact_data_source
@@ -398,6 +399,7 @@ def calib_optimize(hazard, exposure, impf_name_or_instance, param_dict,
     # prepare hazard and exposure
     region_ids = list(np.unique(exposure.region_id))
     hazard_type = hazard.tag.haz_type
+    exposure.assign_centroids(hazard)
     # prepare impact data
     if isinstance(impact_data_source, pd.DataFrame):
         df_impact_data = impact_data_source

--- a/climada/engine/cost_benefit.py
+++ b/climada/engine/cost_benefit.py
@@ -188,7 +188,14 @@ class CostBenefit():
             count the same when there is no future hazard nor entity and 1
             (linear annual change) when there is future hazard or entity.
             Default is None.
-        save_imp : bool, optional)
+        save_imp : bool, optional
+            Default: False
+        assign_centroids : bool, optional
+            indicates whether centroids are assigned to the self.exposures object.
+            Centroids assignment is an expensive operation; set this to ``False`` to save
+            computation time if the exposures from ``ent`` and ``ent_fut`` have already
+            centroids assigned for the respective hazards.
+            Default: True
         True if Impact of each measure is saved. Default is False.
         """
         # Present year given in entity. Future year in ent_future if provided.

--- a/climada/engine/cost_benefit.py
+++ b/climada/engine/cost_benefit.py
@@ -157,8 +157,8 @@ class CostBenefit():
         self.imp_meas_future = dict()
         self.imp_meas_present = dict()
 
-    def calc(self, hazard, entity, haz_future=None, ent_future=None,
-             future_year=None, risk_func=risk_aai_agg, imp_time_depen=None, save_imp=False, assign_centroids=True):
+    def calc(self, hazard, entity, haz_future=None, ent_future=None, future_year=None,
+             risk_func=risk_aai_agg, imp_time_depen=None, save_imp=False, assign_centroids=True):
         """Compute cost-benefit ratio for every measure provided current
         and, optionally, future conditions. Present and future measures need
         to have the same name. The measures costs need to be discounted by the user.
@@ -780,7 +780,8 @@ class CostBenefit():
         # compute impact for each measure
         for measure in meas_set.get_measure(hazard.tag.haz_type):
             LOGGER.debug('%s impact of measure %s.', when, measure.name)
-            imp_tmp, risk_transf = measure.calc_impact(exposures, imp_fun_set, hazard, assign_centroids=False)
+            imp_tmp, risk_transf = measure.calc_impact(exposures, imp_fun_set, hazard,
+                                                       assign_centroids=False)
             impact_meas[measure.name] = dict()
             impact_meas[measure.name]['cost'] = (measure.cost, measure.risk_transf_cost_factor)
             impact_meas[measure.name]['risk'] = risk_func(imp_tmp)

--- a/climada/engine/forecast.py
+++ b/climada/engine/forecast.py
@@ -295,7 +295,7 @@ class Forecast:
         for ind_i, haz_i in enumerate(self.hazard):
             self._impact[ind_i].calc(
                 self.exposure, self.vulnerability, haz_i,
-                save_mat=True, reassign_centroids=force_reassign
+                save_mat=True, assign_centroids=force_reassign
             )
 
     def plot_imp_map(

--- a/climada/engine/forecast.py
+++ b/climada/engine/forecast.py
@@ -293,11 +293,9 @@ class Forecast:
         """
         # calc impact
         for ind_i, haz_i in enumerate(self.hazard):
-            # force reassign
-            if force_reassign:
-                self.exposure.assign_centroids(haz_i)
             self._impact[ind_i].calc(
-                self.exposure, self.vulnerability, haz_i, save_mat=True, reassign_centroids=False
+                self.exposure, self.vulnerability, haz_i,
+                save_mat=True, reassign_centroids=force_reassign
             )
 
     def plot_imp_map(

--- a/climada/engine/forecast.py
+++ b/climada/engine/forecast.py
@@ -292,7 +292,8 @@ class Forecast:
             default is false.
         """
         # calc impact
-        self.exposure.assign_centroids(self.hazard, overwrite=force_reassign)
+        if self.hazard:
+            self.exposure.assign_centroids(self.hazard[0], overwrite=force_reassign)
         for ind_i, haz_i in enumerate(self.hazard):
             self._impact[ind_i].calc(
                 self.exposure, self.vulnerability, haz_i,

--- a/climada/engine/forecast.py
+++ b/climada/engine/forecast.py
@@ -297,7 +297,7 @@ class Forecast:
             if force_reassign:
                 self.exposure.assign_centroids(haz_i)
             self._impact[ind_i].calc(
-                self.exposure, self.vulnerability, haz_i, save_mat=True
+                self.exposure, self.vulnerability, haz_i, save_mat=True, reassign_centroids=False
             )
 
     def plot_imp_map(

--- a/climada/engine/forecast.py
+++ b/climada/engine/forecast.py
@@ -292,10 +292,11 @@ class Forecast:
             default is false.
         """
         # calc impact
+        self.exposure.assign_centroids(self.hazard, overwrite=force_reassign)
         for ind_i, haz_i in enumerate(self.hazard):
             self._impact[ind_i].calc(
                 self.exposure, self.vulnerability, haz_i,
-                save_mat=True, assign_centroids=force_reassign
+                save_mat=True, assign_centroids=False
             )
 
     def plot_imp_map(

--- a/climada/engine/impact.py
+++ b/climada/engine/impact.py
@@ -184,7 +184,7 @@ class Impact():
 
 
 
-    def calc(self, exposures, impact_funcs, hazard, save_mat=False):
+    def calc(self, exposures, impact_funcs, hazard, save_mat=False, reassign_centroids=True):
         """This function is deprecated, use ImpactCalc.impact
         and ImpactCalc.insured_impact instead.
         """
@@ -198,11 +198,11 @@ class Impact():
                 " for insured impacts instead. For non-insured impacts "
                 "please use ImpactCalc().impact()"
                 )
-            self.__dict__ = impcalc.insured_impact(save_mat).__dict__
+            self.__dict__ = impcalc.insured_impact(save_mat, reassign_centroids).__dict__
         else:
             LOGGER.warning("The use of Impact().calc() is deprecated. "
                            "Use ImpactCalc().impact() instead.")
-            self.__dict__ = impcalc.impact(save_mat).__dict__
+            self.__dict__ = impcalc.impact(save_mat, reassign_centroids).__dict__
 
 #TODO: new name
     @classmethod
@@ -1029,7 +1029,7 @@ class Impact():
         imp_arr = np.zeros(len(exp.gdf))
         for i_time, _ in enumerate(haz_list):
             imp_tmp = Impact()
-            imp_tmp.calc(exp, impf_set, haz_list[i_time])
+            imp_tmp.calc(exp, impf_set, haz_list[i_time], reassign_centroids=False)
             imp_arr = np.maximum(imp_arr, imp_tmp.eai_exp)
             # remove not impacted exposures
             save_exp = imp_arr > imp_thresh

--- a/climada/engine/impact.py
+++ b/climada/engine/impact.py
@@ -184,7 +184,7 @@ class Impact():
 
 
 
-    def calc(self, exposures, impact_funcs, hazard, save_mat=False, reassign_centroids=True):
+    def calc(self, exposures, impact_funcs, hazard, save_mat=False, assign_centroids=True):
         """This function is deprecated, use ImpactCalc.impact
         and ImpactCalc.insured_impact instead.
         """
@@ -198,11 +198,11 @@ class Impact():
                 " for insured impacts instead. For non-insured impacts "
                 "please use ImpactCalc().impact()"
                 )
-            self.__dict__ = impcalc.insured_impact(save_mat, reassign_centroids).__dict__
+            self.__dict__ = impcalc.insured_impact(save_mat, assign_centroids).__dict__
         else:
             LOGGER.warning("The use of Impact().calc() is deprecated. "
                            "Use ImpactCalc().impact() instead.")
-            self.__dict__ = impcalc.impact(save_mat, reassign_centroids).__dict__
+            self.__dict__ = impcalc.impact(save_mat, assign_centroids).__dict__
 
 #TODO: new name
     @classmethod
@@ -1027,9 +1027,11 @@ class Impact():
         imp_list = []
         exp_list = []
         imp_arr = np.zeros(len(exp.gdf))
+        # assign centroids once for all
+        exp.assign_centroids(haz_list[0])
         for i_time, _ in enumerate(haz_list):
             imp_tmp = Impact()
-            imp_tmp.calc(exp, impf_set, haz_list[i_time], reassign_centroids=False)
+            imp_tmp.calc(exp, impf_set, haz_list[i_time], assign_centroids=False)
             imp_arr = np.maximum(imp_arr, imp_tmp.eai_exp)
             # remove not impacted exposures
             save_exp = imp_arr > imp_thresh

--- a/climada/engine/impact_calc.py
+++ b/climada/engine/impact_calc.py
@@ -272,7 +272,7 @@ class ImpactCalc():
         """
         if assign_centroids:
             self.exposures.assign_centroids(self.hazard, overwrite=True)
-        elif self.hazard.centr_exp_col not in self.exposures.gdf.column:
+        elif self.hazard.centr_exp_col not in self.exposures.gdf.columns:
             raise ValueError("'assign_centroids' is set to 'False' but no centroids are assigned"
                              f" for the given hazard type ({self.hazard.tag.haz_type})."
                              " Run `asssign_centroids` beforehand or set the 'assign_centroids'"

--- a/climada/engine/impact_calc.py
+++ b/climada/engine/impact_calc.py
@@ -61,7 +61,8 @@ class ImpactCalc():
         self.exposures = exposures
         self.impfset = impfset
         self.hazard = hazard
-        self._orig_exp_idx = np.arange(self.exposures.gdf.shape[0]) #exposures index to use for matrix reconstruction
+        # exposures index to use for matrix reconstruction
+        self._orig_exp_idx = np.arange(self.exposures.gdf.shape[0])
 
     @property
     def n_exp_pnt(self):
@@ -260,7 +261,8 @@ class ImpactCalc():
             )
         if exp_gdf.size == 0:
             LOGGER.warning("No exposures with value >0 in the vicinity of the hazard.")
-        self._orig_exp_idx = mask.nonzero()[0]  #update index of kept exposures points in exp_gdf within the full exposures
+        self._orig_exp_idx = mask.nonzero()[0]  # update index of kept exposures points in exp_gdf
+                                                # within the full exposures
         return exp_gdf
 
     def imp_mat_gen(self, exp_gdf, impf_col):
@@ -381,10 +383,11 @@ class ImpactCalc():
         scipy.sparse.csr_matrix
             Impact per event (rows) per exposure point (columns)
         """
-        n_exp_pnt = len(cent_idx) #implicitly checks in matrix assignement whether len(cent_idx) == len(exp_values)
+        n_exp_pnt = len(cent_idx)  # implicitly checks in matrix assignement whether
+                                   # len(cent_idx) == len(exp_values)
         mdr = self.hazard.get_mdr(cent_idx, impf)
         fract = self.hazard.get_fraction(cent_idx)
-        exp_values_csr = sparse.csr_matrix( #vector 1 x exp_size
+        exp_values_csr = sparse.csr_matrix(  # vector 1 x exp_size
             (exp_values, np.arange(n_exp_pnt), [0, n_exp_pnt]),
             shape=(1, n_exp_pnt))
         return fract.multiply(mdr).multiply(exp_values_csr)
@@ -393,7 +396,9 @@ class ImpactCalc():
         """
         Make an impact matrix from an impact sub-matrix generator
         """
-        data, row, col = np.hstack([  #rows=events index, cols=exposure point index within self.exposures
+        # rows: events index
+        # cols: exposure point index within self.exposures
+        data, row, col = np.hstack([
             (mat.data, mat.nonzero()[0], self._orig_exp_idx[idx][mat.nonzero()[1]])
             for mat, idx in imp_mat_gen
             ])

--- a/climada/engine/impact_calc.py
+++ b/climada/engine/impact_calc.py
@@ -111,11 +111,10 @@ class ImpactCalc():
             if true, save the total impact matrix (events x exposures)
             Default: True
         assign_centroids : bool, optional
-            indicates whether centroids are re-assigned to the self.exposures object
-            or kept from previous impact calculation with a hazard of the same hazard type.
+            indicates whether centroids are assigned to the self.exposures object.
             Centroids assignment is an expensive operation; set this to ``False`` to save
-            computation time if the centroids have not changed since the last impact
-            calculation.
+            computation time if the hazards' centroids are already assigned to the exposures
+            object.
             Default: True
 
         Examples
@@ -157,11 +156,10 @@ class ImpactCalc():
         save_mat : bool
             if true, save the total impact matrix (events x exposures)
         assign_centroids : bool, optional
-            indicates whether centroids are re-assigned to the self.exposures object
-            or kept from previous impact calculation with a hazard of the same hazard type.
+            indicates whether centroids are assigned to the self.exposures object.
             Centroids assignment is an expensive operation; set this to ``False`` to save
-            computation time if the centroids have not changed since the last impact
-            calculation.
+            computation time if the hazards' centroids are already assigned to the exposures
+            object.
             Default: True
 
         Examples

--- a/climada/engine/impact_calc.py
+++ b/climada/engine/impact_calc.py
@@ -239,18 +239,23 @@ class ImpactCalc():
         return Impact.from_eih(self.exposures, self.impfset, self.hazard,
                         at_event, eai_exp, aai_agg, imp_mat)
 
-    def minimal_exp_gdf(self, impf_col):
+    def minimal_exp_gdf(self, impf_col, reassign=True):
         """Get minimal exposures geodataframe for impact computation
 
         Parameters
         ----------
         exposures : climada.entity.Exposures
         hazard : climada.Hazard
-        impf_col: str
+        impf_col : str
             name of the impact function column in exposures.gdf
-
+        reassign : bool, optional
+            indicates whether centroids are re-assigned to the self.exposures object
+            or kept from previous impact calculation with a hazard of the same hazard type.
+            Centroids assignment is an expensive operation, set this to true if you know that
+            the centroids are the same between two impact calculations.
+            Default: True, i.e., re-assign
         """
-        self.exposures.assign_centroids(self.hazard, overwrite=False)
+        self.exposures.assign_centroids(self.hazard, overwrite=reassign)
         mask = (
             (self.exposures.gdf.value.values != 0)
             & (self.exposures.gdf[self.hazard.centr_exp_col].values >= 0)

--- a/climada/engine/impact_calc.py
+++ b/climada/engine/impact_calc.py
@@ -113,8 +113,9 @@ class ImpactCalc():
         reassign_centroids : bool, optional
             indicates whether centroids are re-assigned to the self.exposures object
             or kept from previous impact calculation with a hazard of the same hazard type.
-            Centroids assignment is an expensive operation, set this to true if you know that
-            the centroids are the same between two impact calculations.
+            Centroids assignment is an expensive operation; set this to ``False`` to save 
+            computation time if the centroids have not changed since the last impact
+            calculation.
             Default: True
 
         Examples
@@ -158,8 +159,9 @@ class ImpactCalc():
         reassign_centroids : bool, optional
             indicates whether centroids are re-assigned to the self.exposures object
             or kept from previous impact calculation with a hazard of the same hazard type.
-            Centroids assignment is an expensive operation, set this to true if you know that
-            the centroids are the same between two impact calculations.
+            Centroids assignment is an expensive operation; set this to ``False`` to save 
+            computation time if the centroids have not changed since the last impact
+            calculation.
             Default: True
 
         Examples
@@ -264,8 +266,9 @@ class ImpactCalc():
         reassign_centroids : bool
             Indicates whether centroids are re-assigned to the self.exposures object
             or kept from previous impact calculation with a hazard of the same hazard type.
-            Centroids assignment is an expensive operation, set this to true if you know that
-            the centroids are the same between two impact calculations.
+            Centroids assignment is an expensive operation; set this to ``False`` to save 
+            computation time if the centroids have not changed since the last impact
+            calculation.
         """
         self.exposures.assign_centroids(self.hazard, overwrite=reassign_centroids)
         mask = (

--- a/climada/engine/impact_calc.py
+++ b/climada/engine/impact_calc.py
@@ -275,8 +275,8 @@ class ImpactCalc():
         elif self.hazard.centr_exp_col not in self.exposures.gdf.columns:
             raise ValueError("'assign_centroids' is set to 'False' but no centroids are assigned"
                              f" for the given hazard type ({self.hazard.tag.haz_type})."
-                             " Run `asssign_centroids` beforehand or set the 'assign_centroids'"
-                             " to 'True'")
+                             " Run 'exposures.assign_centroids()' beforehand or set"
+                             " 'assign_centroids' to 'True'")
         mask = (
             (self.exposures.gdf.value.values != 0)
             & (self.exposures.gdf[self.hazard.centr_exp_col].values >= 0)

--- a/climada/engine/impact_calc.py
+++ b/climada/engine/impact_calc.py
@@ -113,7 +113,7 @@ class ImpactCalc():
         assign_centroids : bool, optional
             indicates whether centroids are re-assigned to the self.exposures object
             or kept from previous impact calculation with a hazard of the same hazard type.
-            Centroids assignment is an expensive operation; set this to ``False`` to save 
+            Centroids assignment is an expensive operation; set this to ``False`` to save
             computation time if the centroids have not changed since the last impact
             calculation.
             Default: True
@@ -159,7 +159,7 @@ class ImpactCalc():
         assign_centroids : bool, optional
             indicates whether centroids are re-assigned to the self.exposures object
             or kept from previous impact calculation with a hazard of the same hazard type.
-            Centroids assignment is an expensive operation; set this to ``False`` to save 
+            Centroids assignment is an expensive operation; set this to ``False`` to save
             computation time if the centroids have not changed since the last impact
             calculation.
             Default: True
@@ -266,7 +266,7 @@ class ImpactCalc():
         assign_centroids : bool
             Indicates whether centroids are re-assigned to the self.exposures object
             or kept from previous impact calculation with a hazard of the same hazard type.
-            Centroids assignment is an expensive operation; set this to ``False`` to save 
+            Centroids assignment is an expensive operation; set this to ``False`` to save
             computation time if the centroids have not changed since the last impact
             calculation.
         """

--- a/climada/engine/test/test_cost_benefit.py
+++ b/climada/engine/test/test_cost_benefit.py
@@ -820,7 +820,7 @@ class TestRiskFuncs(unittest.TestCase):
         hazard = Hazard.from_mat(HAZ_TEST_MAT)
         impact = Impact()
         ent.exposures.assign_centroids(hazard)
-        impact.calc(ent.exposures, ent.impact_funcs, hazard)
+        impact.calc(ent.exposures, ent.impact_funcs, hazard, reassign_centroids=False)
         return impact
 
     def test_risk_aai_agg_pass(self):

--- a/climada/engine/test/test_cost_benefit.py
+++ b/climada/engine/test/test_cost_benefit.py
@@ -61,6 +61,7 @@ class TestSteps(unittest.TestCase):
         for meas in entity.measures.get_measure('TC'):
             meas.haz_type = 'TC'
         entity.check()
+        entity.exposures.assign_centroids(hazard)
 
         cost_ben = CostBenefit()
         cost_ben._calc_impact_measures(hazard, entity.exposures, entity.measures,
@@ -241,6 +242,7 @@ class TestSteps(unittest.TestCase):
         for meas in entity.measures.get_measure('TC'):
             meas.haz_type = 'TC'
         entity.check()
+        entity.exposures.assign_centroids(hazard)
 
         cost_ben = CostBenefit()
         cost_ben._calc_impact_measures(hazard, entity.exposures, entity.measures,
@@ -277,6 +279,7 @@ class TestSteps(unittest.TestCase):
         for meas in entity.measures.get_measure('TC'):
             meas.haz_type = 'TC'
         entity.check()
+        entity.exposures.assign_centroids(hazard)
 
         cost_ben = CostBenefit()
         cost_ben._calc_impact_measures(hazard, entity.exposures, entity.measures,
@@ -288,6 +291,7 @@ class TestSteps(unittest.TestCase):
 
         haz_future = copy.deepcopy(hazard)
         haz_future.intensity.data += 25
+        ent_future.exposures.assign_centroids(haz_future)
 
         cost_ben._calc_impact_measures(haz_future, ent_future.exposures, ent_future.measures,
                                        ent_future.impact_funcs, when='future',

--- a/climada/engine/test/test_cost_benefit.py
+++ b/climada/engine/test/test_cost_benefit.py
@@ -820,7 +820,7 @@ class TestRiskFuncs(unittest.TestCase):
         hazard = Hazard.from_mat(HAZ_TEST_MAT)
         impact = Impact()
         ent.exposures.assign_centroids(hazard)
-        impact.calc(ent.exposures, ent.impact_funcs, hazard, reassign_centroids=False)
+        impact.calc(ent.exposures, ent.impact_funcs, hazard, assign_centroids=False)
         return impact
 
     def test_risk_aai_agg_pass(self):

--- a/climada/engine/test/test_impact.py
+++ b/climada/engine/test/test_impact.py
@@ -298,7 +298,7 @@ class TestIO(unittest.TestCase):
 
         imp_write = Impact()
         ent.exposures.assign_centroids(hazard)
-        imp_write.calc(ent.exposures, ent.impact_funcs, hazard, reassign_centroids=False)
+        imp_write.calc(ent.exposures, ent.impact_funcs, hazard, assign_centroids=False)
         file_name = DATA_FOLDER.joinpath('test.xlsx')
         imp_write.write_excel(file_name)
 
@@ -351,7 +351,7 @@ class TestRPmatrix(unittest.TestCase):
         # Assign centroids to exposures
         ent.exposures.assign_centroids(hazard)
         # Compute the impact over the whole exposures
-        impact.calc(ent.exposures, ent.impact_funcs, hazard, save_mat=True, reassign_centroids=False)
+        impact.calc(ent.exposures, ent.impact_funcs, hazard, save_mat=True, assign_centroids=False)
         # Compute the impact per return period over the whole exposures
         impact_rp = impact.local_exceedance_imp(return_periods=(10, 40))
 
@@ -561,7 +561,7 @@ class TestSelect(unittest.TestCase):
         ent.exposures.assign_centroids(hazard)
 
         # Compute the impact over the whole exposures
-        imp.calc(ent.exposures, ent.impact_funcs, hazard, save_mat=True, reassign_centroids=False)
+        imp.calc(ent.exposures, ent.impact_funcs, hazard, save_mat=True, assign_centroids=False)
 
         sel_imp = imp.select(event_ids=imp.event_id,
                              event_names=imp.event_name,

--- a/climada/engine/test/test_impact.py
+++ b/climada/engine/test/test_impact.py
@@ -298,7 +298,7 @@ class TestIO(unittest.TestCase):
 
         imp_write = Impact()
         ent.exposures.assign_centroids(hazard)
-        imp_write.calc(ent.exposures, ent.impact_funcs, hazard)
+        imp_write.calc(ent.exposures, ent.impact_funcs, hazard, reassign_centroids=False)
         file_name = DATA_FOLDER.joinpath('test.xlsx')
         imp_write.write_excel(file_name)
 
@@ -351,7 +351,7 @@ class TestRPmatrix(unittest.TestCase):
         # Assign centroids to exposures
         ent.exposures.assign_centroids(hazard)
         # Compute the impact over the whole exposures
-        impact.calc(ent.exposures, ent.impact_funcs, hazard, save_mat=True)
+        impact.calc(ent.exposures, ent.impact_funcs, hazard, save_mat=True, reassign_centroids=False)
         # Compute the impact per return period over the whole exposures
         impact_rp = impact.local_exceedance_imp(return_periods=(10, 40))
 
@@ -561,7 +561,7 @@ class TestSelect(unittest.TestCase):
         ent.exposures.assign_centroids(hazard)
 
         # Compute the impact over the whole exposures
-        imp.calc(ent.exposures, ent.impact_funcs, hazard, save_mat=True)
+        imp.calc(ent.exposures, ent.impact_funcs, hazard, save_mat=True, reassign_centroids=False)
 
         sel_imp = imp.select(event_ids=imp.event_id,
                              event_names=imp.event_name,

--- a/climada/engine/test/test_impact_calc.py
+++ b/climada/engine/test/test_impact_calc.py
@@ -152,7 +152,7 @@ class TestImpactCalc(unittest.TestCase):
         exp = Exposures.from_hdf5(get_test_file('test_exposure_US_flood_random_locations'))
         impf_set = ImpactFuncSet.from_excel(Path(__file__).parent / 'data' / 'flood_imp_func_set.xls')
         icalc = ImpactCalc(exp, impf_set, haz)
-        impact = icalc.impact()
+        impact = icalc.impact(reassign_centroids=False)
         aai_agg = 161436.05112960344
         eai_exp = np.array([
             1.61159701e+05, 1.33742847e+02, 0.00000000e+00, 4.21352988e-01,
@@ -181,11 +181,11 @@ class TestImpactCalc(unittest.TestCase):
         check_impact(self, impact, haz, exp, aai_agg, eai_exp, at_event, imp_mat_array)
 
     def test_empty_impact(self):
-        """Check that empty impact is returned if no centroids matching the exposures"""
+        """Check that empty impact is returned if no centroids match the exposures"""
         exp = ENT.exposures.copy()
         exp.gdf['centr_TC'] = -1
         icalc = ImpactCalc(exp, ENT.impact_funcs, HAZ)
-        impact = icalc.impact()
+        impact = icalc.impact(reassign_centroids=False)
         aai_agg = 0.0
         eai_exp = np.zeros(len(exp.gdf))
         at_event = np.zeros(HAZ.size)
@@ -299,7 +299,7 @@ class TestImpactCalc(unittest.TestCase):
     def test_minimal_exp_gdf(self):
         """Test obtain minimal exposures gdf"""
         icalc = ImpactCalc(ENT.exposures, ENT.impact_funcs, HAZ)
-        exp_min_gdf = icalc.minimal_exp_gdf('impf_TC')
+        exp_min_gdf = icalc.minimal_exp_gdf('impf_TC', False)
         self.assertSetEqual(
             set(exp_min_gdf.columns), set(['value', 'impf_TC', 'centr_TC'])
             )

--- a/climada/engine/test/test_impact_calc.py
+++ b/climada/engine/test/test_impact_calc.py
@@ -133,7 +133,7 @@ class TestImpactCalc(unittest.TestCase):
         HAZf = deepcopy(HAZ)
         HAZf.fraction *= 0.6
         icalc = ImpactCalc(ENT.exposures, ENT.impact_funcs, HAZf)
-        impact = icalc.impact()
+        impact = icalc.impact(reassign_centroids=False)
         self.assertEqual(icalc.n_events, len(impact.at_event))
         self.assertEqual(0, impact.at_event[0])
         self.assertEqual(0, impact.at_event[7225])
@@ -191,7 +191,7 @@ class TestImpactCalc(unittest.TestCase):
         at_event = np.zeros(HAZ.size)
         check_impact(self, impact, HAZ, exp, aai_agg, eai_exp, at_event, None)
 
-        impact = icalc.impact(save_mat=True)
+        impact = icalc.impact(save_mat=True, reassign_centroids=False)
         imp_mat_array = sparse.csr_matrix((HAZ.size, len(exp.gdf))).toarray()
         check_impact(self, impact, HAZ, exp, aai_agg, eai_exp, at_event, imp_mat_array)
 
@@ -204,7 +204,7 @@ class TestImpactCalc(unittest.TestCase):
         eai_exp = np.zeros(len(ENT.exposures.gdf))
         at_event = np.array([0])
         check_impact(self, impact, haz, ENT.exposures, aai_agg, eai_exp, at_event, None)
-        impact = icalc.impact(save_mat=True)
+        impact = icalc.impact(save_mat=True, reassign_centroids=False)
         imp_mat_array = sparse.csr_matrix((haz.size, len(ENT.exposures.gdf))).toarray()
         check_impact(self, impact, haz, ENT.exposures, aai_agg, eai_exp, at_event, imp_mat_array)
 

--- a/climada/engine/test/test_impact_calc.py
+++ b/climada/engine/test/test_impact_calc.py
@@ -133,7 +133,7 @@ class TestImpactCalc(unittest.TestCase):
         HAZf = deepcopy(HAZ)
         HAZf.fraction *= 0.6
         icalc = ImpactCalc(ENT.exposures, ENT.impact_funcs, HAZf)
-        impact = icalc.impact(reassign_centroids=False)
+        impact = icalc.impact(assign_centroids=False)
         self.assertEqual(icalc.n_events, len(impact.at_event))
         self.assertEqual(0, impact.at_event[0])
         self.assertEqual(0, impact.at_event[7225])
@@ -152,7 +152,7 @@ class TestImpactCalc(unittest.TestCase):
         exp = Exposures.from_hdf5(get_test_file('test_exposure_US_flood_random_locations'))
         impf_set = ImpactFuncSet.from_excel(Path(__file__).parent / 'data' / 'flood_imp_func_set.xls')
         icalc = ImpactCalc(exp, impf_set, haz)
-        impact = icalc.impact(reassign_centroids=False)
+        impact = icalc.impact(assign_centroids=False)
         aai_agg = 161436.05112960344
         eai_exp = np.array([
             1.61159701e+05, 1.33742847e+02, 0.00000000e+00, 4.21352988e-01,
@@ -185,13 +185,13 @@ class TestImpactCalc(unittest.TestCase):
         exp = ENT.exposures.copy()
         exp.gdf['centr_TC'] = -1
         icalc = ImpactCalc(exp, ENT.impact_funcs, HAZ)
-        impact = icalc.impact(reassign_centroids=False)
+        impact = icalc.impact(assign_centroids=False)
         aai_agg = 0.0
         eai_exp = np.zeros(len(exp.gdf))
         at_event = np.zeros(HAZ.size)
         check_impact(self, impact, HAZ, exp, aai_agg, eai_exp, at_event, None)
 
-        impact = icalc.impact(save_mat=True, reassign_centroids=False)
+        impact = icalc.impact(save_mat=True, assign_centroids=False)
         imp_mat_array = sparse.csr_matrix((HAZ.size, len(exp.gdf))).toarray()
         check_impact(self, impact, HAZ, exp, aai_agg, eai_exp, at_event, imp_mat_array)
 
@@ -204,7 +204,7 @@ class TestImpactCalc(unittest.TestCase):
         eai_exp = np.zeros(len(ENT.exposures.gdf))
         at_event = np.array([0])
         check_impact(self, impact, haz, ENT.exposures, aai_agg, eai_exp, at_event, None)
-        impact = icalc.impact(save_mat=True, reassign_centroids=False)
+        impact = icalc.impact(save_mat=True, assign_centroids=False)
         imp_mat_array = sparse.csr_matrix((haz.size, len(ENT.exposures.gdf))).toarray()
         check_impact(self, impact, haz, ENT.exposures, aai_agg, eai_exp, at_event, imp_mat_array)
 

--- a/climada/engine/unsequa/calc_cost_benefit.py
+++ b/climada/engine/unsequa/calc_cost_benefit.py
@@ -279,8 +279,11 @@ class CalcCostBenefit(Calc):
         ent_fut = self.ent_fut_input_var.evaluate(**ent_fut_samples)
 
         cb = CostBenefit()
+        ent.exposures.assign_centroids(haz, overwrite=False)
+        if ent_fut:
+            ent_fut.exposures.assign_centroids(haz_fut if haz_fut else haz, overwrite=False)
         cb.calc(hazard=haz, entity=ent, haz_future=haz_fut, ent_future=ent_fut,
-                save_imp=False, **kwargs)
+                save_imp=False, assign_centroids=False, **kwargs)
 
         # Extract from climada.impact the chosen metrics
         return  [cb.imp_meas_present,

--- a/climada/engine/unsequa/calc_impact.py
+++ b/climada/engine/unsequa/calc_impact.py
@@ -261,8 +261,8 @@ class CalcImpact(Calc):
         haz = self.haz_input_var.evaluate(**haz_samples)
 
         imp = Impact()
-
-        imp.calc(exposures=exp, impact_funcs=impf, hazard=haz)
+        exp.assign_centroids(haz, overwrite=False)
+        imp.calc(exposures=exp, impact_funcs=impf, hazard=haz, assign_centroids=False)
 
         # Extract from climada.impact the chosen metrics
         freq_curve = imp.calc_freq_curve(self.rp).impact

--- a/climada/engine/unsequa/unc_output.py
+++ b/climada/engine/unsequa/unc_output.py
@@ -962,7 +962,7 @@ class UncOutput():
         eai_max_si_df = self.get_largest_si(salib_si, metric_list=['eai_exp'])
 
         plot_val = eai_max_si_df['param']
-        coord = np.array([self.coord_df.latitude, self.coord_df.longitude]).transpose()
+        coord = np.array([self.coord_df.latitude, self.coord_df.longitude]).transpose()  # pylint: disable=no-member
         if 'var_name' not in kwargs:
             kwargs['var_name'] = 'Input parameter with largest ' + salib_si
         if 'title' not in kwargs:

--- a/climada/entity/exposures/base.py
+++ b/climada/entity/exposures/base.py
@@ -417,7 +417,7 @@ class Exposures():
             if overwrite:
                 LOGGER.info('Existing centroids will be overwritten for %s', haz_type)
             else:
-                return None
+                return
 
         LOGGER.info('Matching %s exposures with %s centroids.',
                     str(self.gdf.shape[0]), str(hazard.centroids.size))

--- a/climada/entity/measures/base.py
+++ b/climada/entity/measures/base.py
@@ -121,7 +121,7 @@ class Measure():
         u_check.size(2, self.mdd_impact, 'Measure.mdd_impact')
         u_check.size(2, self.paa_impact, 'Measure.paa_impact')
 
-    def calc_impact(self, exposures, imp_fun_set, hazard):
+    def calc_impact(self, exposures, imp_fun_set, hazard, assign_centroids=True):
         """
         Apply measure and compute impact and risk transfer of measure
         implemented over inputs.
@@ -137,12 +137,12 @@ class Measure():
 
         Returns
         -------
-            : climada.engine.Impact
+        climada.engine.Impact
             resulting impact and risk transfer of measure
         """
 
         new_exp, new_impfs, new_haz = self.apply(exposures, imp_fun_set, hazard)
-        return self._calc_impact(new_exp, new_impfs, new_haz)
+        return self._calc_impact(new_exp, new_impfs, new_haz, assign_centroids)
 
     def apply(self, exposures, imp_fun_set, hazard):
         """
@@ -180,7 +180,7 @@ class Measure():
 
         return new_exp, new_impfs, new_haz
 
-    def _calc_impact(self, new_exp, new_impfs, new_haz):
+    def _calc_impact(self, new_exp, new_impfs, new_haz, assign_centroids):
         """Compute impact and risk transfer of measure implemented over inputs.
 
         Parameters
@@ -194,11 +194,11 @@ class Measure():
 
         Returns
         -------
-            : climada.engine.Impact
+        climada.engine.Impact
         """
         from climada.engine.impact import Impact
         imp = Impact()
-        imp.calc(new_exp, new_impfs, new_haz)
+        imp.calc(new_exp, new_impfs, new_haz, assign_centroids=assign_centroids)
         return imp.calc_risk_transfer(self.risk_transf_attach, self.risk_transf_cover)
 
     def _change_all_hazard(self, hazard):
@@ -360,7 +360,7 @@ class Measure():
 
         from climada.engine.impact import Impact
         imp = Impact()
-        imp.calc(exp_imp, impf_set, hazard)
+        imp.calc(exp_imp, impf_set, hazard, assign_centroids=False)
 
         LOGGER.debug('Cutting events whose damage have a frequency > %s.',
                      self.hazard_freq_cutoff)

--- a/climada/entity/measures/base.py
+++ b/climada/entity/measures/base.py
@@ -134,6 +134,12 @@ class Measure():
             impact function set instance
         hazard : climada.hazard.Hazard
             hazard instance
+        assign_centroids : bool, optional
+            indicates whether centroids are assigned to the self.exposures object.
+            Centroids assignment is an expensive operation; set this to ``False`` to save
+            computation time if the hazards' centroids are already assigned to the exposures
+            object.
+            Default: True
 
         Returns
         -------

--- a/climada/entity/measures/base.py
+++ b/climada/entity/measures/base.py
@@ -282,12 +282,14 @@ class Measure():
         from_id = int(self.imp_fun_map[0:self.imp_fun_map.find('to')])
         to_id = int(self.imp_fun_map[self.imp_fun_map.find('to') + 2:])
         try:
-            exp_change = np.argwhere(new_exp.gdf[INDICATOR_IMPF + self.haz_type].values == from_id).\
-                reshape(-1)
+            exp_change = np.argwhere(
+                new_exp.gdf[INDICATOR_IMPF + self.haz_type].values == from_id
+            ).reshape(-1)
             new_exp.gdf[INDICATOR_IMPF + self.haz_type].values[exp_change] = to_id
         except KeyError:
-            exp_change = np.argwhere(new_exp.gdf[INDICATOR_IMPF].values == from_id).\
-                reshape(-1)
+            exp_change = np.argwhere(
+                new_exp.gdf[INDICATOR_IMPF].values == from_id
+            ).reshape(-1)
             new_exp.gdf[INDICATOR_IMPF].values[exp_change] = to_id
         return new_exp
 

--- a/climada/entity/measures/test/test_base.py
+++ b/climada/entity/measures/test/test_base.py
@@ -83,6 +83,7 @@ class TestApply(unittest.TestCase):
         exp = Exposures.from_mat(ENT_TEST_MAT)
         exp.gdf.rename(columns={'impf': 'impf_TC'}, inplace=True)
         exp.check()
+        exp.assign_centroids(haz)
 
         imp_set = ImpactFuncSet.from_mat(ENT_TEST_MAT)
 
@@ -117,6 +118,7 @@ class TestApply(unittest.TestCase):
         exp.gdf['region_id'] = np.zeros(exp.gdf.shape[0])
         exp.gdf.region_id.values[10:] = 1
         exp.check()
+        exp.assign_centroids(haz)
 
         imp_set = ImpactFuncSet.from_mat(ENT_TEST_MAT)
 

--- a/climada/hazard/trop_cyclone.py
+++ b/climada/hazard/trop_cyclone.py
@@ -388,7 +388,7 @@ class TropCyclone(Hazard):
 
         if file_name:
             LOGGER.info('Generating video %s', file_name)
-            fig, axis, fontsize = u_plot.make_map(figsize=figsize, adapt_fontsize=adapt_fontsize)
+            fig, axis, _fontsize = u_plot.make_map(figsize=figsize, adapt_fontsize=adapt_fontsize)
             pbar = tqdm(total=idx_plt.size - 2)
             ani = animation.FuncAnimation(fig, run, frames=idx_plt.size - 2,
                                           interval=500, blit=False)
@@ -873,7 +873,7 @@ def _v_max_s_holland_2008(penv, pcen, b_s):
     v_squared = b_s / (RHO_AIR * np.exp(1)) * 100 * (penv - pcen)
     return np.sqrt(v_squared)
 
-def _B_holland_1980(gradient_winds, penv, pcen):
+def _B_holland_1980(gradient_winds, penv, pcen):  # pylint: disable=invalid-name
     """Holland's 1980 B-value computation for gradient-level winds.
 
     The parameter applies to gradient-level winds (about 1000 metres above the earth's surface).

--- a/climada/test/test_calibration.py
+++ b/climada/test/test_calibration.py
@@ -18,7 +18,6 @@ with CLIMADA. If not, see <https://www.gnu.org/licenses/>.
 
 Test Calibration class.
 """
-import re
 import unittest
 from pathlib import Path
 import pandas as pd

--- a/climada/test/test_calibration.py
+++ b/climada/test/test_calibration.py
@@ -69,7 +69,7 @@ class TestCalib(unittest.TestCase):
                                        yearly_impact=True)
         # calc Impact as comparison
         impact = Impact()
-        impact.calc(ent.exposures, ent.impact_funcs, hazard, reassign_centroids=False)
+        impact.calc(ent.exposures, ent.impact_funcs, hazard, assign_centroids=False)
         IYS = impact.calc_impact_year_set(all_years=True)
 
         # do the tests

--- a/climada/test/test_calibration.py
+++ b/climada/test/test_calibration.py
@@ -18,6 +18,7 @@ with CLIMADA. If not, see <https://www.gnu.org/licenses/>.
 
 Test Calibration class.
 """
+import re
 import unittest
 from pathlib import Path
 import pandas as pd
@@ -69,7 +70,7 @@ class TestCalib(unittest.TestCase):
                                        yearly_impact=True)
         # calc Impact as comparison
         impact = Impact()
-        impact.calc(ent.exposures, ent.impact_funcs, hazard)
+        impact.calc(ent.exposures, ent.impact_funcs, hazard, reassign_centroids=False)
         IYS = impact.calc_impact_year_set(all_years=True)
 
         # do the tests

--- a/climada/util/lines_polys_handler.py
+++ b/climada/util/lines_polys_handler.py
@@ -124,7 +124,7 @@ def calc_geom_impact(
 
     # compute point impact
     impact_pnt = Impact()
-    impact_pnt.calc(exp_pnt, impf_set, haz, save_mat=True, reassign_centroids=False)
+    impact_pnt.calc(exp_pnt, impf_set, haz, save_mat=True, assign_centroids=False)
 
     # re-aggregate impact to original exposure geometry
     impact_agg = impact_pnt_agg(impact_pnt, exp_pnt.gdf, agg_met)
@@ -295,7 +295,7 @@ def calc_grid_impact(
 
     # compute point impact
     impact_pnt = Impact()
-    impact_pnt.calc(exp_pnt, impf_set, haz, save_mat=True, reassign_centroids=False)
+    impact_pnt.calc(exp_pnt, impf_set, haz, save_mat=True, assign_centroids=False)
 
     # re-aggregate impact to original exposure geometry
     impact_agg = impact_pnt_agg(impact_pnt, exp_pnt.gdf, agg_met)

--- a/climada/util/lines_polys_handler.py
+++ b/climada/util/lines_polys_handler.py
@@ -124,7 +124,7 @@ def calc_geom_impact(
 
     # compute point impact
     impact_pnt = Impact()
-    impact_pnt.calc(exp_pnt, impf_set, haz, save_mat=True)
+    impact_pnt.calc(exp_pnt, impf_set, haz, save_mat=True, reassign_centroids=False)
 
     # re-aggregate impact to original exposure geometry
     impact_agg = impact_pnt_agg(impact_pnt, exp_pnt.gdf, agg_met)
@@ -295,7 +295,7 @@ def calc_grid_impact(
 
     # compute point impact
     impact_pnt = Impact()
-    impact_pnt.calc(exp_pnt, impf_set, haz, save_mat=True)
+    impact_pnt.calc(exp_pnt, impf_set, haz, save_mat=True, reassign_centroids=False)
 
     # re-aggregate impact to original exposure geometry
     impact_agg = impact_pnt_agg(impact_pnt, exp_pnt.gdf, agg_met)


### PR DESCRIPTION
Changes proposed in this PR:
- As discussed in PR #436, not reassigning centroids may lead to faulty results through side effects
- As decided on the CLIMADA developer day, the easiest solution is to introduce an `ImpactCalc.impact` parameter that may be used to suppress re-assignment of centroids
- This PR proposes the parameter(s) `reassign_centroids` in both methods `impact` and `insured_impact`.
- The parameter were set to `True` wherever it seemed suitable throughout the code base

This PR fixes issue #515

### Pull Request Checklist

- [x] Correct target branch selected (if unsure, select `develop`)
- [x] Source branch up-to-date with target branch
- [x] Docs updated
- [x] Tests updated
- [x] Tests passing
- [x] No new linter issues
