### PR TITLE
Update tc_tracks.py

### DIFF
--- a/climada/hazard/tc_tracks.py
+++ b/climada/hazard/tc_tracks.py
@@ -953,6 +953,20 @@ class TCTracks():
         -------
         tracks : TCTracks
             TCTracks with data from the STORM simulations.
+
+        Notes
+        -----
+        All tracks are set in the year 1980. The id of the year (starting from 0) is saved in the
+        attribute 'id_no'. To obtain the year of each track use e.g.
+        `years = [int(tr.attrs['id_no'] / 1000) for tr in tc_tracks.data]`
+
+        If a windfield is generated from these tracks using the method `TropCylcone.from_tracks()`,
+        the following should be considered:
+        1- the frequencies will be set to "1" for each storm. Thus, in order to compute annual values,
+           the frequencies of the TropCylone should be changed to "1/number of years".
+        2- the storm year and the storm id are stored in the 'TropCyclone.event_name' attribute
+
+
         """
         basins = ["EP", "NA", "NI", "SI", "SP", "WP"]
         tracks_df = pd.read_csv(path, names=['year', 'time_start', 'tc_num', 'time_delta',

--- a/climada/hazard/tc_tracks.py
+++ b/climada/hazard/tc_tracks.py
@@ -963,13 +963,12 @@ class TCTracks():
         >>> # or, alternatively, 
         >>> years = [int(tr.attrs['sid'].split("-")[-2]) for tr in tc_tracks.data]
 
-        If a windfield is generated from these tracks using the method `TropCylcone.from_tracks()`,
+        If a windfield is generated from these tracks using the method ``TropCylcone.from_tracks()``,
         the following should be considered:
+
         1. The frequencies will be set to ``1`` for each storm. Thus, in order to compute annual
-        values, the frequencies of the TropCylone should be changed to ``1/number of years``.
+           values, the frequencies of the TropCylone should be changed to ``1/number of years``.
         2. The storm year and the storm id are stored in the ``TropCyclone.event_name`` attribute.
-
-
         """
         basins = ["EP", "NA", "NI", "SI", "SP", "WP"]
         tracks_df = pd.read_csv(path, names=['year', 'time_start', 'tc_num', 'time_delta',

--- a/climada/hazard/tc_tracks.py
+++ b/climada/hazard/tc_tracks.py
@@ -962,9 +962,9 @@ class TCTracks():
 
         If a windfield is generated from these tracks using the method `TropCylcone.from_tracks()`,
         the following should be considered:
-        1- the frequencies will be set to "1" for each storm. Thus, in order to compute annual values,
-           the frequencies of the TropCylone should be changed to "1/number of years".
-        2- the storm year and the storm id are stored in the 'TropCyclone.event_name' attribute
+        1. The frequencies will be set to ``1`` for each storm. Thus, in order to compute annual
+        values, the frequencies of the TropCylone should be changed to ``1/number of years``.
+        2. The storm year and the storm id are stored in the ``TropCyclone.event_name`` attribute.
 
 
         """

--- a/climada/hazard/tc_tracks.py
+++ b/climada/hazard/tc_tracks.py
@@ -957,8 +957,11 @@ class TCTracks():
         Notes
         -----
         All tracks are set in the year 1980. The id of the year (starting from 0) is saved in the
-        attribute 'id_no'. To obtain the year of each track use e.g.
-        `years = [int(tr.attrs['id_no'] / 1000) for tr in tc_tracks.data]`
+        attribute 'id_no'. To obtain the year of each track use
+        
+        >>> years = [int(tr.attrs['id_no'] / 1000) for tr in tc_tracks.data]
+        >>> # or, alternatively, 
+        >>> years = [int(tr.attrs['sid'].split("-")[-2]) for tr in tc_tracks.data]
 
         If a windfield is generated from these tracks using the method `TropCylcone.from_tracks()`,
         the following should be considered:

--- a/climada/hazard/tc_tracks.py
+++ b/climada/hazard/tc_tracks.py
@@ -973,13 +973,6 @@ class TCTracks():
         if years is not None:
             tracks_df = tracks_df[np.isin(tracks_df['year'], years)]
 
-        # set years as labelled in files
-        tracks_df['time_start'] = tracks_df.apply(
-            lambda row: dt.datetime(
-                row['year'], row['time_start'].month, row['time_start'].day
-            ), axis=1
-        )
-        
         # a bug in the data causes some storm tracks to be double-listed:
         tracks_df = tracks_df.drop_duplicates(subset=["year", "tc_num", "time_delta"])
 

--- a/climada/hazard/tc_tracks.py
+++ b/climada/hazard/tc_tracks.py
@@ -973,6 +973,13 @@ class TCTracks():
         if years is not None:
             tracks_df = tracks_df[np.isin(tracks_df['year'], years)]
 
+        # set years as labelled in files
+        tracks_df['time_start'] = tracks_df.apply(
+            lambda row: dt.datetime(
+                row['year'], row['time_start'].month, row['time_start'].day
+            ), axis=1
+        )
+        
         # a bug in the data causes some storm tracks to be double-listed:
         tracks_df = tracks_df.drop_duplicates(subset=["year", "tc_num", "time_delta"])
 


### PR DESCRIPTION
Proposal: start numbering the year as in the data file. This way, the years can be reconstructed, a process needed to for instance study the time-correlations of storms or study changing vulnerabilities.

This PR fixes issue with STORM datasets having all years set to 1980.

### Pull Request Checklist

- [ ] Correct target branch selected (if unsure, select `develop`)
- [ ] Source branch up-to-date with target branch
- [ ] Docs updated
- [ ] Tests updated
- [ ] Tests passing
- [ ] No new linter issues
