### PR TITLE
Test plots of Exposure class

### DIFF
--- a/climada/test/test_plot.py
+++ b/climada/test/test_plot.py
@@ -25,7 +25,6 @@ import pandas as pd
 import contextily as ctx
 import urllib
 
-from rasterio.windows import Window
 from climada.entity.entity_def import Entity
 from climada.hazard.base import Hazard
 from climada.entity.exposures.base import Exposures
@@ -33,17 +32,8 @@ from climada.entity.impact_funcs.impact_func_set import ImpactFuncSet
 from climada.engine import ImpactCalc, ImpactFreqCurve
 from climada.util.constants import HAZ_DEMO_FL, HAZ_DEMO_MAT, ENT_DEMO_TODAY
 
-# Define an exposure to use for plotting
-exp = Exposures.from_raster(HAZ_DEMO_FL, window= Window(10, 20, 50, 60))
-
 class TestPlotter(unittest.TestCase):
     """Test plot functions."""
-
-    def test_plots(self):
-        """ Test plot_scatter, plot_basemap, and plot_raster"""
-        exp.plot_scatter()
-        exp.plot_basemap()
-        exp.plot_raster()
 
     def setUp(self):
         plt.ioff()
@@ -112,6 +102,10 @@ class TestPlotter(unittest.TestCase):
         myexp.tag.description = ''
         myax = myexp.plot_hexbin()
         self.assertIn('', myax.get_title())
+
+        myexp.plot_scatter()
+        myexp.plot_basemap()
+        myexp.plot_raster()
 
     def test_impact_funcs_pass(self):
         """Plot diferent impact functions."""

--- a/climada/test/test_plot.py
+++ b/climada/test/test_plot.py
@@ -30,7 +30,7 @@ from climada.hazard.base import Hazard
 from climada.entity.exposures.base import Exposures
 from climada.entity.impact_funcs.impact_func_set import ImpactFuncSet
 from climada.engine import ImpactCalc, ImpactFreqCurve
-from climada.util.constants import HAZ_DEMO_FL, HAZ_DEMO_MAT, ENT_DEMO_TODAY
+from climada.util.constants import HAZ_DEMO_MAT, ENT_DEMO_TODAY
 
 class TestPlotter(unittest.TestCase):
     """Test plot functions."""

--- a/climada/test/test_plot.py
+++ b/climada/test/test_plot.py
@@ -25,15 +25,27 @@ import pandas as pd
 import contextily as ctx
 import urllib
 
+from rasterio.windows import Window
 from climada.entity.entity_def import Entity
 from climada.hazard.base import Hazard
 from climada.entity.exposures.base import Exposures
 from climada.entity.impact_funcs.impact_func_set import ImpactFuncSet
 from climada.engine import ImpactCalc, ImpactFreqCurve
-from climada.util.constants import HAZ_DEMO_MAT, ENT_DEMO_TODAY
+from climada.util.constants import HAZ_DEMO_FL, HAZ_DEMO_MAT, ENT_DEMO_TODAY
+
+# Define an exposure to use for plotting
+exp = Exposures.from_raster(HAZ_DEMO_FL, window= Window(10, 20, 50, 60))
+exp.set_geometry_points()
+
 
 class TestPlotter(unittest.TestCase):
     """Test plot functions."""
+
+    def test_plots(self):
+        """ Test plot_scatter, plot_basemap, and plot_raster"""
+        exp.plot_scatter()
+        exp.plot_basemap()
+        exp.plot_raster()
 
     def setUp(self):
         plt.ioff()

--- a/climada/test/test_plot.py
+++ b/climada/test/test_plot.py
@@ -35,8 +35,6 @@ from climada.util.constants import HAZ_DEMO_FL, HAZ_DEMO_MAT, ENT_DEMO_TODAY
 
 # Define an exposure to use for plotting
 exp = Exposures.from_raster(HAZ_DEMO_FL, window= Window(10, 20, 50, 60))
-exp.set_geometry_points()
-
 
 class TestPlotter(unittest.TestCase):
     """Test plot functions."""


### PR DESCRIPTION
Changes proposed in this PR:

Increase coverage. Add 3 test to check that the plotting functions of climada/entity/exposure/base.py do not throw
any errors when they are called. Specifically, the functions tested are:

1) plot_scatter
2) plot_raster
3) plot_basemap

I visually checked that the plots were actually plotting something.

### PR Author Checklist

- [x] Read the [Contribution Guide][contrib]
- [x] Correct target branch selected (if unsure, select `develop`)
- [x] Source branch up-to-date with target branch
- [ ] [Documentation](https://climada-python.readthedocs.io/en/latest/guide/Guide_PythonDos-n-Donts.html#2.--Commenting-&-Documenting) updated
- [x] [Tests][testing] updated
- [ ] [Tests][testing] passing
- [ ] No new [linter issues][linter]

### PR Reviewer Checklist

- [x] Read the [Contribution Guide][contrib]
- [x] [CLIMADA Reviewer Checklist](https://climada-python.readthedocs.io/en/latest/guide/Guide_Reviewer_Checklist.html) passed
- [ ] [Tests][testing] passing
- [x] No new [linter issues][linter]

[contrib]: https://github.com/CLIMADA-project/climada_python/blob/main/CONTRIBUTING.md
[testing]: https://climada-python.readthedocs.io/en/latest/guide/Guide_Continuous_Integration_and_Testing.html
[linter]: https://climada-python.readthedocs.io/en/stable/guide/Guide_Continuous_Integration_and_Testing.html#3.C.--Static-Code-Analysis
