### PR TITLE
Feature/coverage nightlight

### DIFF
--- a/climada/entity/exposures/litpop/nightlight.py
+++ b/climada/entity/exposures/litpop/nightlight.py
@@ -355,10 +355,10 @@ def load_nasa_nl_shape_single_tile(geometry, path, layer=0):
     with rasterio.open(path, 'r') as src:
         # read cropped data from  source file (src) to np.ndarray:
         out_image, transform = rasterio.mask.mask(src, [geometry], crop=True)
-        LOGGER.debug(f'Read cropped {path.name} as np.ndarray.')
+        LOGGER.debug('Read cropped %s as np.ndarray.', path.name)
         if out_image.shape[0] < layer:
-            raise IndexError(f"{path.name} has only {out_image.shape[0]} layers, layer {layer} can't"
-                             " be accessed.")
+            raise IndexError(f"{path.name} has only {out_image.shape[0]} layers,"
+                             f" layer {layer} can't be accessed.")
         meta = src.meta
         meta.update({"driver": "GTiff",
                     "height": out_image.shape[1],

--- a/climada/entity/exposures/litpop/nightlight.py
+++ b/climada/entity/exposures/litpop/nightlight.py
@@ -355,6 +355,10 @@ def load_nasa_nl_shape_single_tile(geometry, path, layer=0):
     with rasterio.open(path, 'r') as src:
         # read cropped data from  source file (src) to np.ndarray:
         out_image, transform = rasterio.mask.mask(src, [geometry], crop=True)
+        LOGGER.debug(f'Read cropped {path.name} as np.ndarray.')
+        if out_image.shape[0] < layer:
+            raise IndexError(f"{path.name} has only {out_image.shape[0]} layers, layer {layer} can't"
+                             " be accessed.")
         meta = src.meta
         meta.update({"driver": "GTiff",
                     "height": out_image.shape[1],

--- a/climada/entity/exposures/litpop/nightlight.py
+++ b/climada/entity/exposures/litpop/nightlight.py
@@ -200,15 +200,15 @@ def get_required_nl_files(bounds):
 
     # Now latitude. The height of all tiles is the same as the height.
     # Note that for this analysis returns an index which follows from North to South oritentation.
-    first_tile_lat = min(np.floor(-(min_lat - (90)) / tile_width), 1)
+    first_tile_lat = min(np.floor(-(min_lat - 90) / tile_width), 1)
     last_tile_lat = min(np.floor(-(max_lat - 90) / tile_width), 1)
 
     for i_lon in range(0, int(len(req_files) / 2)):
         if first_tile_lon <= i_lon <= last_tile_lon:
             if first_tile_lat == 0 or last_tile_lat == 0:
-                req_files[((i_lon)) * 2] = 1
+                req_files[(i_lon) * 2] = 1
             if first_tile_lat == 1 or last_tile_lat == 1:
-                req_files[((i_lon)) * 2 + 1] = 1
+                req_files[(i_lon) * 2 + 1] = 1
         else:
             continue
     return req_files

--- a/climada/entity/exposures/test/test_nightlight.py
+++ b/climada/entity/exposures/test/test_nightlight.py
@@ -79,6 +79,44 @@ class TestNightLight(unittest.TestCase):
         # The same length but not the correct length
         self.assertRaises(ValueError, nightlight.download_nl_files, (1, 0, 1), (1, 1, 1))
 
+    def test_get_required_nl_files(self):
+        """ get_required_nl_files return a boolean matrix of 0 and 1
+            indicating which tile of NASA nighlight files are needed giving
+            a bounding box. This test check a few configuration of tiles
+            and check that a value error is raised if the bounding box are 
+            incorrect """
+
+        # incorrect bounds: bounds size =!  4, min lon > max lon, min lat > min lat
+        BOUNDS = [(20, 30, 40), 
+                  (120, -20, 110, 30), 
+                  (-120, 50, 130, 10)]
+        # correct bounds
+        bounds_c1 = (-120, -20, 0, 40)
+        bounds_c2 = (-70, -20, 10, 40)
+        bounds_c3 = (160, 10, 180, 40)
+
+        for bounds in BOUNDS:
+            with self.assertRaises(ValueError) as cm:
+    
+                nightlight.get_required_nl_files(bounds = bounds)
+
+                self.assertEqual('Invalid bounds supplied. `bounds` must be tuple'
+                                ' with (min_lon, min_lat, max_lon, max_lat).',
+                                str(cm.exception))
+        
+        # test first correct bounds configurations
+        req_files = nightlight.get_required_nl_files(bounds = bounds_c1)
+        bool = np.array_equal(np.array([1, 1, 1, 1, 1, 1, 0, 0]), req_files)
+        self.assertTrue(bool)
+        # second correct configuration
+        req_files = nightlight.get_required_nl_files(bounds = bounds_c2)
+        bool = np.array_equal(np.array([0, 0, 1, 1, 1, 1, 0, 0]), req_files)
+        self.assertTrue(bool)
+        # third correct configuration
+        req_files = nightlight.get_required_nl_files(bounds = bounds_c3)
+        bool = np.array_equal(np.array([0, 0, 0, 0, 0, 0, 1, 0]), req_files)
+        self.assertTrue(bool)
+
 # Execute Tests
 if __name__ == "__main__":
     TESTS = unittest.TestLoader().loadTestsFromTestCase(TestNightLight)

--- a/climada/entity/exposures/test/test_nightlight.py
+++ b/climada/entity/exposures/test/test_nightlight.py
@@ -132,7 +132,7 @@ class TestNightLight(unittest.TestCase):
         with self.assertLogs('climada.entity.exposures.litpop.nightlight', level = 'DEBUG') as cm:
             nightlight.check_nl_local_file_exists()
         self.assertIn('Not all satellite files available. '
-                     f'Found 2 out of 8 required files in {Path(SYSTEM_DIR)}', cm.output[0])
+                     f'Found 5 out of 8 required files in {Path(SYSTEM_DIR)}', cm.output[0])
             
         # check logger message: no files found in checkpath 
         with self.assertLogs('climada.entity.exposures.litpop.nightlight', level = 'INFO') as cm:

--- a/climada/entity/exposures/test/test_nightlight.py
+++ b/climada/entity/exposures/test/test_nightlight.py
@@ -147,11 +147,7 @@ class TestNightLight(unittest.TestCase):
 
         # test that files_exist is correct 
         files_exist = nightlight.check_nl_local_file_exists()
-        index_files = np.where(files_exist == 1)
-        self.assertEqual(int(sum(files_exist)), 2)
-        self.assertEqual(BM_FILENAMES[index_files[0][0]], 'BlackMarble_%i_B1_geo_gray.tif')
-        self.assertEqual(BM_FILENAMES[index_files[0][1]], 'BlackMarble_%i_C1_geo_gray.tif')
-        
+        self.assertEqual(int(sum(files_exist)), 5)
 
 # Execute Tests
 if __name__ == "__main__":

--- a/climada/test/test_litpop_integr.py
+++ b/climada/test/test_litpop_integr.py
@@ -278,7 +278,11 @@ class TestGPWPopulation(unittest.TestCase):
             self.assertEqual(data.shape, (31, 36))
             self.assertAlmostEqual(meta['transform'][0], 0.00833333333333333)
             self.assertAlmostEqual(meta['transform'][0], glb_transform[0])
-
+            self.assertEqual(meta['driver'], 'GTiff')
+            self.assertEqual(meta['height'], data.shape[0])
+            self.assertEqual(meta['width'], data.shape[1])
+            self.assertIsInstance(data, np.ndarray)
+            self.assertEqual(len(data.shape), 2) 
         except FileExistsError as err:
             self.assertIn('lease download', err.args[0])
             self.skipTest('GPW input data for GPW v4.%i not found.' %(gpw_version))

--- a/climada/test/test_litpop_integr.py
+++ b/climada/test/test_litpop_integr.py
@@ -29,6 +29,13 @@ import climada.util.coordinates as u_coord
 from climada.util.constants import SYSTEM_DIR
 from climada import CONFIG
 
+bounds = (8.41, 47.2, 8.70, 47.45) # (min_lon, max_lon, min_lat, max_lat)
+shape = Polygon([
+    (bounds[0], bounds[3]),
+    (bounds[2], bounds[3]),
+    (bounds[2], bounds[1]),
+    (bounds[0], bounds[1])
+    ])
 
 class TestLitPopExposure(unittest.TestCase):
     """Test LitPop exposure data model:"""
@@ -122,14 +129,7 @@ class TestLitPopExposure(unittest.TestCase):
     def test_from_shape_zurich_pass(self):
         """test initiating LitPop for custom shape (square around Zurich City)
         Distributing an imaginary total value of 1000 USD"""
-        bounds = (8.41, 47.2, 8.70, 47.45) # (min_lon, max_lon, min_lat, max_lat)
         total_value=1000
-        shape = Polygon([
-            (bounds[0], bounds[3]),
-            (bounds[2], bounds[3]),
-            (bounds[2], bounds[1]),
-            (bounds[0], bounds[1])
-            ])
         ent = lp.LitPop.from_shape(shape, total_value, res_arcsec=30, reference_year=2016)
         self.assertEqual(ent.gdf.value.sum(), 1000.0)
         self.assertEqual(ent.gdf.value.min(), 0.0)
@@ -144,13 +144,7 @@ class TestLitPopExposure(unittest.TestCase):
     def test_from_shape_and_countries_zurich_pass(self):
         """test initiating LitPop for custom shape (square around Zurich City)
         with from_shape_and_countries()"""
-        bounds = (8.41, 47.2, 8.70, 47.45) # (min_lon, max_lon, min_lat, max_lat)
-        shape = Polygon([
-            (bounds[0], bounds[3]),
-            (bounds[2], bounds[3]),
-            (bounds[2], bounds[1]),
-            (bounds[0], bounds[1])
-            ])
+        
         ent = lp.LitPop.from_shape_and_countries(
             shape, 'Switzerland', res_arcsec=30, reference_year=2016)
         self.assertEqual(ent.gdf.value.min(), 0.0)
@@ -185,6 +179,46 @@ class TestLitPopExposure(unittest.TestCase):
         self.assertEqual(ent.value_unit, 'people')
         self.assertAlmostEqual(ent.gdf.latitude.max(), 47.2541666666666)
         self.assertAlmostEqual(ent.meta['transform'][0], 30/3600)
+
+    def test_from_nightlight_intensity(self):
+        """ Test raises, logger and if methods from_countries and from_shape are 
+            are used."""
+
+        with self.assertRaises(ValueError) as cm:
+            lp.LitPop.from_nightlight_intensity()
+        self.assertEqual('Either `countries` or `shape` required. Aborting.', str(cm.exception))
+
+        with self.assertRaises(ValueError) as cm:
+            lp.LitPop.from_nightlight_intensity(countries = 'Liechtenstein', shape = shape)
+        self.assertEqual('Not allowed to set both `countries` and `shape`. Aborting.', str(cm.exception))
+        
+        exp = lp.LitPop.from_nightlight_intensity(countries = 'Liechtenstein') 
+        self.assertEqual(exp.fin_mode, 'none')
+
+        exp = lp.LitPop.from_nightlight_intensity(shape = shape) 
+        self.assertEqual(exp.value_unit, '')
+        
+        with self.assertLogs('climada.entity.exposures.litpop.litpop', level = 'WARNING') as cm:
+            lp.LitPop.from_nightlight_intensity(shape = shape)
+        self.assertIn('Note: set_nightlight_intensity sets values to raw nightlight intensity,', cm.output[0])
+
+    def test_from_population(self):
+        """ Test raises, logger and if methods from_countries and from_shape are 
+            are used."""
+
+        with self.assertRaises(ValueError) as cm:
+            lp.LitPop.from_population()
+        self.assertEqual('Either `countries` or `shape` required. Aborting.', str(cm.exception))
+
+        exp = lp.LitPop.from_population(countries = 'Liechtenstein') 
+        self.assertEqual(exp.fin_mode, 'pop')
+
+        exp = lp.LitPop.from_population(shape = shape) 
+        self.assertEqual(exp.value_unit, 'people')
+
+        with self.assertRaises(ValueError) as cm:
+            lp.LitPop.from_population(countries = 'Liechtenstein', shape = shape)
+        self.assertEqual('Not allowed to set both `countries` and `shape`. Aborting.', str(cm.exception))        
 
 class TestAdmin1(unittest.TestCase):
     """Test the admin1 functionalities within the LitPop module"""
@@ -265,13 +299,6 @@ class TestGPWPopulation(unittest.TestCase):
     def test_load_gpw_pop_shape_pass(self):
         """test method gpw_population.load_gpw_pop_shape"""
         gpw_version = CONFIG.exposures.litpop.gpw_population.gpw_version.int()
-        bounds = (8.41, 47.2, 8.70, 47.45) # (min_lon, max_lon, min_lat, max_lat)
-        shape = Polygon([
-            (bounds[0], bounds[3]),
-            (bounds[2], bounds[3]),
-            (bounds[2], bounds[1]),
-            (bounds[0], bounds[1])
-            ])
         try:
             data, meta, glb_transform = \
                 gpw_population.load_gpw_pop_shape(shape, 2020, gpw_version, verbose=False)

--- a/climada/test/test_nightlight.py
+++ b/climada/test/test_nightlight.py
@@ -20,21 +20,22 @@ Tests on Black marble.
 """
 
 import unittest
-import gzip
-import shutil
 import os
-from tempfile import TemporaryDirectory
-
+import tarfile
+import affine
 import numpy as np
 import scipy.sparse as sparse
-from shapely.geometry import Polygon
 
-from climada.entity.exposures.litpop import nightlight
+from shapely.geometry import Polygon
+from pathlib import Path
+from tempfile import TemporaryDirectory
 from osgeo import gdal
+from climada.entity.exposures.litpop import nightlight
 from climada.util.constants import (SYSTEM_DIR, CONFIG)
-from climada.util import files_handler
+from climada.util import (files_handler, ureg)
 
 BM_FILENAMES = nightlight.BM_FILENAMES
+NOAA_RESOLUTION_DEG = (30 * ureg.arc_second).to(ureg.deg).magnitude
 
 def init_test_shape():
     bounds = (14.18, 35.78, 14.58, 36.09)
@@ -50,38 +51,55 @@ def init_test_shape():
 class TestNightlight(unittest.TestCase):
     """Test litpop.nightlight"""
 
-    def test_load_nasa_nl_shape_single_tile_pass(self):
-        """load_nasa_nl_shape_single_tile pass"""
-        bounds, shape = init_test_shape()
+    def test_load_nasa_nl_shape_single_tile(self):
+        """ Test that the function returns a np.ndarray containing 
+            the cropped .tif image values. Test that
+            just one layer is returned. """
 
-    def test_load_nasa_nl_2016_shape_pass(self):
-        """load_nasa_nl_shape_single_tile pass"""
-        bounds, shape = init_test_shape()
-        nightlight.load_nasa_nl_shape(shape, 2016, data_dir=SYSTEM_DIR, dtype=None)
+        # Initialization
+        path = Path(SYSTEM_DIR, 'BlackMarble_2016_C1_geo_gray.tif')
+        _, shape = init_test_shape()
 
-        # data, meta = nightlight.load_nasa_nl_shape_single_tile(shape, path, layer=0):
+        # Test cropped output
+        out_image, meta = nightlight.load_nasa_nl_shape_single_tile(geometry = shape, path = path)
+        self.assertIsInstance(out_image, np.ndarray)
+        self.assertEqual(len(out_image.shape), 2) 
 
+        # Test meta ouput
+        self.assertEqual(meta['height'],out_image.shape[0])
+        self.assertEqual(meta['width'],out_image.shape[1])
+        self.assertEqual(meta['driver'], 'GTiff')
+        self.assertEqual(meta['transform'], affine.Affine(0.004166666666666667, 0.0, 14.179166666666667,
+                                                            0.0, -0.004166666666666667, 36.09166666666667))
+        # Test raises
+        with self.assertRaises(IndexError) as cm:
+            nightlight.load_nasa_nl_shape_single_tile(geometry = shape, path = path, layer = 4)
+        self.assertEqual("BlackMarble_2016_C1_geo_gray.tif has only 3 layers, layer 4 can't be accessed.",
+                        str(cm.exception))
+        # Test logger
+        with self.assertLogs('climada.entity.exposures.litpop.nightlight', level='DEBUG') as cm:
+            nightlight.load_nasa_nl_shape_single_tile(geometry = shape, path = path)
+        self.assertIn('Read cropped BlackMarble_2016_C1_geo_gray.tif as np.ndarray.', cm.output[0])
+        
     def test_read_bm_files(self):
         """" Test that read_bm_files function read NASA BlackMarble GeoTiff and output
              an array and a gdal DataSet."""
-        # Create a temporary directory and the associated path
-        temp_dir = TemporaryDirectory()
+        
         # Download 'BlackMarble_2016_A1_geo_gray.tif' in the temporary directory and create a path
+        temp_dir = TemporaryDirectory()
         urls = CONFIG.exposures.litpop.nightlights.nasa_sites.list()
         url = str(urls[0]) + 'BlackMarble_2016_A1_geo_gray.tif'
-        files_handler.download_file(url=url, download_dir=temp_dir.name)
-
+        files_handler.download_file(url = url, download_dir = temp_dir.name)
         filename = 'BlackMarble_2016_A1_geo_gray.tif'
-        # Check that the array and gdal DataSet are returned
+
+        # Test logger
         with self.assertLogs('climada.entity.exposures.litpop.nightlight', level='DEBUG') as cm:
             arr1, curr_file = nightlight.read_bm_file(bm_path=temp_dir.name, filename=filename)
-        # Check correct logging
         self.assertIn('Importing' + temp_dir.name, cm.output[0])
 
-        # Check that the outputs are a numpy array and a gdal DataSet
+        # Check outputs are a np.array and a gdal DataSet and band 1 is selected
         self.assertIsInstance(arr1, np.ndarray)
         self.assertIsInstance(curr_file, gdal.Dataset)
-        # Check that the correct band is selected
         self.assertEqual(curr_file.GetRasterBand(1).DataType, 1)
 
         # Release dataset, so the GC can close the file
@@ -92,15 +110,13 @@ class TestNightlight(unittest.TestCase):
             nightlight.read_bm_file(bm_path='/Wrong/path/file.tif', filename='file.tif')
         self.assertEqual('Invalid path: check that the path to BlackMarble file is correct.',
                       str(cm.exception))
-
-        # delete the temporary repository
         temp_dir.cleanup()
 
     def test_download_nl_files(self):
         """ Test that BlackMarble GeoTiff files are downloaded. """
-        # Create a temporary directory and the associated path
-        temp_dir = TemporaryDirectory()
+        
         # Test Raises
+        temp_dir = TemporaryDirectory()
         with self.assertRaises(ValueError) as cm:
             nightlight.download_nl_files(req_files=np.ones(5),
                                         files_exist=np.zeros(4),
@@ -118,36 +134,100 @@ class TestNightlight(unittest.TestCase):
                                         files_exist=np.ones(len(BM_FILENAMES),),
                                         dwnl_path=temp_dir.name, year=2016)
             self.assertIn('All required files already exist. No downloads necessary.', cm.output[0])
-        # Test the download
+
+        # Test download
         with self.assertLogs('climada.entity.exposures.litpop.nightlight', level='DEBUG') as cm:
             dwl_path = nightlight.download_nl_files(req_files=np.array([1, 0, 0, 0, 0, 0, 0, 0]),
                                         files_exist=np.array([0, 1, 1, 1, 1, 1, 1, 1]),
                                         dwnl_path=temp_dir.name)
-            self.assertIn('Attempting to download file from '
+        self.assertIn('Attempting to download file from '
                         'https://eoimages.gsfc.nasa.gov/images/imagerecords/'
                         '144000/144897/BlackMarble_2016_A1_geo_gray.tif', cm.output[0])
-            #Test if dwl_path has been returned
-            self.assertEqual(temp_dir.name, dwl_path)
-        # Delete the temporary repository
+        # Test if dwl_path has been returned
+        self.assertEqual(temp_dir.name, dwl_path)
         temp_dir.cleanup()
 
     def test_unzip_tif_to_py(self):
-        """ Test that .gz files are unzipped and read as a sparse matrix """
-        # compress a demo .tif file to .gz
-        path_file_tif = 'data/demo/earth_engine/dresden.tif'
-        with open(path_file_tif, 'rb') as f_in:
-            with gzip.open('dresden.tif.gz','wb') as f_out:
-                shutil.copyfileobj(f_in, f_out)
-        # test LOGGER
+        """ Test that .gz files are unzipped and read as a sparse matrix, 
+            file_name is correct and logger message recorded. """
+
+        path_file_tif_gz = str(Path(SYSTEM_DIR, 'F182013.v4c_web.stable_lights.avg_vis.tif.gz'))
         with self.assertLogs('climada.entity.exposures.litpop.nightlight', level='INFO') as cm:
-            file_name, night=nightlight.unzip_tif_to_py('dresden.tif.gz')
-            self.assertIn('Unzipping file dresden.tif', cm.output[0])
-        # test file_name
-            self.assertEqual(str(file_name), 'dresden.tif')
-        # test the sparse matrix
-            self.assertIsInstance(night, sparse._csr.csr_matrix)
-        # delate the created demo .gz file
-        os.remove('dresden.tif.gz')
+            file_name, night = nightlight.unzip_tif_to_py(path_file_tif_gz)
+        self.assertIn(f'Unzipping file {path_file_tif_gz}', cm.output[0])
+        self.assertEqual(str(file_name), 'F182013.v4c_web.stable_lights.avg_vis.tif')
+        self.assertIsInstance(night, sparse._csr.csr_matrix)
+        os.remove(Path(SYSTEM_DIR, 'F182013.v4c_web.stable_lights.avg_vis.p'))
+
+    def test_load_nightlight_noaa(self):
+        """ Test that data is downloaded if not present in SYSTEM_DIR,
+            or not downloaded if present. Test the three outputs of the
+            function."""
+
+        # Using an already existing file and without providing arguments
+        night, coord_nl, fn_light = nightlight.load_nightlight_noaa()
+        self.assertIsInstance(night, sparse._csr.csr_matrix)
+        self.assertIn('F182013.v4c_web.stable_lights.avg_vis.tif',str(fn_light))
+        self.assertTrue(np.array_equal(np.array([[-65,NOAA_RESOLUTION_DEG],
+                                    [-180, NOAA_RESOLUTION_DEG]]),coord_nl))
+        os.remove(SYSTEM_DIR.joinpath('F182013.v4c_web.stable_lights.avg_vis.p'))
+        # With arguments
+        night, coord_nl, fn_light = nightlight.load_nightlight_noaa(ref_year = 2010, sat_name = 'F18')
+        self.assertIsInstance(night, sparse._csr.csr_matrix)
+        self.assertIn('F182010.v4d_web.stable_lights.avg_vis', str(fn_light))
+        file = str(SYSTEM_DIR.joinpath('F182010.v4d_web.stable_lights.avg_vis.p')) 
+        os.remove(file)
+
+        # Test raises from wrong input agruments
+        with self.assertRaises(ValueError) as cm:
+            night, coord_nl, fn_light = nightlight.load_nightlight_noaa(
+                                            ref_year = 2050, sat_name = 'F150')
+        self.assertEqual('Nightlight intensities for year 2050 and satellite F150 do not exist.', 
+                            str(cm.exception))
+
+    def test_untar_noaa_stable_nighlight(self):
+        """ Testing that input .tar file is moved into SYSTEM_DIR, 
+            tif.gz file is extracted from .tar file and moved into SYSTEM_DIR, 
+            exception are raised when no .tif.gz file is present in the tar file,
+            and the logger message is recorded if more then one .tif.gz is present in 
+            .tar file. """
+
+        # Create path to .tif.gz and .csv files already existing in SYSTEM_DIR
+        path_tif_gz_1 = Path(SYSTEM_DIR, 'F182013.v4c_web.stable_lights.avg_vis.tif.gz') 
+        path_csv = Path(SYSTEM_DIR, 'GDP_TWN_IMF_WEO_data.csv')  
+        path_tar = Path(SYSTEM_DIR, 'sample.tar')  
+
+        # Create .tar file and add .tif.gz and .csv 
+        file_tar = tarfile.open(path_tar, "w") #create the tar file
+        file_tar.add(name = path_tif_gz_1, recursive = False, arcname = 'F182013.v4c_web.stable_lights.avg_vis.tif.gz') 
+        file_tar.close()
+
+        # Test that the files has been moved
+        path_to_test = nightlight.untar_noaa_stable_nightlight(path_tar)
+        self.assertTrue(path_to_test.exists())
+        self.assertTrue(path_tar .exists())
+        os.remove(path_tar)
+
+        # Put no .tif.gz file in .tar file and check raises
+        path_tar = Path(SYSTEM_DIR, 'sample.tar') 
+        file_tar = tarfile.open(path_tar, "w") #create the tar file
+        file_tar.add(name = path_csv, recursive = False, arcname ='GDP_TWN_IMF_WEO_data.csv' ) 
+        file_tar.close()
+        with self.assertRaises(ValueError) as cm:
+            nightlight.untar_noaa_stable_nightlight(path_tar)
+        self.assertEqual('No stable light intensities for selected year and satellite '
+                            f'in file {path_tar}',str(cm.exception))
+        os.remove(path_tar)
+
+        # Test logger with having two .tif.gz file in .tar file  
+        file_tar = tarfile.open(path_tar, "w") #create the tar file
+        file_tar.add(name = path_tif_gz_1, recursive = False, arcname = 'F182013.v4c_web.stable_lights.avg_vis.tif.gz' ) 
+        file_tar.add(name = path_tif_gz_1, recursive = False, arcname = 'F182013.v4c_web.stable_lights.avg_vis.tif.gz' ) 
+        file_tar.close()
+        with self.assertLogs('climada.entity.exposures.litpop.nightlight', level = 'WARNING') as cm:
+            nightlight.untar_noaa_stable_nightlight(path_tar)
+        self.assertIn('found more than one potential intensity file in', cm.output[0])
+        os.remove(path_tar)
 
 # Execute Tests
 if __name__ == "__main__":


### PR DESCRIPTION
Changes proposed in this PR:

Add coverage tests for `climada/entity/exposures/litpop/nightlight.py`

For nightlight:

1) Add tests for functions:
       - `load_nasa_nl_shape_single_tile`
       - `load_nightlight_noaa`
       - `untar_noaa_stable_nighlight`
       - `get_required_nl_files`
       - `check_nl_local_file exist`
2) Add raises message if wrong layer is selected in function: `load_nasa_nl_shape_single_tile`
3) Add logger message in function: `load_nasa_nl_shape_single_tile`
4)  Correct test: `test_unzip_tif_to_py`
5)  Apply uniform formatting across all tests of `nightlight.py` module

For litpop:

1) Add additional tests for functions: 
       -  `from_nightlight_intensity`
       -  `from_population`
    


### PR Author Checklist

- [x] Read the [Contribution Guide][contrib]
- [x] Correct target branch selected (if unsure, select `develop`)
- [x] Descriptive pull request title added
- [x] Source branch up-to-date with target branch
- [x] [Documentation](https://climada-python.readthedocs.io/en/latest/guide/Guide_PythonDos-n-Donts.html#2.--Commenting-&-Documenting) updated
- [x] [Tests][testing] updated
- [x] [Tests][testing] passing
- [x] No new [linter issues][linter]
- [ ] [Changelog](https://github.com/CLIMADA-project/climada_python/blob/main/CHANGELOG.md) updated

### PR Reviewer Checklist

- [x] Read the [Contribution Guide][contrib]
- [x] [CLIMADA Reviewer Checklist](https://climada-python.readthedocs.io/en/latest/guide/Guide_Reviewer_Checklist.html) passed
- [x] [Tests][testing] passing
- [x] No new [linter issues][linter]

[contrib]: https://github.com/CLIMADA-project/climada_python/blob/main/CONTRIBUTING.md
[testing]: https://climada-python.readthedocs.io/en/latest/guide/Guide_Continuous_Integration_and_Testing.html
[linter]: https://climada-python.readthedocs.io/en/stable/guide/Guide_Continuous_Integration_and_Testing.html#3.C.--Static-Code-Analysis
