### PR TITLE
Feature/get stormtype from ibtracs

### DIFF
--- a/climada/hazard/tc_tracks.py
+++ b/climada/hazard/tc_tracks.py
@@ -1385,7 +1385,8 @@ class TCTracks():
             track = ds_dict[f'track{i}']
             track.attrs['orig_event_flag'] = bool(track.attrs['orig_event_flag'])
             # when writing '<U2' and reading in again, xarray reads as dtype 'object'. undo this:
-            track['basin'] = track['basin'].astype('<U2')
+            for varname in ['basin', 'nature']:
+                track[varname] = track[varname].astype('<U2')
             data.append(track)
         return cls(data)
 
@@ -1883,13 +1884,14 @@ def _read_ibtracs_csv_single(file_name):
     tr_ds['central_pressure'] = ('time', cen_pres)
     tr_ds['environmental_pressure'] = ('time', dfr['penv'].values.astype('float'))
     tr_ds['basin'] = ('time', dfr['gen_basin'].values.astype('<U2'))
-    tr_ds['nature'] = ('time', dfr['nature'].values.astype('<U2'))
     tr_ds.attrs['max_sustained_wind_unit'] = max_sus_wind_unit
     tr_ds.attrs['central_pressure_unit'] = 'mb'
     tr_ds.attrs['name'] = name
     tr_ds.attrs['sid'] = name
     tr_ds.attrs['orig_event_flag'] = bool(dfr['original_data']. values[0])
     tr_ds.attrs['data_provider'] = dfr['data_provider'].values[0]
+    if hasattr(dfr, 'nature'):
+        tr_ds['nature'] = ('time', dfr['nature'].values.astype('<U2'))
     try:
         tr_ds.attrs['id_no'] = float(name.replace('N', '0').replace('S', '1'))
     except ValueError:

--- a/climada/hazard/test/test_tc_tracks.py
+++ b/climada/hazard/test/test_tc_tracks.py
@@ -95,6 +95,7 @@ class TestIbtracs(unittest.TestCase):
         self.assertAlmostEqual(track_ds.central_pressure.values[0], 1008)
         self.assertAlmostEqual(track_ds.environmental_pressure.values[0], 1012)
         self.assertAlmostEqual(track_ds.radius_max_wind.values[0], 60)
+        self.assertEqual(track_ds.nature[0], 'TS')
         self.assertEqual(track_ds.time.size, 123)
 
         self.assertAlmostEqual(track_ds.lat.values[-1], 36.8, places=5)
@@ -103,6 +104,7 @@ class TestIbtracs(unittest.TestCase):
         self.assertAlmostEqual(track_ds.max_sustained_wind.values[-1], 15)
         self.assertAlmostEqual(track_ds.environmental_pressure.values[-1], 1008)
         self.assertAlmostEqual(track_ds.radius_max_wind.values[-1], 60)
+        self.assertEqual(track_ds.nature[-1], 'DS')
 
         self.assertFalse(np.isnan(track_ds.radius_max_wind.values).any())
         self.assertFalse(np.isnan(track_ds.environmental_pressure.values).any())
@@ -309,7 +311,7 @@ class TestIO(unittest.TestCase):
             np.testing.assert_array_equal(tr.basin, "SP")
 
     def test_hdf5_io(self):
-        """Test writting and reading hdf5 TCTracks instances"""
+        """Test writing and reading hdf5 TCTracks instances"""
         path = DATA_DIR.joinpath("tc_tracks.h5")
         tc_track = tc.TCTracks.from_ibtracs_netcdf(
             provider='usa', year_range=(1993, 1994), basin='EP', estimate_missing=True)


### PR DESCRIPTION
Changes proposed in this PR:
- When creating a trackset from IBTrACS also read the 'Nature' of a storm. The nature gives information about whether a system is a disturbance, tropical storm, post-transition extratropical storm, or subtropical storm (or whether agencies disagree or don't report). This is potentially useful in visualisations and for generating synthetic tracks.

**Notes:**
- Not urgent! We don't need this in time for the next release!
- Do we need a discussion? There are lots of variables that we exclude when reading from IBTrACS and we can't include them all. A more flexible alternative would be to add a keyword for 'other columns' you want from the file.
- The 'nature' variable is only explicitly created for tracksets from current IBTrACS (not olders csvs), and not for CHAZ, STORM, etc. It looks like there are already other properties that are IBTrACS-only, e.g radius of outermost closed isobar, so hopefully this is ok. I added a check for existence of the variable where relevant.
- When interpolating with `equal_timestep` I chose a forward fill method, rather than the default nearest neighbour.

### PR Author Checklist

- [x] Read the [Contribution Guide][contrib]
- [x] Correct target branch selected (if unsure, select `develop`)
- [x] Source branch up-to-date with target branch
- [x] [Documentation](https://climada-python.readthedocs.io/en/latest/guide/Guide_PythonDos-n-Donts.html#2.--Commenting-&-Documenting) updated
- [x] [Tests][testing] updated
- [x] [Tests][testing] passing
- [x] No new [linter issues][linter]
- [ ] [Changelog](https://github.com/CLIMADA-project/climada_python/blob/main/CHANGELOG.md) updated

### PR Reviewer Checklist

- [ ] Read the [Contribution Guide][contrib]
- [ ] [CLIMADA Reviewer Checklist](https://climada-python.readthedocs.io/en/latest/guide/Guide_Reviewer_Checklist.html) passed
- [ ] [Tests][testing] passing
- [ ] No new [linter issues][linter]

[contrib]: https://github.com/CLIMADA-project/climada_python/blob/main/CONTRIBUTING.md
[testing]: https://climada-python.readthedocs.io/en/latest/guide/Guide_Continuous_Integration_and_Testing.html
[linter]: https://climada-python.readthedocs.io/en/stable/guide/Guide_Continuous_Integration_and_Testing.html#3.C.--Static-Code-Analysis
