### PR TITLE
fix test.test_exposures_value_pass

### DIFF
--- a/climada/test/test_plot.py
+++ b/climada/test/test_plot.py
@@ -105,9 +105,7 @@ class TestPlotter(unittest.TestCase):
         centroids = Centroids.from_base_grid()
         centroids.plot()
 
-    # sipped because of issue #693
-    # TODO: unskip when #693 is solved
-    def skip_test_exposures_value_pass(self):
+    def test_exposures_value_pass(self):
         """Plot exposures values."""
         myexp = pd.read_excel(ENT_DEMO_TODAY)
         myexp = Exposures(myexp)
@@ -122,7 +120,8 @@ class TestPlotter(unittest.TestCase):
 
         myexp.plot_scatter()
         myexp.plot_basemap()
-        myexp.plot_raster()
+        # note: not specifying raster_res makes jenkins runout of memory
+        myexp.plot_raster(raster_res = 0.001)
 
     def test_impact_funcs_pass(self):
         """Plot diferent impact functions."""

--- a/climada/test/test_plot.py
+++ b/climada/test/test_plot.py
@@ -121,7 +121,7 @@ class TestPlotter(unittest.TestCase):
         myexp.plot_scatter()
         myexp.plot_basemap()
         # note: not specifying raster_res makes jenkins runout of memory
-        myexp.plot_raster(raster_res = 0.001)
+        myexp.plot_raster(raster_res=0.001)
 
     def test_impact_funcs_pass(self):
         """Plot diferent impact functions."""


### PR DESCRIPTION
This PR fixes issue #693 

The test: climada.test.test_plot.TestPlotter.test_exposures_value_pass was making jenkins run out of memory (> 10GB of RAM usage)

By applying a coarser resolution to the function plot.raster() the RAM usage went down to around 400Mb.



### PR Author Checklist

- [x] Read the [Contribution Guide][contrib]
- [x] Correct target branch selected (if unsure, select `develop`)
- [x] Descriptive pull request title added
- [x] Source branch up-to-date with target branch
- [ ] [Documentation](https://climada-python.readthedocs.io/en/latest/guide/Guide_PythonDos-n-Donts.html#2.--Commenting-&-Documenting) updated
- [ ] [Tests][testing] updated
- [ ] [Tests][testing] passing
- [x] No new [linter issues][linter]
- [ ] [Changelog](https://github.com/CLIMADA-project/climada_python/blob/main/CHANGELOG.md) updated

### PR Reviewer Checklist

- [ ] Read the [Contribution Guide][contrib]
- [ ] [CLIMADA Reviewer Checklist](https://climada-python.readthedocs.io/en/latest/guide/Guide_Reviewer_Checklist.html) passed
- [ ] [Tests][testing] passing
- [ ] No new [linter issues][linter]

[contrib]: https://github.com/CLIMADA-project/climada_python/blob/main/CONTRIBUTING.md
[testing]: https://climada-python.readthedocs.io/en/latest/guide/Guide_Continuous_Integration_and_Testing.html
[linter]: https://climada-python.readthedocs.io/en/stable/guide/Guide_Continuous_Integration_and_Testing.html#3.C.--Static-Code-Analysis
