### PR TITLE
Add new coverage tests

### DIFF
--- a/climada/entity/exposures/test/test_base.py
+++ b/climada/entity/exposures/test/test_base.py
@@ -82,6 +82,13 @@ class TestFuncs(unittest.TestCase):
             self.assertEqual(exp.gdf.shape[0], len(exp.gdf[INDICATOR_CENTR + 'FL']))
             np.testing.assert_array_equal(exp.gdf[INDICATOR_CENTR + 'FL'].values, expected_result)
 
+    def test__init__meta_type(self):
+        """ Check if meta of type list raises a ValueError in __init__"""
+        with self.assertRaises(ValueError) as cm:
+            Exposures(None, meta=[], tag=None, ref_year=DEF_REF_YEAR,
+                 value_unit=DEF_VALUE_UNIT, crs=None)
+        self.assertEqual("meta must be a dictionary",
+                      str(cm.exception))
 
     def test_read_raster_pass(self):
         """from_raster"""
@@ -477,6 +484,12 @@ class TestGeoDFFuncs(unittest.TestCase):
         self.assertRaises(ValueError, probe.set_crs, 'epsg:3395')
         self.assertTrue(u_coord.equal_crs('EPSG:4326', probe.meta.get('crs')))
 
+    def test_to_crs_epsg_crs(self):
+        """ Check that if crs and epsg are both provided a ValueError is raised"""
+        with self.assertRaises(ValueError) as cm:
+            Exposures.to_crs(self,crs='GCS', epsg=26915, inplace=False)
+        self.assertEqual("one of crs or epsg must be None",
+                      str(cm.exception))
 
 class TestImpactFunctions(unittest.TestCase):
     """Test impact function handling"""

--- a/climada/entity/exposures/test/test_base.py
+++ b/climada/entity/exposures/test/test_base.py
@@ -486,7 +486,7 @@ class TestGeoDFFuncs(unittest.TestCase):
     def test_to_crs_epsg_crs(self):
         """ Check that if crs and epsg are both provided a ValueError is raised"""
         with self.assertRaises(ValueError) as cm:
-            Exposures.to_crs(self,crs='GCS', epsg=26915, inplace=False)
+            Exposures.to_crs(self, crs='GCS', epsg=26915)
         self.assertEqual("one of crs or epsg must be None",
                       str(cm.exception))
 

--- a/climada/entity/exposures/test/test_base.py
+++ b/climada/entity/exposures/test/test_base.py
@@ -85,8 +85,7 @@ class TestFuncs(unittest.TestCase):
     def test__init__meta_type(self):
         """ Check if meta of type list raises a ValueError in __init__"""
         with self.assertRaises(ValueError) as cm:
-            Exposures(None, meta=[], tag=None, ref_year=DEF_REF_YEAR,
-                 value_unit=DEF_VALUE_UNIT, crs=None)
+            Exposures(meta=[])
         self.assertEqual("meta must be a dictionary",
                       str(cm.exception))
 

--- a/climada/entity/exposures/test/test_base.py
+++ b/climada/entity/exposures/test/test_base.py
@@ -487,8 +487,7 @@ class TestGeoDFFuncs(unittest.TestCase):
         """ Check that if crs and epsg are both provided a ValueError is raised"""
         with self.assertRaises(ValueError) as cm:
             Exposures.to_crs(self, crs='GCS', epsg=26915)
-        self.assertEqual("one of crs or epsg must be None",
-                      str(cm.exception))
+        self.assertEqual("one of crs or epsg must be None", str(cm.exception))
 
 class TestImpactFunctions(unittest.TestCase):
     """Test impact function handling"""


### PR DESCRIPTION
Changes proposed in this PR:

Add 2 new test for the file climada/entity/exposures/test/test.base.py The test check functions at line 171 and 914 of the file: climada/entity/exposures/base.py.

1) The first test (line 171): Check if a ValueError is raised when meta of type list in passed to the function __init__. It also check if the ValueError raised is the excat same as expected.

2) Second test (line 914): Check if a ValueError is raised when both crs and epsg are passed to the function to_crs. It also check if the ValueError raised is the excat same as expected


### PR Author Checklist

- [x] Read the [Contribution Guide][contrib]
- [x] Correct target branch selected (if unsure, select `develop`)
- [x] Source branch up-to-date with target branch
- [x] [Documentation](https://climada-python.readthedocs.io/en/latest/guide/Guide_PythonDos-n-Donts.html#2.--Commenting-&-Documenting) updated
- [ ] [Tests][testing] updated
- [x] [Tests][testing] passing
- [ ] No new [linter issues][linter]

### PR Reviewer Checklist

- [ ] Read the [Contribution Guide][contrib]
- [ ] [CLIMADA Reviewer Checklist](https://climada-python.readthedocs.io/en/latest/guide/Guide_Reviewer_Checklist.html) passed
- [ ] [Tests][testing] passing
- [ ] No new [linter issues][linter]

[contrib]: https://github.com/CLIMADA-project/climada_python/blob/main/CONTRIBUTING.md
[testing]: https://climada-python.readthedocs.io/en/latest/guide/Guide_Continuous_Integration_and_Testing.html
[linter]: https://climada-python.readthedocs.io/en/stable/guide/Guide_Continuous_Integration_and_Testing.html#3.C.--Static-Code-Analysis
