### PR TITLE
convert windspeed to m/s when extracted from TCTracks for windfield g…

### DIFF
--- a/climada/hazard/trop_cyclone.py
+++ b/climada/hazard/trop_cyclone.py
@@ -1347,6 +1347,6 @@ def _extract_vmax_in_mps_from_track(
     elif track.max_sustained_wind_unit == 'km/h':
         t_vmax = track.max_sustained_wind.values.copy() * KMH_TO_MS
     else:
-        raise ValueError(f'The max_sustained_wind_unit {track.max_sustained_wind_unit} in the provided track is not '
-                         f'supported. Use m/s, kn or km/h.')
+        raise ValueError(f'The max_sustained_wind_unit {track.max_sustained_wind_unit} in'
+                         f' the provided track is not supported. Use m/s, kn or km/h.')
     return t_vmax


### PR DESCRIPTION
…eneration

Changes proposed in this PR:
- When extracting the max_sustained_wind from TCTracks for the windfield generation in TropCyclone, it was previously assumed that the max_sustained_wind_unit is knots. Now it also handles the cases correctly also if the unit is m/s or km/h

This PR fixes #694

### PR Author Checklist

- [x] Read the [Contribution Guide][contrib]
- [x] Correct target branch selected (if unsure, select `develop`)
- [x] Descriptive pull request title added
- [x] Source branch up-to-date with target branch
- [x] [Documentation](https://climada-python.readthedocs.io/en/latest/guide/Guide_PythonDos-n-Donts.html#2.--Commenting-&-Documenting) updated
- [x] [Tests][testing] updated
- [x] [Tests][testing] passing
- [x] No new [linter issues][linter]
- [x] [Changelog](https://github.com/CLIMADA-project/climada_python/blob/main/CHANGELOG.md) updated

### PR Reviewer Checklist

- [ ] Read the [Contribution Guide][contrib]
- [ ] [CLIMADA Reviewer Checklist](https://climada-python.readthedocs.io/en/latest/guide/Guide_Reviewer_Checklist.html) passed
- [ ] [Tests][testing] passing
- [ ] No new [linter issues][linter]

[contrib]: https://github.com/CLIMADA-project/climada_python/blob/main/CONTRIBUTING.md
[testing]: https://climada-python.readthedocs.io/en/latest/guide/Guide_Continuous_Integration_and_Testing.html
[linter]: https://climada-python.readthedocs.io/en/stable/guide/Guide_Continuous_Integration_and_Testing.html#3.C.--Static-Code-Analysis
