### PR TITLE
Reassign centroids by default

### DIFF
--- a/climada/entity/exposures/base.py
+++ b/climada/entity/exposures/base.py
@@ -1048,7 +1048,10 @@ class Exposures():
         )
         return np.sum(self.gdf.value.values[nz_mask])
 
-    def affected_total_value(self, hazard: Hazard, threshold_affected: float = 0):
+    def affected_total_value(
+        self, hazard: Hazard, threshold_affected: float = 0,
+        overwrite_assigned_centroids: bool = True
+        ):
         """
         Total value of the exposures that are affected by at least
         one hazard event (sum of value of all exposures points for which
@@ -1061,6 +1064,11 @@ class Exposures():
         threshold_affected : int or float
             Hazard intensity threshold above which an exposures is
             considere affected.
+            The default is 0.
+        overwrite_assigned_centroids : boolean
+            Assign centroids from the hazard to the exposures and overwrite
+            exsisting ones.
+            The default is True.
 
         Returns
         -------
@@ -1069,7 +1077,12 @@ class Exposures():
             a centroids is assigned and that have at least one
             event intensity above threshold.
 
+        See Also
+        --------
+        Exposures.assign_centroids : method to assign centroids.
+
         """
+        self.assign_centroids(hazard=hazard, overwrite=overwrite_assigned_centroids)
         assigned_centroids = self.gdf[hazard.centr_exp_col]
         nz_mask = (self.gdf.value.values > 0) & (assigned_centroids.values >= 0)
         cents = np.unique(assigned_centroids[nz_mask])

--- a/climada/entity/exposures/test/test_base.py
+++ b/climada/entity/exposures/test/test_base.py
@@ -190,26 +190,49 @@ class TestFuncs(unittest.TestCase):
         gdf = gpd.GeoDataFrame(
             {
                 "value": [1, 2, 3, 4, 5, 6],
-                "latitude": [1, 2, 3, 4, 5, 6],
-                "longitude": [-1, -2, -3, -4, -5, -6],
+                "latitude": [1, 2, 3, 4, 1, 0],
+                "longitude": [-1, -2, -3, -4, 0, 1],
                 "centr_" + haz_type: [0, 2, 2, 3, -1, 4],
             }
         )
         exp = Exposures(gdf, crs=4326)
         intensity = sp.sparse.csr_matrix(np.array([[0, 0, 1, 10, 2], [-1, 0, 0, 1, 2]]))
-        cent = Centroids(lat=np.array([1, 2, 3, 4]), lon=np.array([1, 2, 3, 4]))
+        cent = Centroids(lat=np.array([1, 2, 3, 4]), lon=np.array([-1, -2, -3, -4]))
         haz = Hazard(
             haz_type=haz_type, centroids=cent, intensity=intensity, event_id=[1, 2]
         )
 
-        tot_val = exp.affected_total_value(haz, threshold_affected=0)
+        #do not reassign centroids
+        tot_val = exp.affected_total_value(
+            haz, threshold_affected=0, overwrite_assigned_centroids=False
+            )
         self.assertEqual(tot_val, np.sum(exp.gdf.value[[1, 2, 3, 5]]))
-        tot_val = exp.affected_total_value(haz, threshold_affected=3)
+        tot_val = exp.affected_total_value(
+            haz, threshold_affected=3, overwrite_assigned_centroids=False
+            )
         self.assertEqual(tot_val, np.sum(exp.gdf.value[[3]]))
-        tot_val = exp.affected_total_value(haz, threshold_affected=-2)
+        tot_val = exp.affected_total_value(
+            haz, threshold_affected=-2, overwrite_assigned_centroids=False
+            )
         self.assertEqual(tot_val, np.sum(exp.gdf.value[[0, 1, 2, 3, 5]]))
-        tot_val = exp.affected_total_value(haz, threshold_affected=11)
+        tot_val = exp.affected_total_value(
+            haz, threshold_affected=11, overwrite_assigned_centroids=False
+            )
         self.assertEqual(tot_val, 0)
+
+        #reassign centroids (i.e. to [0, 1, 2, 3, -1, -1])
+        tot_val = exp.affected_total_value(
+            haz, threshold_affected=11, overwrite_assigned_centroids=True
+            )
+        self.assertEqual(tot_val, 0)
+        tot_val = exp.affected_total_value(
+            haz, threshold_affected=0, overwrite_assigned_centroids=False
+            )
+        self.assertEqual(tot_val, 7)
+        tot_val = exp.affected_total_value(
+            haz, threshold_affected=3, overwrite_assigned_centroids=False
+            )
+        self.assertEqual(tot_val, 4)
 
 class TestChecker(unittest.TestCase):
     """Test logs of check function"""


### PR DESCRIPTION
Changes proposed in this PR:
- The new functioning of the method `Exposures.affected_value` defined in #702 has been update to reassign centroids by default.

### PR Author Checklist

- [ ] Read the [Contribution Guide][contrib]
- [ ] Correct target branch selected (if unsure, select `develop`)
- [ ] Descriptive pull request title added
- [ ] Source branch up-to-date with target branch
- [ ] [Documentation](https://climada-python.readthedocs.io/en/latest/guide/Guide_PythonDos-n-Donts.html#2.--Commenting-&-Documenting) updated
- [ ] [Tests][testing] updated
- [ ] [Tests][testing] passing
- [ ] No new [linter issues][linter]
- [ ] [Changelog](https://github.com/CLIMADA-project/climada_python/blob/main/CHANGELOG.md) updated

### PR Reviewer Checklist

- [ ] Read the [Contribution Guide][contrib]
- [ ] [CLIMADA Reviewer Checklist](https://climada-python.readthedocs.io/en/latest/guide/Guide_Reviewer_Checklist.html) passed
- [ ] [Tests][testing] passing
- [ ] No new [linter issues][linter]

[contrib]: https://github.com/CLIMADA-project/climada_python/blob/main/CONTRIBUTING.md
[testing]: https://climada-python.readthedocs.io/en/latest/guide/Guide_Continuous_Integration_and_Testing.html
[linter]: https://climada-python.readthedocs.io/en/stable/guide/Guide_Continuous_Integration_and_Testing.html#3.C.--Static-Code-Analysis
