### PR TITLE
Draft: Set all Hazard attributes in __init__

### DIFF
--- a/climada/hazard/base.py
+++ b/climada/hazard/base.py
@@ -159,10 +159,10 @@ class Hazard():
     scalar, string, list, 1dim np.array of size num_events."""
 
     def __init__(self,
-                 haz_type: str,
                  intensity: sparse.csr_matrix,
                  centroids: Centroids,
                  date: np.ndarray,
+                 haz_type: str = "",
                  units: str = "",
                  frequency: Optional[np.ndarray] = None,
                  frequency_unit: str = DEF_FREQ_UNIT,
@@ -182,14 +182,15 @@ class Hazard():
 
         Parameters
         ----------
-        haz_type : str
-            String indicating the hazard type (e.g., ``TC`` for tropical cyclone)
         intensity : sparse.csr_matrix
             The intensity of the hazard for each event. Shape ``(n_event, n_centroids)``
         centroids : Centroids
             The centroids on which this hazard is defined.
         date : np.array of int
             The ordinal representation of the date of each event.
+        haz_type : str (optional)
+            String indicating the hazard type (e.g., ``TC`` for tropical cyclone). This
+            parameter is passed to the hazard ``Tag``.
         units : str (optional)
             The physical units of the intensity (used for plotting)
         frequency : np.array of float (optional)

--- a/climada/hazard/base.py
+++ b/climada/hazard/base.py
@@ -1504,6 +1504,8 @@ class Hazard():
         num_cen = self.centroids.size
         if np.unique(self.event_id).size != num_ev:
             raise ValueError("There are events with the same identifier.")
+        if np.any(self.event_id < 1):
+            raise ValueError("Event IDs must be larger than zero")
 
         u_check.check_oligatories(self.__dict__, self.vars_oblig, 'Hazard.',
                                   num_ev, num_ev, num_cen)

--- a/climada/hazard/test/test_base.py
+++ b/climada/hazard/test/test_base.py
@@ -55,10 +55,10 @@ def dummy_hazard():
                                    [4.3, 2.1, 1.0], [5.3, 0.2, 0.0]])
     units = 'm/s'
 
-    return Hazard(haz_type,
-                  intensity,
+    return Hazard(intensity,
                   centroids,
                   date,
+                  haz_type,
                   units,
                   frequency,
                   frequency_unit,
@@ -86,10 +86,10 @@ class TestLoader(unittest.TestCase):
         self.intensity = sparse.csr_matrix([[1, 2], [1, 2], [1, 2]])
         self.fraction = sparse.csr_matrix([[1, 2], [1, 2], [1, 2]])
 
-        self.hazard = Hazard(self.haz_type,
-                             self.intensity,
+        self.hazard = Hazard(self.intensity,
                              self.centroids,
                              self.date,
+                             self.haz_type,
                              event_id=self.event_id,
                              event_name=self.event_name,
                              frequency=self.frequency,
@@ -101,10 +101,10 @@ class TestLoader(unittest.TestCase):
 
     def test_minimal_hazard(self):
         """Check if stating only the required parameters works"""
-        Hazard(self.haz_type,
-               self.intensity,
+        Hazard(self.intensity,
                self.centroids,
                self.date,
+               self.haz_type,
                fast=False)
 
     def test_fast_init_fail(self):
@@ -112,21 +112,21 @@ class TestLoader(unittest.TestCase):
         frequency = np.array([1, 2])
         # Not fast: Should raise exception
         with self.assertRaises(ValueError) as cm:
-            Hazard(self.haz_type,
-                            self.intensity,
-                            self.centroids,
-                            self.date,
-                            event_id=self.event_id,
-                            event_name=self.event_name,
-                            frequency=frequency,
-                            fraction=self.fraction)
+            Hazard(self.intensity,
+                   self.centroids,
+                   self.date,
+                   self.haz_type,
+                   event_id=self.event_id,
+                   event_name=self.event_name,
+                   frequency=frequency,
+                   fraction=self.fraction)
         self.assertIn("Invalid Hazard.frequency", str(cm.exception))
 
         # Fast: Skip check
-        Hazard(self.haz_type,
-               self.intensity,
+        Hazard(self.intensity,
                self.centroids,
                self.date,
+               self.haz_type,
                event_id=self.event_id,
                event_name=self.event_name,
                frequency=frequency,

--- a/climada/hazard/test/test_base.py
+++ b/climada/hazard/test/test_base.py
@@ -99,6 +99,14 @@ class TestLoader(unittest.TestCase):
         """Return a well-defined hazard"""
         return self.hazard
 
+    def test_minimal_hazard(self):
+        """Check if stating only the required parameters works"""
+        Hazard(self.haz_type,
+               self.intensity,
+               self.centroids,
+               self.date,
+               fast=False)
+
     def test_fast_init_fail(self):
         """Check if fast init correctly disables internal check"""
         frequency = np.array([1, 2])

--- a/climada/hazard/test/test_base.py
+++ b/climada/hazard/test/test_base.py
@@ -178,12 +178,17 @@ class TestLoader(unittest.TestCase):
 
     def test_check_wrongId_fail(self):
         """Wrong hazard definition"""
-        haz = self.good_hazard()
-        haz.event_id = np.array([1, 2, 1])
-
+        # Assert that event IDs must be unique
+        self.hazard.event_id = np.array([1, 2, 1])
         with self.assertRaises(ValueError) as cm:
-            haz.check()
+            self.hazard.check()
         self.assertIn('There are events with the same identifier.', str(cm.exception))
+
+        # Assert that event IDs must be >0
+        self.hazard.event_id = np.array([-1, 0, 1])
+        with self.assertRaises(ValueError) as cm:
+            self.hazard.check()
+        self.assertIn("Event IDs must be larger than zero", str(cm.exception))
 
     def test_check_wrong_date_fail(self):
         """Wrong hazard definition"""

--- a/climada/hazard/test/test_base.py
+++ b/climada/hazard/test/test_base.py
@@ -101,11 +101,29 @@ class TestLoader(unittest.TestCase):
 
     def test_minimal_hazard(self):
         """Check if stating only the required parameters works"""
-        Hazard(self.intensity,
-               self.centroids,
-               self.date,
-               self.haz_type,
-               fast=False)
+        hazard = Hazard(self.intensity,
+                        self.centroids,
+                        self.date,
+                        fast=False)
+
+        # Test optional members
+        np.testing.assert_array_equal(hazard.frequency,
+                                      np.ones_like(self.frequency))
+        self.assertEqual(hazard.frequency_unit, DEF_FREQ_UNIT)
+        np.testing.assert_array_equal(hazard.orig,
+                                      np.full(len(self.event_id), True))
+        np.testing.assert_array_equal(hazard.event_id, self.event_id)
+        np.testing.assert_array_equal(hazard.event_name,
+                                      list(map(str, self.event_id.flat)))
+        self.assertEqual(hazard.fraction.nnz, 0)
+        np.testing.assert_array_equal(hazard.fraction.shape,
+                                      hazard.intensity.shape)
+        self.assertIs(hazard.pool, None)
+
+        # Test tag
+        self.assertEqual(hazard.tag.haz_type, "")
+        self.assertEqual(hazard.tag.description, "")
+        self.assertEqual(hazard.tag.file_name, "")
 
     def test_fast_init_fail(self):
         """Check if fast init correctly disables internal check"""


### PR DESCRIPTION
*WIP: This serves as an example draft*

Changes proposed in this PR:
* Update `Hazard.__init__` to take all data as arguments, skipping the null-initialization.
* Default-initialize all of the attributes that do not require user input.
* Perform a self-check after initialization by default. Users can opt to skip the check by setting `fast=True`.

### To Do
- [ ] Remove superfluous checks from `Hazard.from_raster_xarray`

### PR Author Checklist

- [x] Read the [Contribution Guide][contrib]
- [x] Correct target branch selected (if unsure, select `develop`)
- [x] Source branch up-to-date with target branch
- [ ] [Documentation](https://climada-python.readthedocs.io/en/latest/guide/Guide_PythonDos-n-Donts.html#2.--Commenting-&-Documenting) updated
- [ ] [Tests][testing] updated
- [ ] [Tests][testing] passing
- [ ] No new [linter issues][linter]

### PR Reviewer Checklist

- [ ] Read the [Contribution Guide][contrib]
- [ ] [CLIMADA Reviewer Checklist](https://climada-python.readthedocs.io/en/latest/guide/Guide_Reviewer_Checklist.html) passed
- [ ] [Tests][testing] passing
- [ ] No new [linter issues][linter]

[contrib]: /CONTRIBUTING.md
[testing]: https://climada-python.readthedocs.io/en/latest/guide/Guide_Continuous_Integration_and_Testing.html
[linter]: https://climada-python.readthedocs.io/en/stable/guide/Guide_Continuous_Integration_and_Testing.html#3.C.--Static-Code-Analysis
