### PR TITLE
Avoid `Impact` storing a `pyproj.CRS` object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Removed:
 ### Fixed
 
 - `util.lines_polys_handler` solve polygon disaggregation issue in metre-based projection [#666](https://github.com/CLIMADA-project/climada_python/pull/666)
+- Problem with `pyproj.CRS` as `Impact` attribute, [#706](https://github.com/CLIMADA-project/climada_python/issues/706). Now CRS is always stored as `str` in WKT format.
 
 ### Deprecated
 

--- a/climada/engine/impact.py
+++ b/climada/engine/impact.py
@@ -41,6 +41,7 @@ import pandas as pd
 import xlsxwriter
 from tqdm import tqdm
 import h5py
+from pyproj import CRS
 
 from climada.entity import Exposures, Tag
 from climada.hazard import Tag as TagHaz
@@ -149,7 +150,7 @@ class Impact():
         self.event_name = [] if event_name is None else event_name
         self.date = np.array([], int) if date is None else date
         self.coord_exp = np.array([], float) if coord_exp is None else coord_exp
-        self.crs = crs
+        self.crs = crs.to_wkt() if isinstance(crs, CRS) else crs
         self.eai_exp = np.array([], float) if eai_exp is None else eai_exp
         self.at_event = np.array([], float) if at_event is None else at_event
         self.frequency = np.array([],float) if frequency is None else frequency

--- a/climada/engine/impact.py
+++ b/climada/engine/impact.py
@@ -41,7 +41,8 @@ import pandas as pd
 import xlsxwriter
 from tqdm import tqdm
 import h5py
-from pyproj import CRS
+from pyproj import CRS as pyprojCRS
+from rasterio.crs import CRS as rasterioCRS
 
 from climada.entity import Exposures, Tag
 from climada.hazard import Tag as TagHaz
@@ -129,7 +130,8 @@ class Impact():
         coord_exp : np.array, optional
             exposures coordinates [lat, lon] (in degrees)
         crs : Any, optional
-            coordinate reference system
+            Coordinate reference system. CRS instances from ``pyproj`` and ``rasterio``
+            will be transformed into WKT. Other types are not handled explicitly.
         eai_exp : np.array, optional
             expected impact for each exposure within a period of 1/frequency_unit
         at_event : np.array, optional
@@ -152,7 +154,7 @@ class Impact():
         self.event_name = [] if event_name is None else event_name
         self.date = np.array([], int) if date is None else date
         self.coord_exp = np.array([], float) if coord_exp is None else coord_exp
-        self.crs = crs.to_wkt() if isinstance(crs, CRS) else crs
+        self.crs = crs.to_wkt() if isinstance(crs, (pyprojCRS, rasterioCRS)) else crs
         self.eai_exp = np.array([], float) if eai_exp is None else eai_exp
         self.at_event = np.array([], float) if at_event is None else at_event
         self.frequency = np.array([],float) if frequency is None else frequency

--- a/climada/engine/impact.py
+++ b/climada/engine/impact.py
@@ -74,8 +74,8 @@ class Impact():
         ordinal 1 (ordinal format of datetime library)
     coord_exp : np.array
         exposures coordinates [lat, lon] (in degrees)
-    crs : str or rasterio.crs.CRS
-        coordinate reference system, WKT formatted string or ``rasterio.crs.CRS`` object
+    crs : str
+        WKT string of the impact's crs
     eai_exp : np.array
         expected impact for each exposure within a period of 1/frequency_unit
     at_event : np.array

--- a/climada/engine/impact.py
+++ b/climada/engine/impact.py
@@ -73,6 +73,8 @@ class Impact():
         ordinal 1 (ordinal format of datetime library)
     coord_exp : np.array
         exposures coordinates [lat, lon] (in degrees)
+    crs : str
+        WKT string of the impact's crs
     eai_exp : np.array
         expected impact for each exposure within a period of 1/frequency_unit
     at_event : np.array

--- a/climada/engine/impact.py
+++ b/climada/engine/impact.py
@@ -42,7 +42,7 @@ import xlsxwriter
 from tqdm import tqdm
 import h5py
 from pyproj import CRS as pyprojCRS
-from rasterio.crs import CRS as rasterioCRS
+from rasterio.crs import CRS as rasterioCRS  # pylint: disable=no-name-in-module
 
 from climada.entity import Exposures, Tag
 from climada.hazard import Tag as TagHaz

--- a/climada/engine/test/test_impact.py
+++ b/climada/engine/test/test_impact.py
@@ -25,6 +25,7 @@ import numpy as np
 import numpy.testing as npt
 from scipy import sparse
 import h5py
+from pyproj import CRS
 
 from climada.entity.tag import Tag
 from climada.hazard.tag import Tag as TagHaz
@@ -98,6 +99,11 @@ class TestImpact(unittest.TestCase):
             np.stack([exp.gdf.latitude.values, exp.gdf.longitude.values], axis=1)
             )
 
+    def test_pyproj_crs(self):
+        """Check if initializing with a pyproj.CRS transforms it into a string"""
+        crs = CRS.from_epsg(4326)
+        impact = Impact(crs=crs)
+        self.assertEqual(impact.crs, crs.to_wkt())
 
 class TestImpactConcat(unittest.TestCase):
     """test Impact.concat"""
@@ -926,7 +932,7 @@ class TestImpactH5IO(unittest.TestCase):
             npt.assert_array_equal(file["event_name"].asstr(), impact.event_name)
             npt.assert_array_equal(file["date"], impact.date)
             npt.assert_array_equal(file["coord_exp"], impact.coord_exp)
-            self.assertEqual(file.attrs["crs"], DEF_CRS)
+            self.assertEqual(file.attrs["crs"], impact.crs)
             npt.assert_array_equal(file["eai_exp"], impact.eai_exp)
             npt.assert_array_equal(file["at_event"], impact.at_event)
             npt.assert_array_equal(file["frequency"], impact.frequency)

--- a/climada/engine/test/test_impact.py
+++ b/climada/engine/test/test_impact.py
@@ -26,6 +26,7 @@ import numpy.testing as npt
 from scipy import sparse
 import h5py
 from pyproj import CRS
+from rasterio.crs import CRS as rCRS
 
 from climada.entity.tag import Tag
 from climada.hazard.tag import Tag as TagHaz
@@ -102,6 +103,12 @@ class TestImpact(unittest.TestCase):
     def test_pyproj_crs(self):
         """Check if initializing with a pyproj.CRS transforms it into a string"""
         crs = CRS.from_epsg(4326)
+        impact = Impact(crs=crs)
+        self.assertEqual(impact.crs, crs.to_wkt())
+
+    def test_rasterio_crs(self):
+        """Check if initializing with a rasterio.crs.CRS transforms it into a string"""
+        crs = rCRS.from_epsg(4326)
         impact = Impact(crs=crs)
         self.assertEqual(impact.crs, crs.to_wkt())
 


### PR DESCRIPTION
Changes proposed in this PR:
- Transform `pyproj.CRS` into WKT string in `Impact.__init__`. WKT is the most precise form of storing CRS information, apart from an actual `CRS` object. This should work fine as the `Impact.crs` attribute can now safely be stored as string, and inserting the WKT into the `Exposures` constructor is supported.
- Fix a subtle bug in an impact test

This PR fixes #706 

### PR Author Checklist

- [x] Read the [Contribution Guide][contrib]
- [x] Correct target branch selected (if unsure, select `develop`)
- [x] Descriptive pull request title added
- [x] Source branch up-to-date with target branch
- [ ] [Documentation](https://climada-python.readthedocs.io/en/latest/guide/Guide_PythonDos-n-Donts.html#2.--Commenting-&-Documenting) updated
- [x] [Tests][testing] updated
- [x] [Tests][testing] passing
- [x] No new [linter issues][linter]
- [ ] [Changelog](https://github.com/CLIMADA-project/climada_python/blob/main/CHANGELOG.md) updated

### PR Reviewer Checklist

- [ ] Read the [Contribution Guide][contrib]
- [ ] [CLIMADA Reviewer Checklist](https://climada-python.readthedocs.io/en/latest/guide/Guide_Reviewer_Checklist.html) passed
- [ ] [Tests][testing] passing
- [ ] No new [linter issues][linter]

[contrib]: https://github.com/CLIMADA-project/climada_python/blob/main/CONTRIBUTING.md
[testing]: https://climada-python.readthedocs.io/en/latest/guide/Guide_Continuous_Integration_and_Testing.html
[linter]: https://climada-python.readthedocs.io/en/stable/guide/Guide_Continuous_Integration_and_Testing.html#3.C.--Static-Code-Analysis
