### PR TITLE
Fix heading of doc/guide/guide_Configuration.jbynb

### DIFF
--- a/doc/guide/Guide_Configuration.ipynb
+++ b/doc/guide/Guide_Configuration.ipynb
@@ -15,7 +15,7 @@
     "\n",
     "1. [Constants](#Const)\n",
     "    1. [Hard Coded](#ConstHard)\n",
-    "    2. [Conigurable](#ConstConf)\n",
+    "    2. [Configurable](#ConstConf)\n",
     "    3. [Where to put constants?](#ConstWhere)\n",
     "2. [Configuration](#Conf)\n",
     "    1. [Config files](#ConfFiles)\n",
@@ -28,7 +28,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "##  1. <a id=\"Const\"> Constants </a>\n",
+    "## 1. <a id=\"Const\"> Constants </a>\n",
+    "\n",
     "Constants are values that, once initialized, are never changed during the runtime of a program. In Python constants are assigned to variables with capital letters by convention, and vice versa, variables with capital letters are supposed to be constants.\n",
     "\n",
     "In principle there are about four ways to define a constant's value:\n",
@@ -44,7 +45,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "###  1.A. <a id='ConstHard'> Hard Coded </a>\n",
+    "### 1.A. <a id='ConstHard'> Hard Coded </a>\n",
+    "\n",
     "Hard coding constants is the preferred way to deal with strings that are used to identify objects or files."
    ]
   },
@@ -165,7 +167,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "###  1.B. <a id='ConstConf'> Configurable </a>\n",
+    "### 1.B. <a id='ConstConf'> Configurable </a>\n",
+    "\n",
     "When it comes to absolute paths, it is urgently suggested to not use hard coded constant values, for the obvious reasons. But also relative paths can cause problems. In particular, they may point to a location where the user has not sufficient access permissions. In order to avoid these problems, _all_ paths constants in CLIMADA are supposed to be defined through configuration.\\\n",
     "<b style='color:darkred;font-size:100%'> &rarr; paths must be configurable </b>\n",
     "\n",
@@ -180,7 +183,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "###  1.C. <a id='ConstWhere'> Where to put constants? </a>\n",
+    "### 1.C. <a id='ConstWhere'> Where to put constants? </a>\n",
+    "\n",
     "As a general rule, constants are defined in the module where they intrinsically belong to. If they belong equally to different modules though or they are meant to be used globally, there is the module `climada.util.constants` which is compiling constants CLIMADA wide."
    ]
   },
@@ -188,14 +192,15 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "##  2. <a id='Conf'> Configuration </a>"
+    "## 2. <a id='Conf'> Configuration </a>"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "###  2.A. <a id='ConfFiles'> Configuration files </a>\n",
+    "### 2.A. <a id='ConfFiles'> Configuration files </a>\n",
+    "\n",
     "The proper place to define constants that a user may want (or need) to change without changing the CLIMADA installation are the configuration files.\\\n",
     "These are files in _json_ format with the name `climada.conf`. There is a default config file that comes with the installation of CLIMADA. But it's possible to have several of them. In this case they are complementing one another.\n",
     "\n",
@@ -257,7 +262,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "###  2.B. <a id='ConfAccess'> Accessing configuration values </a>\n",
+    "### 2.B. <a id='ConfAccess'> Accessing configuration values </a>\n",
+    "\n",
     "Configuration values can be accessed through the (constant) `CONFIG` from the `climada` module:"
    ]
   },
@@ -295,6 +301,7 @@
    "metadata": {},
    "source": [
     "#### Data Types\n",
+    "\n",
     "The configuration itself and its attributes have the data type `climada.util.config.Config`"
    ]
   },
@@ -393,6 +400,7 @@
    "metadata": {},
    "source": [
     "### 2.C. <a id='ConfDefault'> Default Configuration </a>\n",
+    "\n",
     "The conifguration file `climada/conf/climada.conf` contains the default configuration.\\\n",
     "On the top level it has the following attributes\n",
     "- __local\\_data__: definition of main paths for accessing and storing CLIMADA related data\n",
@@ -435,6 +443,7 @@
    "metadata": {},
    "source": [
     "#### Data Initialization\n",
+    "\n",
     "When `import climada` is executed in a python script or shell, data files from the installation directory are copied to the location specified in the current configuration.\\\n",
     "This happens only when climada is used for the first time with the current configuration. Subsequent execution will only check for presence of files and won't overwrite existing files."
    ]
@@ -468,6 +477,7 @@
    "metadata": {},
    "source": [
     "### 2.D. <a id='ConfTest'> Test Configuration </a>\n",
+    "\n",
     "The configuration values for unit and integration tests are not part of the default configuration ([2.C](#ConfDefault)), since they are irrelevant for the regular CLIMADA user and only aimed for developers.\\\n",
     "The default test configuration is defined in the `climada.conf` file of the installation directory.\n",
     "This file contains paths to files that are read during tests. If they are part of the GitHub repository, their path i.g. starts with the `climada` folder within the installation directory:\n",
@@ -506,7 +516,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "climada_env",
    "language": "python",
    "name": "python3"
   },
@@ -520,7 +530,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.12"
+   "version": "3.8.13 | packaged by conda-forge | (default, Mar 25 2022, 06:05:47) \n[Clang 12.0.1 ]"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "4aebf7f26d9a9d4c9696d8ddcd034589cd11abb7fe515057c687f2f3cec840ea"
+   }
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Changes proposed in this PR:

File modified: `doc/guide/guide_Configuration.jbynb`

1) Fix headings (1 space after # and 1 blank line after the header)
2) Fix typo in content structure: coniguration --> configuration

### PR Author Checklist

- [ ] Read the [Contribution Guide][contrib]
- [ ] Correct target branch selected (if unsure, select `develop`)
- [ ] Source branch up-to-date with target branch
- [ ] [Documentation](https://climada-python.readthedocs.io/en/latest/guide/Guide_PythonDos-n-Donts.html#2.--Commenting-&-Documenting) updated
- [ ] [Tests][testing] updated
- [ ] [Tests][testing] passing
- [ ] No new [linter issues][linter]

### PR Reviewer Checklist

- [ ] Read the [Contribution Guide][contrib]
- [ ] [CLIMADA Reviewer Checklist](https://climada-python.readthedocs.io/en/latest/guide/Guide_Reviewer_Checklist.html) passed
- [ ] [Tests][testing] passing
- [ ] No new [linter issues][linter]

[contrib]: https://github.com/CLIMADA-project/climada_python/blob/main/CONTRIBUTING.md
[testing]: https://climada-python.readthedocs.io/en/latest/guide/Guide_Continuous_Integration_and_Testing.html
[linter]: https://climada-python.readthedocs.io/en/stable/guide/Guide_Continuous_Integration_and_Testing.html#3.C.--Static-Code-Analysis
