### PR TITLE
Update doc environment

### DIFF
--- a/requirements/env_docs.yml
+++ b/requirements/env_docs.yml
@@ -3,21 +3,21 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - _ipython_minor_entry_point=8.7.0=h3b92ee0_0
   - _libgcc_mutex=0.1=conda_forge
   - _openmp_mutex=4.5=2_gnu
-  - affine=2.3.1=pyhd8ed1ab_0
-  - alabaster=0.7.12=py_0
+  - affine=2.4.0=pyhd8ed1ab_0
+  - alabaster=0.7.13=pyhd8ed1ab_0
+  - appdirs=1.4.4=pyh9f0ad1d_0
   - asttokens=2.2.1=pyhd8ed1ab_0
-  - attrs=22.1.0=pyh71513ae_1
+  - attrs=22.2.0=pyh71513ae_0
   - babel=2.11.0=pyhd8ed1ab_0
   - backcall=0.2.0=pyh9f0ad1d_0
   - backports=1.0=pyhd8ed1ab_3
   - backports.functools_lru_cache=1.6.4=pyhd8ed1ab_0
-  - blosc=1.21.2=hafa529b_0
+  - blosc=1.21.3=hafa529b_0
   - bokeh=2.4.3=py38h578d9bd_0
   - boost-cpp=1.78.0=h75c5d50_1
-  - bottleneck=1.3.5=py38h26c90d9_1
+  - bottleneck=1.3.6=py38h7e4f40d_0
   - branca=0.6.0=pyhd8ed1ab_0
   - brotlipy=0.7.0=py38h0a891b7_1005
   - bzip2=1.0.8=h7f98852_4
@@ -28,7 +28,7 @@ dependencies:
   - cairo=1.16.0=ha61ee94_1014
   - cartopy=0.20.2=py38hb3c56ba_6
   - certifi=2022.12.7=pyhd8ed1ab_0
-  - cffi=1.15.1=py38h4a40e3a_2
+  - cffi=1.15.1=py38h4a40e3a_3
   - cfgrib=0.9.9.1=pyhd8ed1ab_2
   - cfitsio=4.1.0=hd9d235c_0
   - cftime=1.6.2=py38h26c90d9_1
@@ -36,28 +36,28 @@ dependencies:
   - click=8.1.3=py38h578d9bd_1
   - click-plugins=1.1.1=py_0
   - cligj=0.7.2=pyhd8ed1ab_1
-  - cloudpickle=2.2.0=pyhd8ed1ab_0
+  - cloudpickle=2.2.1=pyhd8ed1ab_0
   - colorama=0.4.6=pyhd8ed1ab_0
   - comm=0.1.2=pyhd8ed1ab_0
   - contextily=1.2.0=pyhd8ed1ab_0
-  - cryptography=38.0.4=py38h80a4ca7_0
-  - curl=7.86.0=h2283fc2_1
+  - cryptography=39.0.0=py38h3d167d9_0
+  - curl=7.87.0=hdc1c0ab_0
   - cycler=0.11.0=pyhd8ed1ab_0
   - cytoolz=0.12.0=py38h0a891b7_1
-  - dask=2022.12.0=pyhd8ed1ab_0
-  - dask-core=2022.12.0=pyhd8ed1ab_0
-  - debugpy=1.6.4=py38hfa26641_0
+  - dask=2023.1.0=pyhd8ed1ab_0
+  - dask-core=2023.1.0=pyhd8ed1ab_0
+  - debugpy=1.6.6=py38h8dc9893_0
   - decorator=5.1.1=pyhd8ed1ab_0
   - dill=0.3.6=pyhd8ed1ab_1
-  - distributed=2022.12.0=pyhd8ed1ab_0
+  - distributed=2023.1.0=pyhd8ed1ab_0
   - eccodes=2.26.0=hc08acdf_0
   - entrypoints=0.4=pyhd8ed1ab_0
-  - et_xmlfile=1.0.1=py_1001
+  - et_xmlfile=1.1.0=pyhd8ed1ab_0
   - executing=1.2.0=pyhd8ed1ab_0
   - expat=2.5.0=h27087fc_0
   - findlibs=0.0.2=pyhd8ed1ab_0
   - fiona=1.8.21=py38hd65b8f4_2
-  - folium=0.13.0=pyhd8ed1ab_0
+  - folium=0.14.0=pyhd8ed1ab_0
   - font-ttf-dejavu-sans-mono=2.37=hab24e00_0
   - font-ttf-inconsolata=3.000=h77eed37_0
   - font-ttf-source-code-pro=2.038=h77eed37_0
@@ -68,7 +68,7 @@ dependencies:
   - freeglut=3.2.2=h9c3ff4c_1
   - freetype=2.12.1=hca18f0e_1
   - freexl=1.0.6=h166bdaf_1
-  - fsspec=2022.11.0=pyhd8ed1ab_0
+  - fsspec=2023.1.0=pyhd8ed1ab_0
   - gdal=3.5.0=py38h51ade5a_4
   - geographiclib=1.52=pyhd8ed1ab_0
   - geopandas=0.12.2=pyhd8ed1ab_0
@@ -86,28 +86,28 @@ dependencies:
   - icu=70.1=h27087fc_0
   - idna=3.4=pyhd8ed1ab_0
   - imagesize=1.4.1=pyhd8ed1ab_0
-  - importlib-metadata=5.1.0=pyha770c72_0
-  - ipykernel=6.19.2=pyh210e3f2_0
-  - ipython=8.7.0=pyh41d4057_0
+  - importlib-metadata=6.0.0=pyha770c72_0
+  - ipykernel=6.20.2=pyh210e3f2_0
+  - ipython=8.8.0=pyh41d4057_0
   - jasper=2.0.33=ha77e612_0
   - jedi=0.18.2=pyhd8ed1ab_0
   - jinja2=3.1.2=pyhd8ed1ab_1
   - joblib=1.2.0=pyhd8ed1ab_0
   - jpeg=9e=h166bdaf_2
   - json-c=0.16=hc379101_0
-  - jupyter_client=7.4.8=pyhd8ed1ab_0
-  - jupyter_core=5.1.0=py38h578d9bd_0
+  - jupyter_client=7.4.9=pyhd8ed1ab_0
+  - jupyter_core=5.1.5=py38h578d9bd_0
   - kealib=1.4.15=hfe1a663_0
   - keyutils=1.6.1=h166bdaf_0
   - kiwisolver=1.4.4=py38h43d8883_1
-  - krb5=1.19.3=h08a2579_0
+  - krb5=1.20.1=h81ceb04_0
   - lcms2=2.14=h6ed2654_0
   - ld_impl_linux-64=2.39=hcc3a1bd_1
   - lerc=4.0.0=h27087fc_0
-  - libaec=1.0.6=h9c3ff4c_0
+  - libaec=1.0.6=hcb278e6_1
   - libblas=3.9.0=16_linux64_openblas
   - libcblas=3.9.0=16_linux64_openblas
-  - libcurl=7.86.0=h2283fc2_1
+  - libcurl=7.87.0=hdc1c0ab_0
   - libdap4=3.20.6=hd7c4107_2
   - libdeflate=1.14=h166bdaf_0
   - libedit=3.1.20191231=he28a2e2_2
@@ -125,11 +125,11 @@ dependencies:
   - liblapack=3.9.0=16_linux64_openblas
   - libllvm11=11.1.0=he0ac6c6_5
   - libnetcdf=4.8.1=nompi_h329d8a1_102
-  - libnghttp2=1.47.0=hff17c54_1
+  - libnghttp2=1.51.0=hff17c54_0
   - libnsl=2.0.0=h7f98852_0
   - libopenblas=0.3.21=pthreads_h78a6416_3
   - libpng=1.6.39=h753d276_0
-  - libpq=14.5=h52d0468_3
+  - libpq=14.5=hb675445_5
   - librttopo=1.1.0=h40fdbc5_10
   - libsodium=1.0.18=h36c2ea0_1
   - libspatialindex=1.9.3=h9c3ff4c_4
@@ -137,7 +137,7 @@ dependencies:
   - libsqlite=3.40.0=h753d276_0
   - libssh2=1.10.0=hf14f497_3
   - libstdcxx-ng=12.2.0=h46fd767_19
-  - libtiff=4.4.0=h55922b4_4
+  - libtiff=4.4.0=h82bc61c_5
   - libuuid=2.32.1=h7f98852_1000
   - libwebp-base=1.2.4=h166bdaf_0
   - libxcb=1.13=h7f98852_1004
@@ -147,12 +147,12 @@ dependencies:
   - libzlib=1.2.13=h166bdaf_4
   - llvmlite=0.39.1=py38h38d86a4_1
   - locket=1.0.0=pyhd8ed1ab_0
-  - lxml=4.9.1=py38ha9ef780_1
-  - lz4=4.0.2=py38h1bf946c_0
+  - lxml=4.9.2=py38h215a2d7_0
+  - lz4=4.2.0=py38hd012fdc_0
   - lz4-c=1.9.3=h9c3ff4c_1
   - lzo=2.10=h516909a_1000
-  - mapclassify=2.4.3=pyhd8ed1ab_0
-  - markupsafe=2.1.1=py38h0a891b7_2
+  - mapclassify=2.5.0=pyhd8ed1ab_1
+  - markupsafe=2.1.2=py38h1de0b5d_0
   - matplotlib=3.3.2=0
   - matplotlib-base=3.3.2=py38h5c7f4ab_1
   - matplotlib-inline=0.1.6=pyhd8ed1ab_0
@@ -163,7 +163,7 @@ dependencies:
   - ncurses=6.3=h27087fc_1
   - nest-asyncio=1.5.6=pyhd8ed1ab_0
   - netcdf4=1.6.0=nompi_py38he1ab104_100
-  - networkx=2.8.8=pyhd8ed1ab_0
+  - networkx=3.0=pyhd8ed1ab_0
   - nomkl=1.0=h5ca1d4c_0
   - nspr=4.35=h27087fc_0
   - nss=3.82=he02c5a1_0
@@ -173,8 +173,8 @@ dependencies:
   - openjpeg=2.5.0=h7d73246_1
   - openpyxl=3.0.10=py38h0a891b7_2
   - openssl=3.0.7=h0b41bf4_1
-  - packaging=22.0=pyhd8ed1ab_0
-  - pandas=1.5.2=py38h8f669ce_0
+  - packaging=23.0=pyhd8ed1ab_0
+  - pandas=1.5.3=py38hdc8b05c_0
   - pandas-datareader=0.10.0=pyh6c4a22f_0
   - pandoc=2.19.2=h32600fe_1
   - parso=0.8.3=pyhd8ed1ab_0
@@ -189,10 +189,11 @@ dependencies:
   - pint=0.20.1=pyhd8ed1ab_0
   - pip=22.3.1=pyhd8ed1ab_0
   - pixman=0.40.0=h36c2ea0_0
-  - platformdirs=2.6.0=pyhd8ed1ab_0
+  - platformdirs=2.6.2=pyhd8ed1ab_0
+  - pooch=1.6.0=pyhd8ed1ab_0
   - poppler=22.04.0=h0733791_3
   - poppler-data=0.4.11=hd8ed1ab_0
-  - postgresql=14.5=h96c9388_3
+  - postgresql=14.5=h3248436_5
   - pox=0.3.2=pyhd8ed1ab_0
   - ppft=1.7.6.6=pyhd8ed1ab_0
   - proj=9.0.1=h93bde94_1
@@ -204,8 +205,8 @@ dependencies:
   - pycountry=22.3.5=pyhd8ed1ab_0
   - pycparser=2.21=pyhd8ed1ab_0
   - pyepsg=0.4.0=py_0
-  - pygments=2.13.0=pyhd8ed1ab_0
-  - pyopenssl=22.1.0=pyhd8ed1ab_0
+  - pygments=2.14.0=pyhd8ed1ab_0
+  - pyopenssl=23.0.0=pyhd8ed1ab_0
   - pyparsing=3.0.9=pyhd8ed1ab_0
   - pyproj=3.4.0=py38he1635e7_0
   - pyshp=2.3.1=pyhd8ed1ab_0
@@ -215,24 +216,25 @@ dependencies:
   - python-dateutil=2.8.2=pyhd8ed1ab_0
   - python-eccodes=1.4.2=py38h26c90d9_1
   - python_abi=3.8=3_cp38
-  - pytz=2022.6=pyhd8ed1ab_0
+  - pytz=2022.7.1=pyhd8ed1ab_0
   - pyxlsb=1.0.10=pyhd8ed1ab_0
   - pyyaml=6.0=py38h0a891b7_5
-  - pyzmq=24.0.1=py38hfc09fa9_1
+  - pyzmq=25.0.0=py38he24dcef_0
   - rasterio=1.2.10=py38h164e37e_7
   - readline=8.1.2=h0f457ee_0
-  - requests=2.28.1=pyhd8ed1ab_1
+  - requests=2.28.2=pyhd8ed1ab_0
   - rtree=1.0.1=py38h02d302b_1
-  - scikit-learn=1.2.0=py38h1e1a916_0
-  - scipy=1.9.3=py38h8ce737c_2
-  - setuptools=65.5.1=pyhd8ed1ab_0
+  - scikit-learn=1.2.1=py38h1e1a916_0
+  - scipy=1.10.0=py38h10c12cc_0
+  - setuptools=66.1.1=pyhd8ed1ab_0
   - shapely=1.8.2=py38h928055b_2
   - six=1.16.0=pyh6c4a22f_0
   - snappy=1.1.9=hbd366e4_2
   - snowballstemmer=2.2.0=pyhd8ed1ab_0
   - snuggs=1.4.7=py_0
   - sortedcontainers=2.4.0=pyhd8ed1ab_0
-  - sphinxcontrib-applehelp=1.0.2=py_0
+  - sparse=0.13.0=pyhd8ed1ab_0
+  - sphinxcontrib-applehelp=1.0.4=pyhd8ed1ab_0
   - sphinxcontrib-devhelp=1.0.2=py_0
   - sphinxcontrib-htmlhelp=2.0.0=pyhd8ed1ab_0
   - sphinxcontrib-jsmath=1.0.1=py_0
@@ -249,17 +251,18 @@ dependencies:
   - toolz=0.12.0=pyhd8ed1ab_0
   - tornado=6.2=py38h0a891b7_1
   - tqdm=4.64.1=pyhd8ed1ab_0
-  - traitlets=5.7.0=pyhd8ed1ab_0
+  - traitlets=5.8.1=pyhd8ed1ab_0
+  - typing-extensions=4.4.0=hd8ed1ab_0
   - typing_extensions=4.4.0=pyha770c72_0
   - tzcode=2022g=h166bdaf_0
   - tzdata=2022g=h191b570_0
-  - urllib3=1.26.13=pyhd8ed1ab_0
-  - wcwidth=0.2.5=pyh9f0ad1d_2
+  - urllib3=1.26.14=pyhd8ed1ab_0
+  - wcwidth=0.2.6=pyhd8ed1ab_0
   - wheel=0.38.4=pyhd8ed1ab_0
-  - xarray=2022.12.0=pyhd8ed1ab_0
+  - xarray=2023.1.0=pyhd8ed1ab_0
   - xerces-c=3.2.4=h55805fa_1
   - xlrd=2.0.1=pyhd8ed1ab_3
-  - xlsxwriter=3.0.3=pyhd8ed1ab_0
+  - xlsxwriter=3.0.7=pyhd8ed1ab_0
   - xmlrunner=1.7.7=py_0
   - xorg-fixesproto=5.0=h7f98852_1002
   - xorg-inputproto=2.3.2=h7f98852_1002
@@ -283,23 +286,23 @@ dependencies:
   - zict=2.2.0=pyhd8ed1ab_0
   - zipp=3.11.0=pyhd8ed1ab_0
   - zlib=1.2.13=h166bdaf_4
-  - zstd=1.5.2=h6239696_4
+  - zstd=1.5.2=h3eb15da_6
   - pip:
     - astroid==2.5
     - beautifulsoup4==4.11.1
     - bitstring==4.0.1
-    - bleach==5.0.1
-    - coverage==6.5.0
+    - bleach==6.0.0
+    - coverage==7.1.0
     - defusedxml==0.7.1
     - deprecation==2.1.0
     - descartes==1.1.0
     - docutils==0.17.1
     - fastjsonschema==2.16.2
-    - importlib-resources==5.10.1
-    - isort==5.10.1
+    - importlib-resources==5.10.2
+    - isort==5.11.4
     - jsonschema==4.17.3
     - jupyterlab-pygments==0.2.2
-    - lazy-object-proxy==1.8.0
+    - lazy-object-proxy==1.9.0
     - markdown==3.4.1
     - markdown-it-py==2.1.0
     - mccabe==0.6.1
@@ -308,9 +311,9 @@ dependencies:
     - mistune==2.0.4
     - myst-parser==0.18.1
     - nbclient==0.7.2
-    - nbconvert==7.2.6
-    - nbformat==5.7.0
-    - nbsphinx==0.8.10
+    - nbconvert==7.2.9
+    - nbformat==5.7.3
+    - nbsphinx==0.8.12
     - overpy==0.6
     - pandocfilters==1.5.0
     - peewee==3.15.4
@@ -318,7 +321,7 @@ dependencies:
     - pybufrkit==0.2.19
     - pydata-sphinx-theme==0.8.1
     - pylint==2.7.1
-    - pyrsistent==0.19.2
+    - pyrsistent==0.19.3
     - readthedocs-sphinx-ext==2.2.0
     - salib==1.3.12
     - soupsieve==2.3.2.post1


### PR DESCRIPTION
Changes proposed in this PR:
- Update `env_doc.yml` to include `sparse`
- 

This PR fixes the documentation. Currently, many of the module docs are missing because the `sparse` module is not part of the `env_doc.yml` specs. Without it, the respective Climada modules cannot be imported and the docstrings are not displayed in the documentation. This fails silently because the autodoc module only issues warnings. On the other hand, we cannot use `sphinx build -W` (which turns warnings into errors), because we have many other warnings during our build.

### PR Author Checklist

- [x] Read the [Contribution Guide][contrib]
- [x] Correct target branch selected (if unsure, select `develop`)
- [x] Source branch up-to-date with target branch
- [ ] [Documentation](https://climada-python.readthedocs.io/en/latest/guide/Guide_PythonDos-n-Donts.html#2.--Commenting-&-Documenting) updated
- [ ] [Tests][testing] updated
- [x] [Tests][testing] passing
- [x] No new [linter issues][linter]

### PR Reviewer Checklist

- [ ] Read the [Contribution Guide][contrib]
- [ ] [CLIMADA Reviewer Checklist](https://climada-python.readthedocs.io/en/latest/guide/Guide_Reviewer_Checklist.html) passed
- [ ] [Tests][testing] passing
- [ ] No new [linter issues][linter]

[contrib]: https://github.com/CLIMADA-project/climada_python/blob/main/CONTRIBUTING.md
[testing]: https://climada-python.readthedocs.io/en/latest/guide/Guide_Continuous_Integration_and_Testing.html
[linter]: https://climada-python.readthedocs.io/en/stable/guide/Guide_Continuous_Integration_and_Testing.html#3.C.--Static-Code-Analysis
