### PR TITLE
Improve impact calc error messages

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -28,3 +28,4 @@
 * Lukas Riedel
 * Raphael Portmann
 * Nicolas Colombi
+* Leonie Villiger

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Removed:
 - Modified the method to disaggregate lines in the `lines_polys_handler` utility module in order to better conserve the total length of all lines on average [#679](https://github.com/CLIMADA-project/climada_python/pull/679).
 - Added test for non-default impact function id in the `lines_polys_handler` [#676](https://github.com/CLIMADA-project/climada_python/pull/676)
 - The sigmoid and step impact functions now require the user to define the hazard type. [#675](https://github.com/CLIMADA-project/climada_python/pull/675)
+- Improved error messages produced by `ImpactCalc.impact()` in case hazard type is not found in exposures/impf_set [#669](https://github.com/CLIMADA-project/climada_python/pull/669)
 
 ### Fixed
 

--- a/climada/engine/impact_calc.py
+++ b/climada/engine/impact_calc.py
@@ -73,7 +73,7 @@ class ImpactCalc():
     def n_events(self):
         """Number of hazard events (size of event_id array)"""
         return self.hazard.size
-
+    
     def impact(self, save_mat=True, assign_centroids=True,
                ignore_cover=False, ignore_deductible=False):
         """Compute the impact of a hazard on exposures.
@@ -112,6 +112,22 @@ class ImpactCalc():
         apply_deductible_to_mat : apply deductible to impact matrix
         apply_cover_to_mat : apply cover to impact matrix
         """
+        # check for compability of exposures and hazard type        
+        if all(name not in self.exposures.gdf.columns for 
+               name in ['if_', f'if_{self.hazard.haz_type}', 
+                        'impf_', f'impf_{self.hazard.haz_type}']):
+            raise AttributeError(
+                "Impact calculation not possible. No impact functions found " 
+                f"for hazard type {self.hazard.haz_type} in exposures."
+                )
+        
+        # check for compability of impact function and hazard type
+        if not self.impfset.get_func(haz_type=self.hazard.haz_type):
+            raise AttributeError(
+                "Impact calculation not possible. No impact functions found " 
+                f"for hazard type {self.hazard.haz_type} in impf_set."
+                )
+        
         impf_col = self.exposures.get_impf_column(self.hazard.haz_type)
         exp_gdf = self.minimal_exp_gdf(impf_col, assign_centroids, ignore_cover, ignore_deductible)
         if exp_gdf.size == 0:


### PR DESCRIPTION
Changes proposed in this PR:
`ImpactCalc.impact(exposures, impfset, hazard)` checks that 
- exposures refers to impact functions for the given hazard type
- impfset contains impact functions for the given hazard type. 
In case of mismatching hazard types, a comprehensible error message is produced. Currently, these cases result in the cryptic error message `AttributeError: 'list' has no attribute 'calc_mdr'` 

This PR fixes #669

### PR Author Checklist

- [ ] Read the [Contribution Guide][contrib]
- [ ] Correct target branch selected (if unsure, select `develop`)
- [x] Descriptive pull request title added
- [ ] Source branch up-to-date with target branch
- [ ] [Documentation](https://climada-python.readthedocs.io/en/latest/guide/Guide_PythonDos-n-Donts.html#2.--Commenting-&-Documenting) updated
- [x] [Tests][testing] updated
- [ ] [Tests][testing] passing
- [ ] No new [linter issues][linter]
- [ ] [Changelog](https://github.com/CLIMADA-project/climada_python/blob/main/CHANGELOG.md) updated

### PR Reviewer Checklist

- [ ] Read the [Contribution Guide][contrib]
- [ ] [CLIMADA Reviewer Checklist](https://climada-python.readthedocs.io/en/latest/guide/Guide_Reviewer_Checklist.html) passed
- [ ] [Tests][testing] passing
- [ ] No new [linter issues][linter]

[contrib]: https://github.com/CLIMADA-project/climada_python/blob/main/CONTRIBUTING.md
[testing]: https://climada-python.readthedocs.io/en/latest/guide/Guide_Continuous_Integration_and_Testing.html
[linter]: https://climada-python.readthedocs.io/en/stable/guide/Guide_Continuous_Integration_and_Testing.html#3.C.--Static-Code-Analysis
