### PR TITLE
Allow use of non-default projection in plots

### DIFF
--- a/climada/util/plot.py
+++ b/climada/util/plot.py
@@ -195,7 +195,8 @@ def _plot_scattered_data(method, array_sub, geo_coord, var_name, title,
     if axes is None:
         proj_plot = proj
         if isinstance(proj, ccrs.PlateCarree):
-            # for PlateCarree, center plot around data's central lon without overwriting the data's original projection info
+            # for PlateCarree, center plot around data's central lon
+            # without overwriting the data's original projection info
             xmin, xmax = u_coord.lon_bounds(np.concatenate([c[:, 1] for c in list_coord]))
             proj_plot = ccrs.PlateCarree(central_longitude=0.5 * (xmin + xmax))
         _, axes, fontsize = make_map(num_im, proj=proj_plot, figsize=figsize,
@@ -310,7 +311,8 @@ def geo_im_from_array(array_sub, coord, var_name, title,
     if axes is None:
         proj_plot = proj
         if isinstance(proj, ccrs.PlateCarree):
-            # use different projections for plot and data to shift the central lon in the plot
+            # for PlateCarree, center plot around data's central lon 
+            # without overwriting the data's original projection info
             xmin, xmax = u_coord.lon_bounds(np.concatenate([c[:, 1] for c in list_coord]))
             proj_plot = ccrs.PlateCarree(central_longitude=0.5 * (xmin + xmax))
         _, axes, fontsize = make_map(num_im, proj=proj_plot, figsize=figsize,

--- a/climada/util/plot.py
+++ b/climada/util/plot.py
@@ -308,10 +308,11 @@ def geo_im_from_array(array_sub, coord, var_name, title,
     if 'vmax' not in kwargs:
         kwargs['vmax'] = np.nanmax(array_sub)
     if axes is None:
+        proj_plot = proj
         if isinstance(proj, ccrs.PlateCarree):
             # use different projections for plot and data to shift the central lon in the plot
             xmin, xmax = u_coord.lon_bounds(np.concatenate([c[:, 1] for c in list_coord]))
-            proj_plot = ccrs.PlateCarree(central_longitude=0.5 * (xmin + xmax))
+            proj_plot = ccrs.PlateCarree(central_longitude=0.5 * (xmin + xmax))            
         _, axes, fontsize = make_map(num_im, proj=proj_plot, figsize=figsize,
                                      adapt_fontsize=adapt_fontsize)
     else:

--- a/climada/util/plot.py
+++ b/climada/util/plot.py
@@ -195,7 +195,7 @@ def _plot_scattered_data(method, array_sub, geo_coord, var_name, title,
     if axes is None:
         proj_plot = proj
         if isinstance(proj, ccrs.PlateCarree):
-            # use different projections for plot and data to shift the central lon in the plot
+            # for PlateCarree, center plot around data's central lon without overwriting the data's original projection info
             xmin, xmax = u_coord.lon_bounds(np.concatenate([c[:, 1] for c in list_coord]))
             proj_plot = ccrs.PlateCarree(central_longitude=0.5 * (xmin + xmax))
         _, axes, fontsize = make_map(num_im, proj=proj_plot, figsize=figsize,

--- a/climada/util/plot.py
+++ b/climada/util/plot.py
@@ -312,7 +312,7 @@ def geo_im_from_array(array_sub, coord, var_name, title,
         if isinstance(proj, ccrs.PlateCarree):
             # use different projections for plot and data to shift the central lon in the plot
             xmin, xmax = u_coord.lon_bounds(np.concatenate([c[:, 1] for c in list_coord]))
-            proj_plot = ccrs.PlateCarree(central_longitude=0.5 * (xmin + xmax))            
+            proj_plot = ccrs.PlateCarree(central_longitude=0.5 * (xmin + xmax))
         _, axes, fontsize = make_map(num_im, proj=proj_plot, figsize=figsize,
                                      adapt_fontsize=adapt_fontsize)
     else:

--- a/climada/util/test/test_plot.py
+++ b/climada/util/test/test_plot.py
@@ -136,6 +136,15 @@ class TestPlots(unittest.TestCase):
         self.assertEqual(cmap, ax.collections[0].cmap.name)
         plt.close()
 
+        projection = ccrs.AzimuthalEquidistant()
+        ax = u_plot.geo_im_from_array(values, coord, var_name, title,
+                      proj=projection, smooth=True, axes=None, figsize=(9, 13), cmap=cmap)
+        self.assertEqual(var_name, ax.get_title())
+        self.assertAlmostEqual(np.max(values), ax.collections[0].colorbar.vmax)
+        self.assertAlmostEqual(np.min(values), ax.collections[0].colorbar.vmin)
+        self.assertEqual(cmap, ax.collections[0].cmap.name)
+        plt.close()
+
 
 # Execute Tests
 if __name__ == "__main__":


### PR DESCRIPTION
Changes proposed in this PR:
- Fix a bug in the method `util.plot.geo_im_from_array` .
- Non-default projections were not properly passed over.

This PR fixes #

### PR Author Checklist

- [x] Read the [Contribution Guide][contrib]
- [x] Correct target branch selected (if unsure, select `develop`)
- [x] Source branch up-to-date with target branch
- [ ] [Documentation](https://climada-python.readthedocs.io/en/latest/guide/Guide_PythonDos-n-Donts.html#2.--Commenting-&-Documenting) updated
- [x] [Tests][testing] updated
- [x] [Tests][testing] passing
- [ ] No new [linter issues][linter]

### PR Reviewer Checklist

- [ ] Read the [Contribution Guide][contrib]
- [ ] [CLIMADA Reviewer Checklist](https://climada-python.readthedocs.io/en/latest/guide/Guide_Reviewer_Checklist.html) passed
- [ ] [Tests][testing] passing
- [ ] No new [linter issues][linter]

[contrib]: https://github.com/CLIMADA-project/climada_python/blob/main/CONTRIBUTING.md
[testing]: https://climada-python.readthedocs.io/en/latest/guide/Guide_Continuous_Integration_and_Testing.html
[linter]: https://climada-python.readthedocs.io/en/stable/guide/Guide_Continuous_Integration_and_Testing.html#3.C.--Static-Code-Analysis
