### PR TITLE
Docs: Remove env_developer.yml from install guide

### DIFF
--- a/doc/guide/install.rst
+++ b/doc/guide/install.rst
@@ -118,26 +118,27 @@ For advanced Python users or developers of CLIMADA, we recommed cloning the CLIM
       git checkout develop
 
 #. Create an Anaconda environment called ``climada_env`` for installing CLIMADA.
-   Use the default environment specs in ``env_climada.yml`` to create it, and update it with the ``env_developer.yml`` specs.
+   Use the default environment specs in ``env_climada.yml`` to create it.
    Then activate the environment:
 
    .. code-block:: shell
 
       conda env create -n climada_env -f requirements/env_climada.yml
-      conda env update -n climada_env -f requirements/env_developer.yml
       conda activate climada_env
 
-#. Install the local CLIMADA source files as Python package using ``pip``:
+#. Install the local CLIMADA source files as Python package using ``pip``, including additional
+   requirements for developers:
 
    .. code-block:: shell
 
-      python -m pip install -e ./
+      python -m pip install -e .[dev]
 
    .. hint::
 
-      Using a path ``./`` (referring to the path you are currently located at) will instruct ``pip`` to install the local files instead of downloading the module from the internet.
+      Using a path ``.`` (referring to the path you are currently located at) will instruct ``pip`` to install the local files instead of downloading the module from the internet.
       The ``-e`` (for "editable") option further instructs ``pip`` to link to the source files instead of copying them during installation.
       This means that any changes to the source files will have immediate effects in your environment, and re-installing the module is never required.
+      Specifying the ``[dev]`` extra requirement will instruct ``pip`` to install additional packages that are required for testing and compiling the docs.
 
 #. Verify that everything is installed correctly by executing a single test:
 

--- a/doc/guide/install.rst
+++ b/doc/guide/install.rst
@@ -126,19 +126,17 @@ For advanced Python users or developers of CLIMADA, we recommed cloning the CLIM
       conda env create -n climada_env -f requirements/env_climada.yml
       conda activate climada_env
 
-#. Install the local CLIMADA source files as Python package using ``pip``, including additional
-   requirements for developers:
+#. Install the local CLIMADA source files as Python package using ``pip``:
 
    .. code-block:: shell
 
-      python -m pip install -e .[dev]
+      python -m pip install -e ./
 
    .. hint::
 
-      Using a path ``.`` (referring to the path you are currently located at) will instruct ``pip`` to install the local files instead of downloading the module from the internet.
+      Using a path ``./`` (referring to the path you are currently located at) will instruct ``pip`` to install the local files instead of downloading the module from the internet.
       The ``-e`` (for "editable") option further instructs ``pip`` to link to the source files instead of copying them during installation.
       This means that any changes to the source files will have immediate effects in your environment, and re-installing the module is never required.
-      Specifying the ``[dev]`` extra requirement will instruct ``pip`` to install additional packages that are required for testing and compiling the docs.
 
 #. Verify that everything is installed correctly by executing a single test:
 


### PR DESCRIPTION
Changes proposed in this PR:
- Following #712, the installation instructions for developers were outdated. This fixes the install guide.

### PR Author Checklist

- [x] Read the [Contribution Guide][contrib]
- [x] Correct target branch selected (if unsure, select `develop`)
- [x] Descriptive pull request title added
- [x] Source branch up-to-date with target branch
- [x] [Documentation](https://climada-python.readthedocs.io/en/latest/guide/Guide_PythonDos-n-Donts.html#2.--Commenting-&-Documenting) updated
- [ ] [Tests][testing] updated
- [ ] [Tests][testing] passing
- [ ] No new [linter issues][linter]
- [ ] [Changelog](https://github.com/CLIMADA-project/climada_python/blob/main/CHANGELOG.md) updated

### PR Reviewer Checklist

- [ ] Read the [Contribution Guide][contrib]
- [ ] [CLIMADA Reviewer Checklist](https://climada-python.readthedocs.io/en/latest/guide/Guide_Reviewer_Checklist.html) passed
- [ ] [Tests][testing] passing
- [ ] No new [linter issues][linter]

[contrib]: https://github.com/CLIMADA-project/climada_python/blob/main/CONTRIBUTING.md
[testing]: https://climada-python.readthedocs.io/en/latest/guide/Guide_Continuous_Integration_and_Testing.html
[linter]: https://climada-python.readthedocs.io/en/stable/guide/Guide_Continuous_Integration_and_Testing.html#3.C.--Static-Code-Analysis
