### PR TITLE
Check crs attribute on GDF if no geo is present

### DIFF
--- a/climada/entity/exposures/base.py
+++ b/climada/entity/exposures/base.py
@@ -996,7 +996,9 @@ class Exposures():
         ]
         crss = [
             ex.crs for ex in exposures_list
-            if isinstance(ex, (Exposures, GeoDataFrame)) and not ex.crs is None
+            if isinstance(ex, (Exposures, GeoDataFrame))
+            and hasattr(ex, "crs")
+            and ex.crs is not None
         ]
         if crss:
             crs = crss[0]

--- a/climada/entity/exposures/test/test_base.py
+++ b/climada/entity/exposures/test/test_base.py
@@ -447,7 +447,7 @@ class TestGeoDFFuncs(unittest.TestCase):
         probe.set_gdf(empty_gdf)
         self.assertTrue(probe.gdf.equals(gpd.GeoDataFrame()))
         self.assertTrue(u_coord.equal_crs(DEF_CRS, probe.crs))
-        self.assertIsNone(probe.gdf.crs)
+        self.assertFalse(hasattr(probe.gdf, "crs"))
 
         probe.set_gdf(gdf_with_geometry)
         self.assertTrue(probe.gdf.equals(gdf_with_geometry))
@@ -457,7 +457,7 @@ class TestGeoDFFuncs(unittest.TestCase):
         probe.set_gdf(gdf_without_geometry)
         self.assertTrue(probe.gdf.equals(good_exposures().gdf))
         self.assertTrue(u_coord.equal_crs(DEF_CRS, probe.crs))
-        self.assertIsNone(probe.gdf.crs)
+        self.assertFalse(hasattr(probe.gdf, "crs"))
 
     def test_set_crs(self):
         """Test setting the CRS"""

--- a/climada/entity/measures/test/test_base.py
+++ b/climada/entity/measures/test/test_base.py
@@ -280,7 +280,8 @@ class TestApply(unittest.TestCase):
         self.assertEqual(res_exp.tag.file_name, exp.tag.file_name)
         self.assertEqual(res_exp.tag.description, exp.tag.description)
         self.assertTrue(u_coord.equal_crs(res_exp.crs, exp.crs))
-        self.assertTrue(u_coord.equal_crs(res_exp.gdf.crs, exp.gdf.crs))
+        self.assertFalse(hasattr(exp.gdf, "crs"))
+        self.assertFalse(hasattr(res_exp.gdf, "crs"))
 
         # regions (that is just input data, no need for testing, but it makes the changed and unchanged parts obious)
         self.assertTrue(np.array_equal(res_exp.gdf.region_id.values[0], 4))

--- a/climada/util/test/test_coordinates.py
+++ b/climada/util/test/test_coordinates.py
@@ -1191,7 +1191,7 @@ class TestRasterMeta(unittest.TestCase):
         df_val['value'] = np.ones(len(df_val)) * 10
         crs = 'epsg:2202'
         _raster, meta = u_coord.points_to_raster(df_val, val_names=['value'], crs=crs)
-        self.assertIsNone(df_val.crs)  # points_to_raster must not modify df_val
+        self.assertFalse(hasattr(df_val, "crs"))  # points_to_raster must not modify df_val
         self.assertTrue(u_coord.equal_crs(meta['crs'], crs))
         self.assertAlmostEqual(meta['transform'][0], 0.5)
         self.assertAlmostEqual(meta['transform'][1], 0)


### PR DESCRIPTION
Changes proposed in this PR:
- Fix the recently failing unittests related to a change in `geopandas` where an `AttributeError` would be raised if the `crs` attribute is used on `GeoDataFrame`s without a geometry column.

### PR Author Checklist

- [x] Read the [Contribution Guide][contrib]
- [x] Correct target branch selected (if unsure, select `develop`)
- [x] Source branch up-to-date with target branch
- [x] [Documentation](https://climada-python.readthedocs.io/en/latest/guide/Guide_PythonDos-n-Donts.html#2.--Commenting-&-Documenting) updated
- [x] [Tests][testing] updated
- [x] [Tests][testing] passing
- [x] No new [linter issues][linter]

### PR Reviewer Checklist

- [ ] Read the [Contribution Guide][contrib]
- [ ] [CLIMADA Reviewer Checklist](https://climada-python.readthedocs.io/en/latest/guide/Guide_Reviewer_Checklist.html) passed
- [ ] [Tests][testing] passing
- [ ] No new [linter issues][linter]

[contrib]: /CONTRIBUTING.md
[testing]: https://climada-python.readthedocs.io/en/latest/guide/Guide_Continuous_Integration_and_Testing.html
[linter]: https://climada-python.readthedocs.io/en/stable/guide/Guide_Continuous_Integration_and_Testing.html#3.C.--Static-Code-Analysis
