### PR TITLE
Don't re-project projected polygon gdfs in metre-disaggregation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,10 @@ Removed:
 
 - `Impact.impact_at_reg` method for aggregating impacts per country or custom region [#642](https://github.com/CLIMADA-project/climada_python/pull/642)
 
-### Changed
+### Changed 
 
 ### Fixed
+- `util.lines_polys_handler` solve polygon disaggregation issue in metre-based projection   [#666](https://github.com/CLIMADA-project/climada_python/pull/666)
 
 ### Deprecated
 

--- a/climada/util/lines_polys_handler.py
+++ b/climada/util/lines_polys_handler.py
@@ -970,7 +970,9 @@ def _pnts_per_line(length, res):
 
 def _swap_geom_cols(gdf, geom_to, new_geom):
     """
-    Change which column is the geometry column
+    Change which column is the geometry column.
+    Conserves the crs of the original geometry column.
+
     Parameters
     ----------
     gdf : gpd.GeoDataFrame
@@ -987,7 +989,7 @@ def _swap_geom_cols(gdf, geom_to, new_geom):
     """
     gdf_swap = gdf.rename(columns = {'geometry': geom_to})
     gdf_swap.rename(columns = {new_geom: 'geometry'}, inplace=True)
-    gdf_swap.set_geometry('geometry', inplace=True)
+    gdf_swap.set_geometry('geometry', inplace=True, crs=gdf.crs)
     return gdf_swap
 
 

--- a/climada/util/lines_polys_handler.py
+++ b/climada/util/lines_polys_handler.py
@@ -38,8 +38,8 @@ class DisaggMethod(Enum):
     """
     Disaggregation Method for the ... function
 
-	DIV : the geometry's distributed to equal parts over all its interpolated points
-	FIX : the geometry's value is replicated over all its interpolated points
+    DIV : the geometry's distributed to equal parts over all its interpolated points
+    FIX : the geometry's value is replicated over all its interpolated points
     """
     DIV = 'div'
     FIX = 'fix'
@@ -49,7 +49,7 @@ class AggMethod(Enum):
     """
     Aggregation Method for the aggregate_impact_mat function
 
-	SUM : the impact is summed over all points in the polygon/line
+    SUM : the impact is summed over all points in the polygon/line
     """
     SUM = 'sum'
 
@@ -649,7 +649,7 @@ def _poly_to_pnts(gdf, res, to_meters):
     """
 
     if gdf.empty:
-        return gdf 
+        return gdf
 
     # Needed because gdf.explode(index_parts=True) requires numeric index
     idx = gdf.index.to_list() #To restore the naming of the index

--- a/climada/util/lines_polys_handler.py
+++ b/climada/util/lines_polys_handler.py
@@ -656,7 +656,8 @@ def _poly_to_pnts(gdf, res, to_meters):
 
     gdf_points = gdf.copy().reset_index(drop=True)
 
-    if to_meters & ~(gdf.geometry.crs.is_projected):
+    # Check if we need to reproject
+    if to_meters and not gdf.geometry.crs.is_projected:
         gdf_points['geometry_pnt'] = gdf_points.apply(
             lambda row: _interp_one_poly_m(row.geometry, res, gdf.crs), axis=1)
     else:

--- a/climada/util/lines_polys_handler.py
+++ b/climada/util/lines_polys_handler.py
@@ -649,14 +649,14 @@ def _poly_to_pnts(gdf, res, to_meters):
     """
 
     if gdf.empty:
-        return gdf
+        return gdf 
 
     # Needed because gdf.explode(index_parts=True) requires numeric index
     idx = gdf.index.to_list() #To restore the naming of the index
 
     gdf_points = gdf.copy().reset_index(drop=True)
 
-    if to_meters:
+    if to_meters & ~(gdf.geometry.crs.is_projected):
         gdf_points['geometry_pnt'] = gdf_points.apply(
             lambda row: _interp_one_poly_m(row.geometry, res, gdf.crs), axis=1)
     else:

--- a/climada/util/test/test_lines_polys_handler.py
+++ b/climada/util/test/test_lines_polys_handler.py
@@ -183,6 +183,10 @@ class TestExposureGeomToPnt(unittest.TestCase):
         _interp_one_poly_m.assert_called()
         _interp_one_poly.assert_not_called()
 
+        # Reset mocks
+        _interp_one_poly.reset_mock()
+        _interp_one_poly_m.reset_mock()
+
         # Use projected CRS
         EXP_POLY_PROJ = Exposures(GDF_POLY.to_crs(epsg=28992))
         u_lp.exp_geom_to_pnt(

--- a/climada/util/test/test_lines_polys_handler.py
+++ b/climada/util/test/test_lines_polys_handler.py
@@ -144,8 +144,7 @@ class TestExposureGeomToPnt(unittest.TestCase):
 
         #projected crs, to_meters=TRUE, FIX, dissag_val
         res = 20000
-        GDF_POLY_PROJ = GDF_POLY.to_crs(epsg=28992)
-        EXP_POLY_PROJ = Exposures(GDF_POLY_PROJ)
+        EXP_POLY_PROJ = Exposures(GDF_POLY.to_crs(epsg=28992))
         exp_pnt = u_lp.exp_geom_to_pnt(
             EXP_POLY_PROJ, res=res, to_meters=True,
             disagg_met=u_lp.DisaggMethod.FIX, disagg_val=res**2

--- a/climada/util/test/test_lines_polys_handler.py
+++ b/climada/util/test/test_lines_polys_handler.py
@@ -143,6 +143,25 @@ class TestExposureGeomToPnt(unittest.TestCase):
             52.55795685, 52.55795685, 52.23308448, 52.23308448
             ])
         np.testing.assert_allclose(exp_pnt.gdf.latitude, lat)
+        
+        #projected crs, to_meters=TRUE, FIX, dissag_val
+        res = 20000
+        EXP_POLY_PROJ = Exposures(GDF_POLY.to_crs(epsg=28992))
+        exp_pnt = u_lp.exp_geom_to_pnt(
+            EXP_POLY_PROJ, res=res, to_meters=True,
+            disagg_met=u_lp.DisaggMethod.FIX, disagg_val=res**2
+            )
+        self.check_unchanged_exp(EXP_POLY_PROJ, exp_pnt)
+        val = res**2
+        self.assertEqual(np.unique(exp_pnt.gdf.value)[0], val)
+        lat = np.array([574891.12225222, 547411.67251407, 499789.43052324,
+                        460177.36473906, 364182.25061015, 369862.57549558,
+                        394014.84676059, 444749.18166595, 514229.75466288,
+                        568740.1294081 , 507005.3662343 , 458457.48789088])
+        np.testing.assert_allclose(
+            exp_pnt.gdf.groupby(level=[0])['latitude'].nth(0).values,
+            lat, atol=100000)
+
 
     def test_point_exposure_from_polygons_on_grid(self):
         """Test disaggregation of polygons to points on grid"""

--- a/climada/util/test/test_lines_polys_handler.py
+++ b/climada/util/test/test_lines_polys_handler.py
@@ -20,7 +20,6 @@ Test of lines_polys_handler
 """
 
 import unittest
-from pathlib import Path
 
 import numpy as np
 
@@ -29,7 +28,6 @@ import climada.util.lines_polys_handler as u_lp
 import climada.util.coordinates as u_coord
 from climada.util.api_client import Client
 from climada.engine import Impact, ImpactCalc
-from climada.hazard import Hazard
 from climada.entity.impact_funcs import ImpactFuncSet
 from climada.entity.impact_funcs.storm_europe import ImpfStormEurope
 
@@ -154,13 +152,7 @@ class TestExposureGeomToPnt(unittest.TestCase):
         self.check_unchanged_exp(EXP_POLY_PROJ, exp_pnt)
         val = res**2
         self.assertEqual(np.unique(exp_pnt.gdf.value)[0], val)
-        lat = np.array([574891.12225222, 547411.67251407, 499789.43052324,
-                        460177.36473906, 364182.25061015, 369862.57549558,
-                        394014.84676059, 444749.18166595, 514229.75466288,
-                        568740.1294081 , 507005.3662343 , 458457.48789088])
-        np.testing.assert_allclose(
-            exp_pnt.gdf.groupby(level=[0])['latitude'].nth(0).values,
-            lat, atol=100000)
+        self.assertEqual(exp_pnt.gdf.crs, EXP_POLY_PROJ.gdf.crs)
 
 
     def test_point_exposure_from_polygons_on_grid(self):

--- a/climada/util/test/test_lines_polys_handler.py
+++ b/climada/util/test/test_lines_polys_handler.py
@@ -144,7 +144,8 @@ class TestExposureGeomToPnt(unittest.TestCase):
 
         #projected crs, to_meters=TRUE, FIX, dissag_val
         res = 20000
-        EXP_POLY_PROJ = Exposures(GDF_POLY.to_crs(epsg=28992))
+        GDF_POLY_PROJ = GDF_POLY.to_crs(epsg=28992)
+        EXP_POLY_PROJ = Exposures(GDF_POLY_PROJ)
         exp_pnt = u_lp.exp_geom_to_pnt(
             EXP_POLY_PROJ, res=res, to_meters=True,
             disagg_met=u_lp.DisaggMethod.FIX, disagg_val=res**2

--- a/climada/util/test/test_lines_polys_handler.py
+++ b/climada/util/test/test_lines_polys_handler.py
@@ -143,7 +143,7 @@ class TestExposureGeomToPnt(unittest.TestCase):
             52.55795685, 52.55795685, 52.23308448, 52.23308448
             ])
         np.testing.assert_allclose(exp_pnt.gdf.latitude, lat)
-        
+
         #projected crs, to_meters=TRUE, FIX, dissag_val
         res = 20000
         EXP_POLY_PROJ = Exposures(GDF_POLY.to_crs(epsg=28992))


### PR DESCRIPTION
Changes proposed in this PR:
- When disaggregating a polygon-containing geodataframe, one needs to specify whether resolution is specified in metres. For gdfs which are already in a projected crs (aka a metre-based one), it is currently strictly necessary to give the resolution (in metres), yet indicate to_metres=False (since else the code tries to re-project the already projected gdf, and fails). This is however a bit confusing to some end-users.
- This hotfix checks in the mentioned case whether the gdf is already projected, and avoids re-projection.

This PR fixes #648

### PR Author Checklist

- [x] Read the [Contribution Guide][contrib]
- [x] Correct target branch selected (if unsure, select `develop`)
- [x] Descriptive pull request title added
- [x] Source branch up-to-date with target branch
- [x] [Documentation](https://climada-python.readthedocs.io/en/latest/guide/Guide_PythonDos-n-Donts.html#2.--Commenting-&-Documenting) updated
- [x] [Tests][testing] updated
- [x] [Tests][testing] passing
- [x] No new [linter issues][linter]
- [x] [Changelog](https://github.com/CLIMADA-project/climada_python/blob/main/CHANGELOG.md) updated

### PR Reviewer Checklist

- [ ] Read the [Contribution Guide][contrib]
- [ ] [CLIMADA Reviewer Checklist](https://climada-python.readthedocs.io/en/latest/guide/Guide_Reviewer_Checklist.html) passed
- [x] [Tests][testing] passing
- [x] No new [linter issues][linter]

[contrib]: https://github.com/CLIMADA-project/climada_python/blob/main/CONTRIBUTING.md
[testing]: https://climada-python.readthedocs.io/en/latest/guide/Guide_Continuous_Integration_and_Testing.html
[linter]: https://climada-python.readthedocs.io/en/stable/guide/Guide_Continuous_Integration_and_Testing.html#3.C.--Static-Code-Analysis
