### PR TITLE
Small bugfix: infer projection from axis

### DIFF
--- a/climada/hazard/tc_tracks.py
+++ b/climada/hazard/tc_tracks.py
@@ -1234,6 +1234,8 @@ class TCTracks():
         if not axis:
             proj = ccrs.PlateCarree(central_longitude=mid_lon)
             _, axis, _ = u_plot.make_map(proj=proj, figsize=figsize, adapt_fontsize=adapt_fontsize)
+        else:
+            proj = axis.projection
         axis.set_extent(extent, crs=kwargs['transform'])
         u_plot.add_shapes(axis)
 


### PR DESCRIPTION
Changes proposed in this PR:
- Small bugfix: when plotting TCTracks onto an existing axis (passed to `TCTracks.plot`), the variable `proj` is missing. This PR fixes the problem by inferring the projection from the axis object.

This is a one-line fix. No changes to tests, documentation or changelog.

### PR Author Checklist

- [x] Read the [Contribution Guide][contrib]
- [x] Correct target branch selected (if unsure, select `develop`)
- [x] Source branch up-to-date with target branch
- [x] [Documentation](https://climada-python.readthedocs.io/en/latest/guide/Guide_PythonDos-n-Donts.html#2.--Commenting-&-Documenting) updated
- [x] [Tests][testing] updated
- [x] [Tests][testing] passing
- [x] No new [linter issues][linter]
- [x] [Changelog](https://github.com/CLIMADA-project/climada_python/blob/main/CHANGELOG.md) updated

### PR Reviewer Checklist

- [ ] Read the [Contribution Guide][contrib]
- [ ] [CLIMADA Reviewer Checklist](https://climada-python.readthedocs.io/en/latest/guide/Guide_Reviewer_Checklist.html) passed
- [ ] [Tests][testing] passing
- [ ] No new [linter issues][linter]

[contrib]: https://github.com/CLIMADA-project/climada_python/blob/main/CONTRIBUTING.md
[testing]: https://climada-python.readthedocs.io/en/latest/guide/Guide_Continuous_Integration_and_Testing.html
[linter]: https://climada-python.readthedocs.io/en/stable/guide/Guide_Continuous_Integration_and_Testing.html#3.C.--Static-Code-Analysis
