### PR TITLE
Feature/haz type in step impf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ Removed:
 - Renamed `climada.util.coordinate.assign_grid_points` to `match_grid_points` and `climada.util.coordinates.assign_coordinates` to `match_coordinates`
 [#602](https://github.com/CLIMADA-project/climada_python/pull/602)
 - Modified the method to disaggregate lines in the lines_polygons_handler utility module in order to better conserve the total length of all lines on average [#679](https://github.com/CLIMADA-project/climada_python/pull/679).
-- The sigmoid and step impact functions now required the user to define the hazard type. [#675](https://github.com/CLIMADA-project/climada_python/pull/675)
+- The sigmoid and step impact functions now require the user to define the hazard type. [#675](https://github.com/CLIMADA-project/climada_python/pull/675)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Removed:
 - Renamed `climada.util.coordinate.assign_grid_points` to `match_grid_points` and `climada.util.coordinates.assign_coordinates` to `match_coordinates`
 [#602](https://github.com/CLIMADA-project/climada_python/pull/602)
 - Modified the method to disaggregate lines in the lines_polygons_handler utility module in order to better conserve the total length of all lines on average [#679](https://github.com/CLIMADA-project/climada_python/pull/679).
+- The sigmoid and step impact functions now required the user to define the hazard type. [#675](https://github.com/CLIMADA-project/climada_python/pull/675)
 
 ### Fixed
 

--- a/climada/entity/impact_funcs/base.py
+++ b/climada/entity/impact_funcs/base.py
@@ -258,7 +258,7 @@ class ImpactFunc():
         Return
         ------
         impf : climada.entity.impact_funcs.ImpactFunc
-            Step impact function
+            Sigmoid impact function
         """
         inten_min, inten_max, inten_step = intensity
         intensity = np.arange(inten_min, inten_max, inten_step)

--- a/climada/entity/impact_funcs/base.py
+++ b/climada/entity/impact_funcs/base.py
@@ -162,7 +162,8 @@ class ImpactFunc():
             return
 
     @classmethod
-    def from_step_impf(cls, intensity, mdd=(0, 1), paa=(1, 1), impf_id=1):
+    def from_step_impf(cls, intensity, haz_type, mdd=(0, 1), paa=(1, 1),
+        impf_id=1, **kwargs):
 
         """ Step function type impact function.
 
@@ -176,12 +177,16 @@ class ImpactFunc():
         ----------
         intensity: tuple(float, float, float)
             tuple of 3-intensity numbers: (minimum, threshold, maximum)
+        haz_type: str
+            the reference string for the hazard (e.g., 'TC', 'RF', 'WS', ...)
         mdd: tuple(float, float)
             (min, max) mdd values. The default is (0, 1)
         paa: tuple(float, float)
             (min, max) paa values. The default is (1, 1)
         impf_id : int, optional, default=1
             impact function id
+        kwargs :
+            keyword arguments passed to ImpactFunc()
 
         Return
         ------
@@ -196,7 +201,8 @@ class ImpactFunc():
         mdd_min, mdd_max = mdd
         mdd = np.array([mdd_min, mdd_min, mdd_max, mdd_max])
 
-        return cls(id=impf_id, intensity=intensity, mdd=mdd, paa=paa)
+        return cls(haz_type=haz_type, id=impf_id,
+            intensity=intensity, mdd=mdd, paa=paa, **kwargs)
 
     def set_step_impf(self, *args, **kwargs):
         """This function is deprecated, use ImpactFunc.from_step_impf instead."""
@@ -205,7 +211,7 @@ class ImpactFunc():
         self.__dict__ = ImpactFunc.from_step_impf(*args, **kwargs).__dict__
 
     @classmethod
-    def from_sigmoid_impf(cls, intensity, L, k, x0, if_id=1):
+    def from_sigmoid_impf(cls, intensity, L, k, x0, haz_type, impf_id=1, **kwargs):
         """Sigmoid type impact function hinging on three parameter.
 
         This type of impact function is very flexible for any sort of study,
@@ -228,8 +234,12 @@ class ImpactFunc():
             "slope" of sigmoid
         x0 : float
             intensity value where f(x)==L/2
-        if_id : int, optional, default=1
+        haz_type: str
+            the reference string for the hazard (e.g., 'TC', 'RF', 'WS', ...)
+        impf_id : int, optional, default=1
             impact function id
+        kwargs :
+            keyword arguments passed to ImpactFunc()
 
         Return
         ------
@@ -241,7 +251,8 @@ class ImpactFunc():
         paa = np.ones(len(intensity))
         mdd = L / (1 + np.exp(-k * (intensity - x0)))
 
-        return cls(id=if_id, intensity=intensity, paa=paa, mdd=mdd)
+        return cls(haz_type=haz_type, id=impf_id, intensity=intensity,
+            paa=paa, mdd=mdd, **kwargs)
 
     def set_sigmoid_impf(self, *args, **kwargs):
         """This function is deprecated, use LitPop.from_countries instead."""

--- a/climada/entity/impact_funcs/base.py
+++ b/climada/entity/impact_funcs/base.py
@@ -96,7 +96,7 @@ class ImpactFunc():
         self.mdd = mdd if mdd is not None else np.array([])
         self.paa = paa if paa is not None else np.array([])
 
-    def calc_mdr(self, inten):
+    def calc_mdr(self, inten: Union[float, np.ndarray]) -> np.ndarray:
         """Interpolate impact function to a given intensity.
 
         Parameters
@@ -162,8 +162,14 @@ class ImpactFunc():
             return
 
     @classmethod
-    def from_step_impf(cls, intensity, haz_type, mdd=(0, 1), paa=(1, 1),
-        impf_id=1, **kwargs):
+    def from_step_impf(
+        cls,
+        intensity: tuple[float, float, float],
+        haz_type: str,
+        mdd: tuple[float, float] = (0, 1),
+        paa: tuple[float, float] = (1, 1),
+        impf_id: int = 1,
+        **kwargs):
 
         """ Step function type impact function.
 
@@ -211,7 +217,15 @@ class ImpactFunc():
         self.__dict__ = ImpactFunc.from_step_impf(*args, **kwargs).__dict__
 
     @classmethod
-    def from_sigmoid_impf(cls, intensity, L, k, x0, haz_type, impf_id=1, **kwargs):
+    def from_sigmoid_impf(
+        cls,
+        intensity: tuple[float, float, float],
+        L: float,
+        k: float,
+        x0: float,
+        haz_type: str,
+        impf_id: int = 1,
+        **kwargs):
         """Sigmoid type impact function hinging on three parameter.
 
         This type of impact function is very flexible for any sort of study,

--- a/climada/entity/impact_funcs/test/test_base.py
+++ b/climada/entity/impact_funcs/test/test_base.py
@@ -39,24 +39,29 @@ class TestInterpolation(unittest.TestCase):
     def test_set_step(self):
         """Check default impact function: step function"""
         inten = (0, 5, 10)
-        imp_fun = ImpactFunc.from_step_impf(inten)
+        imp_fun = ImpactFunc.from_step_impf(
+            intensity=inten, haz_type='TC', intensity_unit='m/s')
         self.assertTrue(np.array_equal(imp_fun.paa, np.ones(4)))
         self.assertTrue(np.array_equal(imp_fun.mdd, np.array([0, 0, 1, 1])))
         self.assertTrue(np.array_equal(imp_fun.intensity, np.array([0, 5, 5, 10])))
+        self.assertEqual(imp_fun.haz_type, 'TC')
+        self.assertEqual(imp_fun.intensity_unit, 'm/s')
 
     def test_set_sigmoid(self):
         """Check default impact function: sigmoid function"""
         inten = (0, 100, 5)
-        imp_fun = ImpactFunc.from_sigmoid_impf(inten, L=1.0, k=2., x0=50.)
+        imp_fun = ImpactFunc.from_sigmoid_impf(
+            inten, L=1.0, k=2., x0=50., haz_type='RF', name='sigmoid impf')
         self.assertTrue(np.array_equal(imp_fun.paa, np.ones(20)))
         self.assertEqual(imp_fun.mdd[10], 0.5)
         self.assertEqual(imp_fun.mdd[-1], 1.0)
         self.assertTrue(np.array_equal(imp_fun.intensity, np.arange(0, 100, 5)))
+        self.assertEqual(imp_fun.haz_type, 'RF')
+        self.assertEqual(imp_fun.name, 'sigmoid impf')
+
+
 
 # Execute Tests
 if __name__ == "__main__":
     TESTS = unittest.TestLoader().loadTestsFromTestCase(TestInterpolation)
     unittest.TextTestRunner(verbosity=2).run(TESTS)
-
-
-

--- a/climada/entity/impact_funcs/test/test_base.py
+++ b/climada/entity/impact_funcs/test/test_base.py
@@ -36,28 +36,29 @@ class TestInterpolation(unittest.TestCase):
         new_inten = 17.2
         self.assertEqual(imp_fun.calc_mdr(new_inten), 0.029583999999999996)
 
-    def test_set_step(self):
+    def test_from_step(self):
         """Check default impact function: step function"""
         inten = (0, 5, 10)
         imp_fun = ImpactFunc.from_step_impf(
-            intensity=inten, haz_type='TC', intensity_unit='m/s')
+            intensity=inten, haz_type='TC', impf_id=2)
         self.assertTrue(np.array_equal(imp_fun.paa, np.ones(4)))
         self.assertTrue(np.array_equal(imp_fun.mdd, np.array([0, 0, 1, 1])))
         self.assertTrue(np.array_equal(imp_fun.intensity, np.array([0, 5, 5, 10])))
         self.assertEqual(imp_fun.haz_type, 'TC')
-        self.assertEqual(imp_fun.intensity_unit, 'm/s')
+        self.assertEqual(imp_fun.id, 2)
 
-    def test_set_sigmoid(self):
+
+    def test_from_sigmoid(self):
         """Check default impact function: sigmoid function"""
         inten = (0, 100, 5)
         imp_fun = ImpactFunc.from_sigmoid_impf(
-            inten, L=1.0, k=2., x0=50., haz_type='RF', name='sigmoid impf')
+            inten, L=1.0, k=2., x0=50., haz_type='RF', impf_id=2)
         self.assertTrue(np.array_equal(imp_fun.paa, np.ones(20)))
         self.assertEqual(imp_fun.mdd[10], 0.5)
         self.assertEqual(imp_fun.mdd[-1], 1.0)
         self.assertTrue(np.array_equal(imp_fun.intensity, np.arange(0, 100, 5)))
         self.assertEqual(imp_fun.haz_type, 'RF')
-        self.assertEqual(imp_fun.name, 'sigmoid impf')
+        self.assertEqual(imp_fun.id, 2)
 
 # Execute Tests
 if __name__ == "__main__":

--- a/climada/entity/impact_funcs/test/test_base.py
+++ b/climada/entity/impact_funcs/test/test_base.py
@@ -59,8 +59,6 @@ class TestInterpolation(unittest.TestCase):
         self.assertEqual(imp_fun.haz_type, 'RF')
         self.assertEqual(imp_fun.name, 'sigmoid impf')
 
-
-
 # Execute Tests
 if __name__ == "__main__":
     TESTS = unittest.TestLoader().loadTestsFromTestCase(TestInterpolation)

--- a/climada/hazard/test/test_base.py
+++ b/climada/hazard/test/test_base.py
@@ -1392,7 +1392,7 @@ class TestClear(unittest.TestCase):
 def dummy_step_impf(haz):
     from climada.entity import ImpactFunc
     intensity = (0, 1, haz.intensity.max())
-    impf = ImpactFunc.from_step_impf(intensity)
+    impf = ImpactFunc.from_step_impf(intensity, haz_type=haz.tag.haz_type)
     return impf
 
 class TestImpactFuncs(unittest.TestCase):


### PR DESCRIPTION
Changes proposed in this PR:
- Make it obligatory for the sigmoid and step function methods to have haz_type defined
- Pass kwargs to the ImpactFunc init

### PR Author Checklist

- [x] Read the [Contribution Guide][contrib]
- [x] Correct target branch selected (if unsure, select `develop`)
- [x] Descriptive pull request title added
- [x] Source branch up-to-date with target branch
- [x] [Documentation](https://climada-python.readthedocs.io/en/latest/guide/Guide_PythonDos-n-Donts.html#2.--Commenting-&-Documenting) updated
- [x] [Tests][testing] updated
- [x] [Tests][testing] passing
- [ ] No new [linter issues][linter]
- [x] [Changelog](https://github.com/CLIMADA-project/climada_python/blob/main/CHANGELOG.md) updated

### PR Reviewer Checklist

- [x] Read the [Contribution Guide][contrib]
- [x] [CLIMADA Reviewer Checklist](https://climada-python.readthedocs.io/en/latest/guide/Guide_Reviewer_Checklist.html) passed
- [x] [Tests][testing] passing
- [x] No new [linter issues][linter]

[contrib]: https://github.com/CLIMADA-project/climada_python/blob/main/CONTRIBUTING.md
[testing]: https://climada-python.readthedocs.io/en/latest/guide/Guide_Continuous_Integration_and_Testing.html
[linter]: https://climada-python.readthedocs.io/en/stable/guide/Guide_Continuous_Integration_and_Testing.html#3.C.--Static-Code-Analysis
