### PR TITLE
Bugfix: yearsets frequency curve calculations fail

### DIFF
--- a/climada/util/yearsets.py
+++ b/climada/util/yearsets.py
@@ -262,7 +262,7 @@ def compute_imp_per_year(imp, sampling_vect):
     imp_per_year = [np.sum(imp.at_event[list(sampled_events)]) for sampled_events in
                     sampling_vect]
 
-    return imp_per_year
+    return np.array(imp_per_year)
 
 def calculate_correction_fac(imp_per_year, imp):
     """Calculate a correction factor that can be used to scale the yimp in such

--- a/climada/util/yearsets.py
+++ b/climada/util/yearsets.py
@@ -162,7 +162,7 @@ def sample_from_poisson(n_sampled_years, lam, seed=None):
 
     Returns
     -------
-        events_per_year : array
+        events_per_year : np.ndarray
             Number of events per sampled year
     """
     if seed is not None:
@@ -184,9 +184,9 @@ def sample_events(events_per_year, freqs_orig, seed=None):
 
     Parameters
     -----------
-        events_per_year : array
+        events_per_year : np.ndarray
             Number of events per sampled year
-        freqs_orig : array
+        freqs_orig : np.ndarray
             Frequency of each input event
         seed : Any, optional
             seed for the default bit generator.
@@ -255,7 +255,7 @@ def compute_imp_per_year(imp, sampling_vect):
 
     Returns
     -------
-        imp_per_year: array
+        imp_per_year: np.ndarray
             Sampled impact per year (length = sampled_years)
     """
 
@@ -271,7 +271,7 @@ def calculate_correction_fac(imp_per_year, imp):
 
     Parameters
     -----------
-        imp_per_year : array
+        imp_per_year : np.ndarray
             sampled yimp
         imp : climada.engine.Impact()
             impact object containing impacts per event


### PR DESCRIPTION
Changes proposed in this PR:
- Small bugfix to `yearsets`. An `Impact.at_event` object needs to be a numpy array, or it can't be reindexed in the `Impact.calc_freq_curve` calculation. The `yearsets` class creates these as lists so frequency curve calcuations currently fail. From the documentation they are clearly supposed to be arrays when they are calculated in the `compute_imp_per_year` method. The fix is one line.

### PR Author Checklist

- [x] Read the [Contribution Guide][contrib]
- [x] Correct target branch selected (if unsure, select `develop`)
- [x] Descriptive pull request title added
- [x] Source branch up-to-date with target branch
- [x] [Documentation](https://climada-python.readthedocs.io/en/latest/guide/Guide_PythonDos-n-Donts.html#2.--Commenting-&-Documenting) updated
- [ ] [Tests][testing] updated
- [x] [Tests][testing] passing
- [x] No new [linter issues][linter]
- [ ] [Changelog](https://github.com/CLIMADA-project/climada_python/blob/main/CHANGELOG.md) updated

### PR Reviewer Checklist

- [ ] Read the [Contribution Guide][contrib]
- [ ] [CLIMADA Reviewer Checklist](https://climada-python.readthedocs.io/en/latest/guide/Guide_Reviewer_Checklist.html) passed
- [ ] [Tests][testing] passing
- [ ] No new [linter issues][linter]

[contrib]: https://github.com/CLIMADA-project/climada_python/blob/main/CONTRIBUTING.md
[testing]: https://climada-python.readthedocs.io/en/latest/guide/Guide_Continuous_Integration_and_Testing.html
[linter]: https://climada-python.readthedocs.io/en/stable/guide/Guide_Continuous_Integration_and_Testing.html#3.C.--Static-Code-Analysis
