### PR TITLE
Update Readthedocs installation / unittest instructions

### DIFF
--- a/doc/guide/install.rst
+++ b/doc/guide/install.rst
@@ -416,7 +416,7 @@ Move into the CLIMADA repository, activate the environment and then execute the 
 
    cd <path/to/workspace>/climada_python
    conda activate climada_env
-   python -m unittest -s climada/ -p "test*.py"
+   python -m unittest discover -s climada -p "test*.py"
 
 Error: ``ModuleNotFoundError``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Changes proposed in this PR:
Modify the section "Verifying Your Installation" in the readthedocs installation instructions.
The command-line command for discovering & executing unittests was erroneous. This is fixed now.

This PR fixes # -

### PR Author Checklist

- [x] Read the [Contribution Guide][contrib]
- [x] Correct target branch selected (if unsure, select `develop`)
- [x] Descriptive pull request title added
- [x] Source branch up-to-date with target branch
- [x] [Documentation](https://climada-python.readthedocs.io/en/latest/guide/Guide_PythonDos-n-Donts.html#2.--Commenting-&-Documenting) updated
- [ ] [Tests][testing] updated
- [ ] [Tests][testing] passing
- [x] No new [linter issues][linter]
- [ ] [Changelog](https://github.com/CLIMADA-project/climada_python/blob/main/CHANGELOG.md) updated

### PR Reviewer Checklist

- [x] Read the [Contribution Guide][contrib]
- [x] [CLIMADA Reviewer Checklist](https://climada-python.readthedocs.io/en/latest/guide/Guide_Reviewer_Checklist.html) passed
- [x] [Tests][testing] passing
- [x] No new [linter issues][linter]

[contrib]: https://github.com/CLIMADA-project/climada_python/blob/main/CONTRIBUTING.md
[testing]: https://climada-python.readthedocs.io/en/latest/guide/Guide_Continuous_Integration_and_Testing.html
[linter]: https://climada-python.readthedocs.io/en/stable/guide/Guide_Continuous_Integration_and_Testing.html#3.C.--Static-Code-Analysis
