### PR TITLE
util.coordinates.get_admin1_geometries: pd.concat in lieu of gdf.append

### DIFF
--- a/climada/util/coordinates.py
+++ b/climada/util/coordinates.py
@@ -1583,7 +1583,7 @@ def get_admin1_geometries(countries):
         # fill columns with country identifiers (admin 0):
         gdf_tmp.iso_3n = pycountry.countries.lookup(country).numeric
         gdf_tmp.iso_3a = country
-        gdf = gdf.append(gdf_tmp, ignore_index=True)
+        gdf = pd.concat([gdf, gdf_tmp], ignore_index=True)
     return gdf
 
 def get_resolution_1d(coords, min_resol=1.0e-8):

--- a/climada/util/test/test_coordinates.py
+++ b/climada/util/test/test_coordinates.py
@@ -1059,6 +1059,7 @@ class TestGetGeodata(unittest.TestCase):
         """test get_admin1_geometries"""
         countries = ['CHE', 'Indonesia', '840', 51]
         gdf = u_coord.get_admin1_geometries(countries=countries)
+        self.assertEqual(type(gdf), gpd.GeoDataFrame)
         self.assertEqual(len(gdf.iso_3a.unique()), 4) # 4 countries
         self.assertEqual(gdf.loc[gdf.iso_3a=='CHE'].shape[0], 26) # 26 cantons in CHE
         self.assertEqual(gdf.shape[0], 121) # 121 admin 1 regions in the 4 countries

--- a/climada/util/test/test_coordinates.py
+++ b/climada/util/test/test_coordinates.py
@@ -1059,7 +1059,7 @@ class TestGetGeodata(unittest.TestCase):
         """test get_admin1_geometries"""
         countries = ['CHE', 'Indonesia', '840', 51]
         gdf = u_coord.get_admin1_geometries(countries=countries)
-        self.assertEqual(type(gdf), gpd.GeoDataFrame)
+        self.assertIsInstance(gdf, gpd.GeoDataFrame)
         self.assertEqual(len(gdf.iso_3a.unique()), 4) # 4 countries
         self.assertEqual(gdf.loc[gdf.iso_3a=='CHE'].shape[0], 26) # 26 cantons in CHE
         self.assertEqual(gdf.shape[0], 121) # 121 admin 1 regions in the 4 countries


### PR DESCRIPTION
Changes proposed in this PR:
- replace deprecated `geopandas.GeoDataFrame.append` by `pandas.concat` in `get_admin1_geometries`

This PR is analogous to #443

### PR Author Checklist

- [ ] Read the [Contribution Guide][contrib]
- [x] Correct target branch selected (if unsure, select `develop`)
- [x] Source branch up-to-date with target branch
- [ ] [Documentation](https://climada-python.readthedocs.io/en/latest/guide/Guide_PythonDos-n-Donts.html#2.--Commenting-&-Documenting) updated
- [x] [Tests][testing] updated
- [x] [Tests][testing] passing
- [x] No new [linter issues][linter]

### PR Reviewer Checklist

- [x] Read the [Contribution Guide][contrib]
- [x] [CLIMADA Reviewer Checklist](https://climada-python.readthedocs.io/en/latest/guide/Guide_Reviewer_Checklist.html) passed
- [ ] [Tests][testing] passing
- [ ] No new [linter issues][linter]

[contrib]: https://github.com/CLIMADA-project/climada_python/blob/main/CONTRIBUTING.md
[testing]: https://climada-python.readthedocs.io/en/latest/guide/Guide_Continuous_Integration_and_Testing.html
[linter]: https://climada-python.readthedocs.io/en/stable/guide/Guide_Continuous_Integration_and_Testing.html#3.C.--Static-Code-Analysis
