### PR TITLE
api_client: allow searching for None

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ Removed:
 - New file format for `TCTracks` I/O with better performance. This change is not backwards compatible: If you stored `TCTracks` objects with `TCTracks.write_hdf5`, reload the original data and store them again. [#735](https://github.com/CLIMADA-project/climada_python/pull/735)
 - Add option to load only a subset when reading TC tracks using `TCTracks.from_simulations_emanuel`. [#741](https://github.com/CLIMADA-project/climada_python/pull/741)
 - Set `save_mat` to `False` in the `unsequa` module [#746](https://github.com/CLIMADA-project/climada_python/pull/746)
+- `list_dataset_infos` from `climada.util.api_client.Client`: the `properties` argument, a `dict`, can now have `None` as values. Before, only strings and lists of strings were allowed. Setting a particular property to `None` triggers a search for datasets where this property is not assigned. [#752](https://github.com/CLIMADA-project/climada_python/pull/752)
 
 ### Fixed
 

--- a/climada/test/test_api_client.py
+++ b/climada/test/test_api_client.py
@@ -64,6 +64,15 @@ class TestClient(unittest.TestCase):
         dataset2 = client.get_dataset_info_by_uuid(dataset.uuid)
         self.assertEqual(dataset, dataset2)
 
+    def test_search_for_property_not_set(self):
+        """"""
+        client = Client()
+
+        nocountry = client.list_dataset_infos(data_type="earthquake",
+                                              properties={'country_name': None})[0]
+        self.assertNotIn('country_name', nocountry.properties)
+        self.assertIn('spatial_coverage', nocountry.properties)
+
     def test_dataset_offline(self):
         """"""
         client = Client()

--- a/climada/util/api_client.py
+++ b/climada/util/api_client.py
@@ -334,7 +334,9 @@ class Client():
     def _divide_straight_from_multi(properties):
         straights, multis = dict(), dict()
         for k, _v in properties.items():
-            if isinstance(_v, str):
+            if _v is None:
+                straights[k] = ''
+            elif isinstance(_v, str):
                 straights[k] = _v
             elif isinstance(_v, list):
                 multis[k] = _v


### PR DESCRIPTION
Changes proposed in this PR:
- Small change so that the `api_client.Client.list_dataset_infos` accepts `None` as a property value.
  So far only strings and list of strings were accepted. This allows looking for unset properties with the more intuitive `None`. 
  Before one had to look for `""`, an empty string.


This PR fixes #

### PR Author Checklist

- [ ] Read the [Contribution Guide][contrib]
- [x] Correct target branch selected (if unsure, select `develop`)
- [x] Descriptive pull request title added
- [x] Source branch up-to-date with target branch
- [ ] [Documentation](https://climada-python.readthedocs.io/en/latest/guide/Guide_PythonDos-n-Donts.html#2.--Commenting-&-Documenting) updated
- [x] [Tests][testing] updated
- [ ] [Tests][testing] passing
- [x] No new [linter issues][linter]
- [x] [Changelog](https://github.com/CLIMADA-project/climada_python/blob/main/CHANGELOG.md) updated

### PR Reviewer Checklist

- [x] Read the [Contribution Guide][contrib]
- [x] [CLIMADA Reviewer Checklist](https://climada-python.readthedocs.io/en/latest/guide/Guide_Reviewer_Checklist.html) passed
- [x] [Tests][testing] passing
- [x] No new [linter issues][linter]

[contrib]: https://github.com/CLIMADA-project/climada_python/blob/main/CONTRIBUTING.md
[testing]: https://climada-python.readthedocs.io/en/latest/guide/Guide_Continuous_Integration_and_Testing.html
[linter]: https://climada-python.readthedocs.io/en/stable/guide/Guide_Continuous_Integration_and_Testing.html#3.C.--Static-Code-Analysis
