### PR TITLE
Feature/fix nightlight test

### DIFF
--- a/climada/test/test_nightlight.py
+++ b/climada/test/test_nightlight.py
@@ -182,16 +182,15 @@ class TestNightlight(unittest.TestCase):
         night, coord_nl, fn_light = nightlight.load_nightlight_noaa()
         self.assertIsInstance(night, sparse._csr.csr_matrix)
         self.assertIn('F182013.v4c_web.stable_lights.avg_vis.tif',str(fn_light))
-        self.assertTrue(np.array_equal(np.array([[-65,NOAA_RESOLUTION_DEG],
+        self.assertTrue(np.array_equal(np.array([[-65, NOAA_RESOLUTION_DEG],
                                     [-180, NOAA_RESOLUTION_DEG]]),coord_nl))
         os.remove(SYSTEM_DIR.joinpath('F182013.v4c_web.stable_lights.avg_vis.p'))
-        
+    
         # with arguments
-        night, coord_nl, fn_light = nightlight.load_nightlight_noaa(ref_year = 2010, sat_name = 'F18')
+        night, coord_nl, fn_light = nightlight.load_nightlight_noaa(ref_year = 2013, sat_name = 'F18')
         self.assertIsInstance(night, sparse._csr.csr_matrix)
-        self.assertIn('F182010.v4d_web.stable_lights.avg_vis', str(fn_light))
-        file = str(SYSTEM_DIR.joinpath('F182010.v4d_web.stable_lights.avg_vis.p')) 
-        os.remove(file)
+        self.assertIn('F182013.v4c_web.stable_lights.avg_vis.tif', str(fn_light))
+        os.remove(SYSTEM_DIR.joinpath('F182013.v4c_web.stable_lights.avg_vis.p'))
         os.remove(path_fake_file)
 
         # test raises from wrong input agruments

--- a/climada/test/test_nightlight.py
+++ b/climada/test/test_nightlight.py
@@ -25,6 +25,9 @@ import tarfile
 import affine
 import numpy as np
 import scipy.sparse as sparse
+import gzip
+import tifffile
+import io
 
 from shapely.geometry import Polygon
 from pathlib import Path
@@ -163,22 +166,35 @@ class TestNightlight(unittest.TestCase):
         """ Test that data is downloaded if not present in SYSTEM_DIR,
             or not downloaded if present. Test the three outputs of the
             function."""
+        
+        # path of fake .tif.gz file
+        path_fake_file = SYSTEM_DIR.joinpath('F182013.v4c_web.stable_lights.avg_vis.tif.gz')
+        # create an empty image 
+        image = np.zeros((100, 100), dtype=np.uint8)
+        # save the image as .tif
+        with io.BytesIO() as mem:
+            tifffile.imwrite(mem, image)
+            # compressed image to a gzip file 
+            with gzip.GzipFile(path_fake_file, 'wb') as f:
+                f.write(mem.getvalue())
 
-        # Using an already existing file and without providing arguments
+        # using already existing file and without providing arguments
         night, coord_nl, fn_light = nightlight.load_nightlight_noaa()
         self.assertIsInstance(night, sparse._csr.csr_matrix)
         self.assertIn('F182013.v4c_web.stable_lights.avg_vis.tif',str(fn_light))
         self.assertTrue(np.array_equal(np.array([[-65,NOAA_RESOLUTION_DEG],
                                     [-180, NOAA_RESOLUTION_DEG]]),coord_nl))
         os.remove(SYSTEM_DIR.joinpath('F182013.v4c_web.stable_lights.avg_vis.p'))
-        # With arguments
+        
+        # with arguments
         night, coord_nl, fn_light = nightlight.load_nightlight_noaa(ref_year = 2010, sat_name = 'F18')
         self.assertIsInstance(night, sparse._csr.csr_matrix)
         self.assertIn('F182010.v4d_web.stable_lights.avg_vis', str(fn_light))
         file = str(SYSTEM_DIR.joinpath('F182010.v4d_web.stable_lights.avg_vis.p')) 
         os.remove(file)
+        os.remove(path_fake_file)
 
-        # Test raises from wrong input agruments
+        # test raises from wrong input agruments
         with self.assertRaises(ValueError) as cm:
             night, coord_nl, fn_light = nightlight.load_nightlight_noaa(
                                             ref_year = 2050, sat_name = 'F150')


### PR DESCRIPTION
Changes proposed in this PR:
- Create `.tif.gz` file with a mock `.tif` image in it to run the test: `climada/test/test_nightlight/test_load_nighlight_noaa`, after the test is executed, the image is automatically delated.
- the test failed because of a missing file in the jenkins environment 

This PR fixes 

- A failing integration test `load_nightlight_noaa`

### PR Author Checklist

- [x] Read the [Contribution Guide][contrib]
- [x] Correct target branch selected (if unsure, select `develop`)
- [x] Descriptive pull request title added
- [x] Source branch up-to-date with target branch
- [ ] [Documentation](https://climada-python.readthedocs.io/en/latest/guide/Guide_PythonDos-n-Donts.html#2.--Commenting-&-Documenting) updated
- [ ] [Tests][testing] updated
- [x] [Tests][testing] passing
- [ ] No new [linter issues][linter]
- [ ] [Changelog](https://github.com/CLIMADA-project/climada_python/blob/main/CHANGELOG.md) updated

### PR Reviewer Checklist

- [ ] Read the [Contribution Guide][contrib]
- [ ] [CLIMADA Reviewer Checklist](https://climada-python.readthedocs.io/en/latest/guide/Guide_Reviewer_Checklist.html) passed
- [ ] [Tests][testing] passing
- [ ] No new [linter issues][linter]

[contrib]: https://github.com/CLIMADA-project/climada_python/blob/main/CONTRIBUTING.md
[testing]: https://climada-python.readthedocs.io/en/latest/guide/Guide_Continuous_Integration_and_Testing.html
[linter]: https://climada-python.readthedocs.io/en/stable/guide/Guide_Continuous_Integration_and_Testing.html#3.C.--Static-Code-Analysis
