### PR TITLE
Fix Hazard.read_hdf5 for subclasses

### DIFF
--- a/climada/hazard/base.py
+++ b/climada/hazard/base.py
@@ -1812,7 +1812,7 @@ class Hazard():
         """This function is deprecated, use Hazard.from_hdf5."""
         LOGGER.warning("The use of Hazard.read_hdf5 is deprecated."
                        "Use Hazard.from_hdf5 instead.")
-        self.__dict__ = Hazard.from_hdf5(*args, **kwargs).__dict__
+        self.__dict__ = self.__class__.from_hdf5(*args, **kwargs).__dict__
 
     @classmethod
     def from_hdf5(cls, file_name):


### PR DESCRIPTION
Changes proposed in this PR:
- Fix the legacy `Hazard.read_hdf5` method to work correctly with derived classes, such as `TropCyclone.` Previously, when calling `haz.read_hdf5(...)` on a `TropCyclone` object, subclass-specific attributes such as `category` or `basin` would be missing from the result.

### PR Author Checklist

- [x] Read the [Contribution Guide][contrib]
- [x] Correct target branch selected (if unsure, select `develop`)
- [x] Source branch up-to-date with target branch
- [ ] [Documentation](https://climada-python.readthedocs.io/en/latest/guide/Guide_PythonDos-n-Donts.html#2.--Commenting-&-Documenting) updated
- [ ] [Tests][testing] updated
- [ ] [Tests][testing] passing
- [ ] No new [linter issues][linter]
- [ ] [Changelog](https://github.com/CLIMADA-project/climada_python/blob/main/CHANGELOG.md) updated

### PR Reviewer Checklist

- [x] Read the [Contribution Guide][contrib]
- [x] [CLIMADA Reviewer Checklist](https://climada-python.readthedocs.io/en/latest/guide/Guide_Reviewer_Checklist.html) passed
- [x] [Tests][testing] passing
- [x] No new [linter issues][linter]

[contrib]: https://github.com/CLIMADA-project/climada_python/blob/main/CONTRIBUTING.md
[testing]: https://climada-python.readthedocs.io/en/latest/guide/Guide_Continuous_Integration_and_Testing.html
[linter]: https://climada-python.readthedocs.io/en/stable/guide/Guide_Continuous_Integration_and_Testing.html#3.C.--Static-Code-Analysis
