### PR TITLE
Speed up TCTrack plotting speed using LineString instead of LineCollection

### DIFF
--- a/climada/hazard/tc_tracks.py
+++ b/climada/hazard/tc_tracks.py
@@ -1267,7 +1267,7 @@ class TCTracks():
             leg_lines = [Line2D([0], [0], color=CAT_COLORS[i_col], lw=2)
                          for i_col in range(len(SAFFIR_SIM_CAT))]
             leg_names = [CAT_NAMES[i_col] for i_col in sorted(CAT_NAMES.keys())]
-            if not all(tracks_gdf['orig_event_flag']):
+            if not tracks_gdf['orig_event_flag'].values.all():
                 leg_lines.append(Line2D([0], [0], color='grey', lw=2, ls='solid'))
                 leg_lines.append(Line2D([0], [0], color='grey', lw=2, ls=':'))
                 leg_names.append('Historical')


### PR DESCRIPTION
### Changes proposed in this PR

Plotting large TC event sets can take minutes or hours. This updates the `TCTracks.plot` method to convert tracks to shapely `LineStrings` rather than the current matplotlib `LineCollections`, which seems to speed up plotting significantly.

I also take the chance to improve the previous data wrangling by manipulating the data as a GeoDataFrame. In doing so it fixes a couple of small bugs:
- Tracks that crossed 0 longitude were inadvertently identified as crossing 180 longitude and had a gap in them when plotted
- Tracks that were identified as crossing 180 longitude unintentionally had their wind speeds shifted by one frame for the frames _after_ the track crossed the meridian. This was because a line segment was removed from the track but not from the wind speed data (`LineString`'s plotting methods don't check for equal vector lengths when assigning colours to lines, for some reason).

### Note
- Tracks crossing 180 degrees still have a line segment removed. We could improve this: the `TCTracks.to_geodataframe` shows one way to do it.
- There is room for further speed improvements by combining consecutive line segments when the category doesn't change.
- Shapely issues some deprecation warnings (I don't think they're new?)
- No tests updated since the functionality doesn't change

### To discuss
- This uses the `TCTracks.to_geodataframe` method. It creates a GeoDataFrame and assigns the default CRS to it. I had to overwrite the GeoDataFrame's CRS with the CRS used in the `plot` method. Should we update `TCTracks.to_geodataframe` with the CRS as a new parameter? 

### Validation
Code to test `develop` against this branch:
```
from climada.hazard import TCTracks
import time

### Test case: Southern Indian Ocean tracks since 2015 (about 120 tracks)
tracks = TCTracks.from_ibtracs_netcdf(basin='SI', year_range=(2015, 2022))

tstart = time.perf_counter()
tracks.plot()
tend = time.perf_counter()
print(f'Plotting {len(tracks.data)} completed in {tend - tstart:0.1f} seconds')
```
Running this on my machine gives an improvement from 15 minutes (was I doing something wrong???) to 17 seconds.

**OLD:**
![newmethod_testSI_old](https://user-images.githubusercontent.com/18582147/210815933-84e24f46-e9f1-4118-bc84-1a79b7071fd3.png)
**NEW:**
![newmethod_testSI_new](https://user-images.githubusercontent.com/18582147/210815957-79b29bc1-a7ee-4092-9c67-692157d3fbe9.png)

As far as I can tell, the new method draws slightly thicker lines, but nothing else has changed.

### PR Author Checklist

- [x] Read the [Contribution Guide][contrib]
- [x] Correct target branch selected (if unsure, select `develop`)
- [x] Source branch up-to-date with target branch
- [x] [Documentation](https://climada-python.readthedocs.io/en/latest/guide/Guide_PythonDos-n-Donts.html#2.--Commenting-&-Documenting) updated
- [x] [Tests][testing] updated
- [x] [Tests][testing] passing
- [x] No new [linter issues][linter]

### PR Reviewer Checklist

- [ ] Read the [Contribution Guide][contrib]
- [ ] [CLIMADA Reviewer Checklist](https://climada-python.readthedocs.io/en/latest/guide/Guide_Reviewer_Checklist.html) passed
- [ ] [Tests][testing] passing
- [ ] No new [linter issues][linter]

[contrib]: https://github.com/CLIMADA-project/climada_python/blob/main/CONTRIBUTING.md
[testing]: https://climada-python.readthedocs.io/en/latest/guide/Guide_Continuous_Integration_and_Testing.html
[linter]: https://climada-python.readthedocs.io/en/stable/guide/Guide_Continuous_Integration_and_Testing.html#3.C.--Static-Code-Analysis
