### PR TITLE
Improve Error Message of api_client.get_litpop

### DIFF
--- a/climada/test/test_api_client.py
+++ b/climada/test/test_api_client.py
@@ -198,6 +198,13 @@ class TestClient(unittest.TestCase):
         self.assertTrue('[1, 1]' in litpop.tag.description)
         self.assertTrue('pc' in litpop.tag.description)
 
+    def test_get_litpop_fail(self):
+        client = Client()
+        with self.assertRaises(ValueError) as cm:
+            client.get_litpop(['AUT', 'CHE'])
+        self.assertIn(" can only query single countries. Download the data for multiple countries individually and concatenate ",
+            str(cm.exception))
+
     def test_multi_filter(self):
         client = Client()
         testds = client.list_dataset_infos(data_type='storm_europe')

--- a/climada/util/api_client.py
+++ b/climada/util/api_client.py
@@ -836,7 +836,7 @@ class Client():
 
         Parameters
         ----------
-        country : str or list, optional
+        country : str, optional
             List of country name or iso3 codes for which to create the LitPop object.
             If None is given, a global LitPop instance is created. Defaut is None
         exponents : tuple of two integers, optional
@@ -862,9 +862,13 @@ class Client():
         elif isinstance(country, str):
             properties['country_name'] = pycountry.countries.lookup(country).name
         elif isinstance(country, list):
+            if len(set(country)) > 1:
+                raise ValueError("``get_litpop`` can only query single countries. Download the"
+                                 " data for multiple countries individually, and concatenate the"
+                                 " objects using ``LitPop.concat``")
             properties['country_name'] = [pycountry.countries.lookup(c).name for c in country]
         else:
-            raise ValueError("country must be string or list of strings")
+            raise ValueError("country must be string")
         return self.get_exposures(exposures_type='litpop', properties=properties, version=version,
                                   dump_dir=dump_dir)
 

--- a/climada/util/api_client.py
+++ b/climada/util/api_client.py
@@ -831,14 +831,16 @@ class Client():
         return exposures_concat
 
     def get_litpop(self, country=None, exponents=(1,1), version=None, dump_dir=SYSTEM_DIR):
-        """Get a LitPop instance on a 150arcsec grid with the default parameters:
+        """Get a LitPop ``Exposures`` instance on a 150arcsec grid with the default parameters:
         exponents = (1,1) and fin_mode = 'pc'.
 
         Parameters
         ----------
         country : str, optional
             Country name or iso3 codes for which to create the LitPop object.
-            If None is given, a global LitPop instance is created. Defaut is None
+            For creating a LitPop object over multiple countries, use ``get_litpop`` individually
+            and concatenate using ``LitPop.concat``, see Examples.
+            If country is None a global LitPop instance is created. Defaut is None.
         exponents : tuple of two integers, optional
             Defining power with which lit (nightlights) and pop (gpw) go into LitPop. To get
             nightlights^3 without population count: (3, 0).
@@ -854,6 +856,15 @@ class Client():
         -------
         climada.entity.exposures.Exposures
             default litpop Exposures object
+        
+        Examples
+        --------
+        Combined default LitPop object for Austria and Switzerland:
+
+        >>> client = Client()
+        >>> litpop_aut = client.get_litpop("AUT")
+        >>> litpop_che = client.get_litpop("CHE")
+        >>> litpop_comb = LitPop.concat([litpop_aut, litpop_che]) 
         """
         properties = {
             'exponents': "".join(['(',str(exponents[0]),',',str(exponents[1]),')'])}
@@ -864,7 +875,7 @@ class Client():
         elif isinstance(country, list):
             if len(set(country)) > 1:
                 raise ValueError("``get_litpop`` can only query single countries. Download the"
-                                 " data for multiple countries individually, and concatenate the"
+                                 " data for multiple countries individually and concatenate the"
                                  " objects using ``LitPop.concat``")
             properties['country_name'] = [pycountry.countries.lookup(c).name for c in country]
         else:

--- a/climada/util/api_client.py
+++ b/climada/util/api_client.py
@@ -837,7 +837,7 @@ class Client():
         Parameters
         ----------
         country : str, optional
-            List of country name or iso3 codes for which to create the LitPop object.
+            Country name or iso3 codes for which to create the LitPop object.
             If None is given, a global LitPop instance is created. Defaut is None
         exponents : tuple of two integers, optional
             Defining power with which lit (nightlights) and pop (gpw) go into LitPop. To get

--- a/climada/util/api_client.py
+++ b/climada/util/api_client.py
@@ -856,7 +856,7 @@ class Client():
         -------
         climada.entity.exposures.Exposures
             default litpop Exposures object
-        
+
         Examples
         --------
         Combined default LitPop object for Austria and Switzerland:
@@ -864,7 +864,7 @@ class Client():
         >>> client = Client()
         >>> litpop_aut = client.get_litpop("AUT")
         >>> litpop_che = client.get_litpop("CHE")
-        >>> litpop_comb = LitPop.concat([litpop_aut, litpop_che]) 
+        >>> litpop_comb = LitPop.concat([litpop_aut, litpop_che])
         """
         properties = {
             'exponents': "".join(['(',str(exponents[0]),',',str(exponents[1]),')'])}


### PR DESCRIPTION
Changes proposed in this PR:
- Add workaround hints in case someone tries to use get_litpop with multiple countries.

This PR fixes #485

### PR Author Checklist

- [x] Read the [Contribution Guide][contrib]
- [x] Correct target branch selected (if unsure, select `develop`)
- [x] Source branch up-to-date with target branch
- [x] [Documentation](https://climada-python.readthedocs.io/en/latest/guide/Guide_PythonDos-n-Donts.html#2.--Commenting-&-Documenting) updated
- [x] [Tests][testing] updated
- [x] [Tests][testing] passing
- [ ] No new [linter issues][linter] - almost

### PR Reviewer Checklist

- [x] Read the [Contribution Guide][contrib]
- [x] [CLIMADA Reviewer Checklist](https://climada-python.readthedocs.io/en/latest/guide/Guide_Reviewer_Checklist.html) passed
- [x] [Tests][testing] passing
- [x] No new [linter issues][linter]

[contrib]: https://github.com/CLIMADA-project/climada_python/blob/main/CONTRIBUTING.md
[testing]: https://climada-python.readthedocs.io/en/latest/guide/Guide_Continuous_Integration_and_Testing.html
[linter]: https://climada-python.readthedocs.io/en/stable/guide/Guide_Continuous_Integration_and_Testing.html#3.C.--Static-Code-Analysis
