### PR TITLE
Add warning not to load IBTrACS with `TCTracks.from_netcdf`

### DIFF
--- a/climada/hazard/tc_tracks.py
+++ b/climada/hazard/tc_tracks.py
@@ -396,9 +396,9 @@ class TCTracks():
             which simulates the genesis location. Note that the resulting genesis basin of a
             particular track may depend on the selected `provider` and on `estimate_missing`
             because only the first *valid* eye position is considered. Possible values are 'NA'
-            (North Atlantic), 'SA' (South Atlantic), 'EP'​ (Eastern North Pacific, which includes
-            the Central Pacific region), 'WP'​ (Western North Pacific), 'SP'​ (South Pacific),
-            'SI'​ (South Indian), 'NI'​ (North Indian). If None, this filter is not applied.
+            (North Atlantic), 'SA' (South Atlantic), 'EP' (Eastern North Pacific, which includes
+            the Central Pacific region), 'WP' (Western North Pacific), 'SP' (South Pacific),
+            'SI' (South Indian), 'NI' (North Indian). If None, this filter is not applied.
             Default: None.
         interpolate_missing : bool, optional
             If True, interpolate temporal reporting gaps within a variable (such as pressure, wind

--- a/climada/hazard/tc_tracks.py
+++ b/climada/hazard/tc_tracks.py
@@ -1259,6 +1259,13 @@ class TCTracks():
     def from_netcdf(cls, folder_name):
         """Create new TCTracks object from NetCDF files contained in a given folder
 
+        Warning
+        -------
+        Do not use this classmethod for reading IBTrACS NetCDF files! If you need to
+        manually download IBTrACS NetCDF files, place them in the
+        ``~/climada/data/system`` folder and use the ``TCTracks.from_ibtracks_netcdf``
+        classmethod.
+
         Parameters
         ----------
         folder_name : str


### PR DESCRIPTION
Changes proposed in this PR:
- Add instructions to the `TCTracks.from_netcdf` docstring on how to load IBTrACS NetCDF files when downloading them manually
- Fix stray unicode symbols in `TCTracks.from_ibtracs_netcdf` docstring

This PR fixes #530

### PR Author Checklist

- [x] Read the [Contribution Guide][contrib]
- [x] Correct target branch selected (if unsure, select `develop`)
- [x] Source branch up-to-date with target branch
- [x] [Documentation](https://climada-python.readthedocs.io/en/latest/guide/Guide_PythonDos-n-Donts.html#2.--Commenting-&-Documenting) updated
- ~~[ ] [Tests][testing] updated~~
- [x] [Tests][testing] passing
- [x] No new [linter issues][linter]

### PR Reviewer Checklist

- [ ] Read the [Contribution Guide][contrib]
- [ ] [CLIMADA Reviewer Checklist](https://climada-python.readthedocs.io/en/latest/guide/Guide_Reviewer_Checklist.html) passed
- [ ] [Tests][testing] passing
- [ ] No new [linter issues][linter]

[contrib]: https://github.com/CLIMADA-project/climada_python/blob/main/CONTRIBUTING.md
[testing]: https://climada-python.readthedocs.io/en/latest/guide/Guide_Continuous_Integration_and_Testing.html
[linter]: https://climada-python.readthedocs.io/en/stable/guide/Guide_Continuous_Integration_and_Testing.html#3.C.--Static-Code-Analysis
