### PR TITLE
Helper function: toggle_extent_bounds

### DIFF
--- a/climada/hazard/base.py
+++ b/climada/hazard/base.py
@@ -848,8 +848,9 @@ class Hazard():
             cent_nz = (self.fraction != 0).sum(axis=0).nonzero()[1]
         lon_nz = self.centroids.lon[cent_nz]
         lat_nz = self.centroids.lat[cent_nz]
-        ext = u_coord.latlon_bounds(lat=lat_nz, lon=lon_nz, buffer=buffer)
-        return self.select(extent=(ext[0], ext[2], ext[1], ext[3]))
+        return self.select(extent=u_coord.toggle_extent_bounds(
+            u_coord.latlon_bounds(lat=lat_nz, lon=lon_nz, buffer=buffer)
+        ))
 
     def local_exceedance_inten(self, return_periods=(25, 50, 100, 250)):
         """Compute exceedance intensity map for given return periods.

--- a/climada/hazard/tc_tracks.py
+++ b/climada/hazard/tc_tracks.py
@@ -1142,8 +1142,7 @@ class TCTracks():
         -------
         extent : tuple (lon_min, lon_max, lat_min, lat_max)
         """
-        bounds = self.get_bounds(deg_buffer=deg_buffer)
-        return (bounds[0], bounds[2], bounds[1], bounds[3])
+        return u_coord.toggle_extent_bounds(self.get_bounds(deg_buffer=deg_buffer))
 
     @property
     def extent(self):

--- a/climada/hazard/test/test_tc_tracks.py
+++ b/climada/hazard/test/test_tc_tracks.py
@@ -551,11 +551,10 @@ class TestFuncs(unittest.TestCase):
         storms = ['1988169N14259', '2002073S16161', '2002143S07157']
         tc_track = tc.TCTracks.from_ibtracs_netcdf(storm_id=storms, provider=["usa", "bom"])
         bounds = (153.585022, -23.200001, 258.714996, 17.514986)
-        extent = (bounds[0], bounds[2], bounds[1], bounds[3])
         bounds_buf = (153.485022, -23.300001, 258.814996, 17.614986)
         np.testing.assert_array_almost_equal(tc_track.bounds, bounds)
         np.testing.assert_array_almost_equal(tc_track.get_bounds(deg_buffer=0.1), bounds_buf)
-        np.testing.assert_array_almost_equal(tc_track.extent, extent)
+        np.testing.assert_array_almost_equal(tc_track.extent, u_coord.toggle_extent_bounds(bounds))
 
     def test_generate_centroids(self):
         """Test centroids generation feature."""

--- a/climada/util/coordinates.py
+++ b/climada/util/coordinates.py
@@ -684,12 +684,10 @@ def coord_on_land(lat, lon, land_geom=None):
         lon_mid = 0.5 * (bounds[0] + bounds[1])
         # normalize lon
         lon_normalize(lons, center=lon_mid)
+        bounds = latlon_bounds(lat, lons, buffer=delta_deg)
         # load land geometry with appropriate same extent
         land_geom = get_land_geometry(
-            extent=(bounds[0] - delta_deg,
-                    bounds[1] + delta_deg,
-                    np.min(lat) - delta_deg,
-                    np.max(lat) + delta_deg),
+            extent=(bounds[0], bounds[2], bounds[1], bounds[3]),
             resolution=10)
     elif not land_geom.is_empty:
         # ensure lon values are within extent of provided land_geom

--- a/climada/util/coordinates.py
+++ b/climada/util/coordinates.py
@@ -243,6 +243,27 @@ def latlon_bounds(lat, lon, buffer=0.0):
     lon_min, lon_max = lon_bounds(lon, buffer=buffer)
     return (lon_min, max(lat.min() - buffer, -90), lon_max, min(lat.max() + buffer, 90))
 
+
+def toggle_extent_bounds(bounds_or_extent):
+    """Convert between the "bounds" and the "extent" description of a bounding box
+
+    The difference between the two conventions is in the order in which the bounds for each
+    coordinate direction are given. To convert from one description to the other, the two central
+    entries of the 4-tuple are swapped. Hence, the conversion is symmetric.
+
+    Parameters
+    ----------
+    bounds_or_extent : tuple (a, b, c, d)
+        Bounding box of the given points in "bounds" (or "extent") convention.
+
+    Returns
+    -------
+    extent_or_bounds : tuple (a, c, b, d)
+        Bounding box of the given points in "extent" (or "bounds") convention.
+    """
+    return (bounds_or_extent[0], bounds_or_extent[2], bounds_or_extent[1], bounds_or_extent[3])
+
+
 def dist_approx(lat1, lon1, lat2, lon2, log=False, normalize=True,
                 method="equirect", units='km'):
     """Compute approximation of geodistance in specified units
@@ -687,7 +708,7 @@ def coord_on_land(lat, lon, land_geom=None):
         bounds = latlon_bounds(lat, lons, buffer=delta_deg)
         # load land geometry with appropriate same extent
         land_geom = get_land_geometry(
-            extent=(bounds[0], bounds[2], bounds[1], bounds[3]),
+            extent=u_coord.toggle_extent_bounds(bounds),
             resolution=10)
     elif not land_geom.is_empty:
         # ensure lon values are within extent of provided land_geom
@@ -792,14 +813,14 @@ def get_country_geometries(country_names=None, extent=None, resolution=10):
         # rewrap longitudes unless longitude extent is already normalized (within [-180, +180])
         lon_normalized = extent[0] >= -180 and extent[1] <= 180
         if lon_normalized:
-            bbox = box(extent[0], extent[2], extent[1], extent[3])
+            bbox = box(*u_coord.toggle_extent_bounds(extent))
         else:
             # split the extent box into two boxes both within [-180, +180] in longitude
             lon_left, lon_right = lon_normalize(np.array(extent[:2]))
             extent_left = (lon_left, 180, extent[2], extent[3])
             extent_right = (-180, lon_right, extent[2], extent[3])
             bbox = shapely.ops.unary_union(
-                [box(e[0], e[2], e[1], e[3]) for e in [extent_left, extent_right]]
+                [box(*u_coord.toggle_extent_bounds(e)) for e in [extent_left, extent_right]]
             )
         bbox = gpd.GeoSeries(bbox, crs=DEF_CRS)
         bbox = gpd.GeoDataFrame({'geometry': bbox}, crs=DEF_CRS)

--- a/climada/util/coordinates.py
+++ b/climada/util/coordinates.py
@@ -708,7 +708,7 @@ def coord_on_land(lat, lon, land_geom=None):
         bounds = latlon_bounds(lat, lons, buffer=delta_deg)
         # load land geometry with appropriate same extent
         land_geom = get_land_geometry(
-            extent=u_coord.toggle_extent_bounds(bounds),
+            extent=toggle_extent_bounds(bounds),
             resolution=10)
     elif not land_geom.is_empty:
         # ensure lon values are within extent of provided land_geom
@@ -813,14 +813,14 @@ def get_country_geometries(country_names=None, extent=None, resolution=10):
         # rewrap longitudes unless longitude extent is already normalized (within [-180, +180])
         lon_normalized = extent[0] >= -180 and extent[1] <= 180
         if lon_normalized:
-            bbox = box(*u_coord.toggle_extent_bounds(extent))
+            bbox = box(*toggle_extent_bounds(extent))
         else:
             # split the extent box into two boxes both within [-180, +180] in longitude
             lon_left, lon_right = lon_normalize(np.array(extent[:2]))
             extent_left = (lon_left, 180, extent[2], extent[3])
             extent_right = (-180, lon_right, extent[2], extent[3])
             bbox = shapely.ops.unary_union(
-                [box(*u_coord.toggle_extent_bounds(e)) for e in [extent_left, extent_right]]
+                [box(*toggle_extent_bounds(e)) for e in [extent_left, extent_right]]
             )
         bbox = gpd.GeoSeries(bbox, crs=DEF_CRS)
         bbox = gpd.GeoDataFrame({'geometry': bbox}, crs=DEF_CRS)

--- a/climada/util/plot.py
+++ b/climada/util/plot.py
@@ -599,7 +599,7 @@ def add_populated_places(axis, extent, proj=ccrs.PlateCarree(), fontsize=None):
                                          name='populated_places_simple')
 
     shp = shapereader.Reader(shp_file)
-    ext_pts = list(box(extent[0], extent[2], extent[1], extent[3]).exterior.coords)
+    ext_pts = list(box(*u_coord.toggle_extent_bounds(extent)).exterior.coords)
     ext_trans = [ccrs.PlateCarree().transform_point(pts[0], pts[1], proj)
                  for pts in ext_pts]
     for rec, point in zip(shp.records(), shp.geometries()):
@@ -632,7 +632,7 @@ def add_cntry_names(axis, extent, proj=ccrs.PlateCarree(), fontsize=None):
                                          name='admin_0_countries')
 
     shp = shapereader.Reader(shp_file)
-    ext_pts = list(box(extent[0], extent[2], extent[1], extent[3]).exterior.coords)
+    ext_pts = list(box(*u_coord.toggle_extent_bounds(extent)).exterior.coords)
     ext_trans = [ccrs.PlateCarree().transform_point(pts[0], pts[1], proj)
                  for pts in ext_pts]
     for rec, point in zip(shp.records(), shp.geometries()):

--- a/climada/util/test/test_coordinates.py
+++ b/climada/util/test/test_coordinates.py
@@ -258,6 +258,10 @@ class TestFunc(unittest.TestCase):
         bounds = u_coord.latlon_bounds(lat, lon, buffer=1)
         self.assertEqual(bounds, (-180, -90, 180, 90))
 
+    def test_toggle_extent_bounds(self):
+        """Test the conversion between 'extent' and 'bounds'"""
+        self.assertEqual(u_coord.toggle_extent_bounds((0, -1, 1, 3)), (0, 1, -1, 3))
+
     def test_geosph_vector(self):
         """Test conversion from lat/lon to unit vector on geosphere"""
         data = np.array([[0, 0], [-13, 179]], dtype=np.float64)

--- a/climada/util/test/test_coordinates.py
+++ b/climada/util/test/test_coordinates.py
@@ -899,13 +899,13 @@ class TestGetGeodata(unittest.TestCase):
 
     def test_on_land_pass(self):
         """check point on land with 1:50.000.000 resolution."""
-        lat = np.array([28.203216, 28.555994, 28.860875])
-        lon = np.array([-16.567489, -18.554130, -9.532476])
+        rows, cols, trans = u_coord.pts_to_raster_meta((-179.5, -60, 179.5, 60), (1, -1))
+        xgrid, ygrid = u_coord.raster_to_meshgrid(trans, cols, rows)
+        lat = np.concatenate([[28.203216, 28.555994, 28.860875], ygrid.ravel()])
+        lon = np.concatenate([[-16.567489, -18.554130, -9.532476], xgrid.ravel()])
         res = u_coord.coord_on_land(lat, lon)
-        self.assertEqual(res.size, 3)
-        self.assertTrue(res[0])
-        self.assertFalse(res[1])
-        self.assertTrue(res[2])
+        self.assertEqual(res.size, lat.size)
+        np.testing.assert_array_equal(res[:3], [True, False, True])
 
     def test_dist_to_coast(self):
         """Test point in coast and point not in coast"""


### PR DESCRIPTION
Changes proposed in this PR:
- Building on #542, introduce a helper function that converts between "extent" and "bounds" convention for the description of a two-dimensional bounding box.

### PR Author Checklist

- [x] Read the [Contribution Guide][contrib]
- [x] Correct target branch selected (if unsure, select `develop`)
- [x] Source branch up-to-date with target branch
- [x] [Documentation](https://climada-python.readthedocs.io/en/latest/guide/Guide_PythonDos-n-Donts.html#2.--Commenting-&-Documenting) updated
- [x] [Tests][testing] updated
- [x] [Tests][testing] passing
- [ ] No new [linter issues][linter]

### PR Reviewer Checklist

- [ ] Read the [Contribution Guide][contrib]
- [ ] [CLIMADA Reviewer Checklist](https://climada-python.readthedocs.io/en/latest/guide/Guide_Reviewer_Checklist.html) passed
- [ ] [Tests][testing] passing
- [ ] No new [linter issues][linter]

[contrib]: /CONTRIBUTING.md
[testing]: https://climada-python.readthedocs.io/en/latest/guide/Guide_Continuous_Integration_and_Testing.html
[linter]: https://climada-python.readthedocs.io/en/stable/guide/Guide_Continuous_Integration_and_Testing.html#3.C.--Static-Code-Analysis
