### PR TITLE
uitl.coordinates.get_country_code: ignore UserWarning

### DIFF
--- a/climada/util/coordinates.py
+++ b/climada/util/coordinates.py
@@ -26,7 +26,7 @@ import math
 from multiprocessing import cpu_count
 from pathlib import Path
 import re
-
+import warnings
 import zipfile
 
 from cartopy.io import shapereader
@@ -1462,7 +1462,13 @@ def get_country_code(lat, lon, gridded=False):
         extent = (lon.min() - 0.001, lon.max() + 0.001,
                   lat.min() - 0.001, lat.max() + 0.001)
         countries = get_country_geometries(extent=extent)
-        countries['area'] = countries.geometry.area
+        with warnings.catch_warnings():
+            # in order to suppress the following
+            # UserWarning: Geometry is in a geographic CRS. Results from 'area' are likely
+            # incorrect. Use 'GeoSeries.to_crs()' to re-project geometries to a projected CRS
+            # before this operation.
+            warnings.simplefilter('ignore', UserWarning)
+            countries['area'] = countries.geometry.area
         countries = countries.sort_values(by=['area'], ascending=False)
         region_id = np.full((lon.size,), -1, dtype=int)
         total_land = countries.geometry.unary_union


### PR DESCRIPTION
Changes proposed in this PR:
- the util function `get_country_code` raises a `UserWarning` whenever it is called, because `get_country_geometries` returns a GeoDataFrame with EPSG:4326 (WGS84), which is a geographic CRS. Now, accessing a GeoDataFrame with a geogrphic CRS immediately triggers a Warning. This PR simply suppresses the warning.

This PR fixes #415

### PR Author Checklist

- [ ] Read the [Contribution Guide][contrib]
- [x] Correct target branch selected (if unsure, select `develop`)
- [x] Source branch up-to-date with target branch
- [ ] [Documentation](https://climada-python.readthedocs.io/en/latest/guide/Guide_PythonDos-n-Donts.html#2.--Commenting-&-Documenting) updated
- [ ] [Tests][testing] updated (not needed as this only suppresses a warning)
- [x] [Tests][testing] passing
- [x] No new [linter issues][linter]

### PR Reviewer Checklist

- [x] Read the [Contribution Guide][contrib]
- [x] [CLIMADA Reviewer Checklist](https://climada-python.readthedocs.io/en/latest/guide/Guide_Reviewer_Checklist.html) passed
- [x] [Tests][testing] passing
- [x] No new [linter issues][linter]

[contrib]: https://github.com/CLIMADA-project/climada_python/blob/main/CONTRIBUTING.md
[testing]: https://climada-python.readthedocs.io/en/latest/guide/Guide_Continuous_Integration_and_Testing.html
[linter]: https://climada-python.readthedocs.io/en/stable/guide/Guide_Continuous_Integration_and_Testing.html#3.C.--Static-Code-Analysis
