### PR TITLE
Feature/fix haz type twice

### DIFF
--- a/climada/hazard/test/test_trop_cyclone.py
+++ b/climada/hazard/test/test_trop_cyclone.py
@@ -444,6 +444,24 @@ class TestClimateSce(unittest.TestCase):
             tc._apply_knutson_criterion(criterion, 3)
 
 
+class TestHDF5Cycle(unittest.TestCase):
+    def setUp(self) -> None:
+        self.dump = '.shorttrack-dump.hdf5'
+        tc_track = TCTracks.from_processed_ibtracs_csv(TEST_TRACK_SHORT)
+        self.haz = TropCyclone.from_tracks(tc_track, centroids=CENTR_TEST_BRB)
+        return super().setUp()
+    
+    def test_dump_reload(self):
+        """Try to write hazard to a hdf5 file and read it back in"""
+        self.haz.write_hdf5(self.dump)
+        trop_cyclone = TropCyclone.from_hdf5(self.dump)
+        self.assertTrue(np.allclose(self.haz.category, trop_cyclone.category))
+    
+    def tearDown(self) -> None:
+        Path(self.dump).unlink(missing_ok=True)
+        return super().tearDown()
+
+
 if __name__ == "__main__":
     TESTS = unittest.TestLoader().loadTestsFromTestCase(TestReader)
     TESTS.addTests(unittest.TestLoader().loadTestsFromTestCase(TestWindfieldHelpers))

--- a/climada/hazard/trop_cyclone.py
+++ b/climada/hazard/trop_cyclone.py
@@ -150,7 +150,8 @@ class TropCyclone(Hazard):
         **kwargs : Hazard properties, optional
             All other keyword arguments are passed to the Hazard constructor.
         """
-        Hazard.__init__(self, haz_type=HAZ_TYPE, **kwargs)
+        kwargs.setdefault('haz_type', HAZ_TYPE)
+        Hazard.__init__(self, **kwargs)
         self.category = category if category is not None else np.array([], int)
         self.basin = basin if basin is not None else []
         self.windfields = windfields if windfields is not None else []


### PR DESCRIPTION
Changes proposed in this PR:
- The haz_type argument must not be given twice when calling the `Hazard.__init__` constructor from `TropicalCyclone.__init__`

This PR fixes #

### PR Author Checklist

- [ ] Read the [Contribution Guide][contrib]
- [x] Correct target branch selected (if unsure, select `develop`)
- [x] Source branch up-to-date with target branch
- [ ] [Documentation](https://climada-python.readthedocs.io/en/latest/guide/Guide_PythonDos-n-Donts.html#2.--Commenting-&-Documenting) updated
- [x] [Tests][testing] updated
- [x] [Tests][testing] passing
- [x] No new [linter issues][linter]

### PR Reviewer Checklist

- [ ] Read the [Contribution Guide][contrib]
- [ ] [CLIMADA Reviewer Checklist](https://climada-python.readthedocs.io/en/latest/guide/Guide_Reviewer_Checklist.html) passed
- [ ] [Tests][testing] passing
- [ ] No new [linter issues][linter]

[contrib]: https://github.com/CLIMADA-project/climada_python/blob/main/CONTRIBUTING.md
[testing]: https://climada-python.readthedocs.io/en/latest/guide/Guide_Continuous_Integration_and_Testing.html
[linter]: https://climada-python.readthedocs.io/en/stable/guide/Guide_Continuous_Integration_and_Testing.html#3.C.--Static-Code-Analysis
