### PR TITLE
coord_on_land: fix buffer for global grids

### DIFF
--- a/climada/util/coordinates.py
+++ b/climada/util/coordinates.py
@@ -684,12 +684,10 @@ def coord_on_land(lat, lon, land_geom=None):
         lon_mid = 0.5 * (bounds[0] + bounds[1])
         # normalize lon
         lon_normalize(lons, center=lon_mid)
+        bounds = latlon_bounds(lat, lons, buffer=delta_deg)
         # load land geometry with appropriate same extent
         land_geom = get_land_geometry(
-            extent=(bounds[0] - delta_deg,
-                    bounds[1] + delta_deg,
-                    np.min(lat) - delta_deg,
-                    np.max(lat) + delta_deg),
+            extent=(bounds[0], bounds[2], bounds[1], bounds[3]),
             resolution=10)
     elif not land_geom.is_empty:
         # ensure lon values are within extent of provided land_geom

--- a/climada/util/test/test_coordinates.py
+++ b/climada/util/test/test_coordinates.py
@@ -899,13 +899,13 @@ class TestGetGeodata(unittest.TestCase):
 
     def test_on_land_pass(self):
         """check point on land with 1:50.000.000 resolution."""
-        lat = np.array([28.203216, 28.555994, 28.860875])
-        lon = np.array([-16.567489, -18.554130, -9.532476])
+        rows, cols, trans = u_coord.pts_to_raster_meta((-179.5, -60, 179.5, 60), (1, -1))
+        xgrid, ygrid = u_coord.raster_to_meshgrid(trans, cols, rows)
+        lat = np.concatenate([[28.203216, 28.555994, 28.860875], ygrid.ravel()])
+        lon = np.concatenate([[-16.567489, -18.554130, -9.532476], xgrid.ravel()])
         res = u_coord.coord_on_land(lat, lon)
-        self.assertEqual(res.size, 3)
-        self.assertTrue(res[0])
-        self.assertFalse(res[1])
-        self.assertTrue(res[2])
+        self.assertEqual(res.size, lat.size)
+        np.testing.assert_array_equal(res[:3], [True, False, True])
 
     def test_dist_to_coast(self):
         """Test point in coast and point not in coast"""


### PR DESCRIPTION
Changes proposed in this PR:
- In `u_coord.coord_on_land`, use the more stable `latlon_bounds` function to add a buffer around the specified coordinates to avoid problems with global grids where the buffer would increase the bounds beyond 360 degrees in width.

This PR fixes issue #539

### PR Author Checklist

- [x] Read the [Contribution Guide][contrib]
- [x] Correct target branch selected (if unsure, select `develop`)
- [x] Source branch up-to-date with target branch
- [x] [Documentation](https://climada-python.readthedocs.io/en/latest/guide/Guide_PythonDos-n-Donts.html#2.--Commenting-&-Documenting) updated
- [x] [Tests][testing] updated
- [x] [Tests][testing] passing
- [x] No new [linter issues][linter]

### PR Reviewer Checklist

- [x] Read the [Contribution Guide][contrib]
- [x] [CLIMADA Reviewer Checklist](https://climada-python.readthedocs.io/en/latest/guide/Guide_Reviewer_Checklist.html) passed
- [x] [Tests][testing] passing
- [x] No new [linter issues][linter]

[contrib]: /CONTRIBUTING.md
[testing]: https://climada-python.readthedocs.io/en/latest/guide/Guide_Continuous_Integration_and_Testing.html
[linter]: https://climada-python.readthedocs.io/en/stable/guide/Guide_Continuous_Integration_and_Testing.html#3.C.--Static-Code-Analysis
