### PR TITLE
Fix bug in centroids natural earth feature test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ Removed:
 
 - `util.lines_polys_handler` solve polygon disaggregation issue in metre-based projection [#666](https://github.com/CLIMADA-project/climada_python/pull/666)
 - Problem with `pyproj.CRS` as `Impact` attribute, [#706](https://github.com/CLIMADA-project/climada_python/issues/706). Now CRS is always stored as `str` in WKT format.
+- Correctly handle assertion errors in `Centroids.values_from_vector_files` and fix the associated test [#768](https://github.com/CLIMADA-project/climada_python/pull/768/)
 
 ### Deprecated
 

--- a/climada/hazard/centroids/centr.py
+++ b/climada/hazard/centroids/centr.py
@@ -575,19 +575,24 @@ class Centroids():
             Sparse array of shape (len(val_name), len(geometry)).
         """
         if val_names is None:
-            val_names = ['intensity']
+            val_names = ["intensity"]
 
         values = []
         for file_name in file_names:
             tmp_lat, tmp_lon, tmp_geometry, data = u_coord.read_vector(
-                file_name, val_names, dst_crs=dst_crs)
-            if not (u_coord.equal_crs(tmp_geometry.crs, self.geometry.crs)
-                    and np.allclose(tmp_lat, self.lat)
-                    and np.allclose(tmp_lon, self.lon)):
-                raise ValueError('Vector data inconsistent with contained vector.')
+                file_name, val_names, dst_crs=dst_crs
+            )
+            try:
+                assert u_coord.equal_crs(tmp_geometry.crs, self.geometry.crs)
+                np.testing.assert_allclose(tmp_lat, self.lat)
+                np.testing.assert_allclose(tmp_lon, self.lon)
+            except AssertionError as exc:
+                raise ValueError(
+                    "Vector data inconsistent with contained vector"
+                ) from exc
             values.append(sparse.csr_matrix(data))
 
-        return sparse.vstack(values, format='csr')
+        return sparse.vstack(values, format="csr")
 
     def read_mat(self, *args, **kwargs):
         """This function is deprecated, use Centroids.from_mat instead."""

--- a/climada/hazard/centroids/test/test_vec_ras.py
+++ b/climada/hazard/centroids/test/test_vec_ras.py
@@ -617,8 +617,11 @@ class TestReader(unittest.TestCase):
         # Test reading values from file with incompatible geometry
         shp_file = shapereader.natural_earth(resolution='10m', category='cultural',
                                              name='populated_places_simple')
-        with self.assertRaises(ValueError):
-            centr.values_from_vector_files(shp_file, val_names=['pop_min', 'pop_max'])
+        with self.assertRaises(ValueError) as cm:
+            centr.values_from_vector_files([shp_file], val_names=['pop_min', 'pop_max'])
+        self.assertIn(
+            "Vector data inconsistent with contained vector", str(cm.exception)
+        )
 
     def test_from_raster_file_wrong_fail(self):
         """Test from_raster_file with wrong centroids"""


### PR DESCRIPTION
Changes proposed in this PR:
- Correctly pass a list to the function
- Correctly check consistency of input arrays (`allclose` could also throw errors if the arrays had a wrong size, but this was not accounted for)

The original test incorrectly checked for a `ValueError`: The `natural_earth` method would return a string (which was iterable), and a `ValueError` was thrown because a file could not be read from a single character...

This PR fixes the broken pipeline in `develop`

### PR Author Checklist

- [x] Read the [Contribution Guide][contrib]
- [x] Correct target branch selected (if unsure, select `develop`)
- [x] Descriptive pull request title added
- [x] Source branch up-to-date with target branch
- [ ] [Documentation](https://climada-python.readthedocs.io/en/latest/guide/Guide_PythonDos-n-Donts.html#2.--Commenting-&-Documenting) updated
- [x] [Tests][testing] updated
- [ ] [Tests][testing] passing
- [ ] No new [linter issues][linter]
- [x] [Changelog](https://github.com/CLIMADA-project/climada_python/blob/main/CHANGELOG.md) updated

### PR Reviewer Checklist

- [ ] Read the [Contribution Guide][contrib]
- [ ] [CLIMADA Reviewer Checklist](https://climada-python.readthedocs.io/en/latest/guide/Guide_Reviewer_Checklist.html) passed
- [ ] [Tests][testing] passing
- [ ] No new [linter issues][linter]

[contrib]: https://github.com/CLIMADA-project/climada_python/blob/main/CONTRIBUTING.md
[testing]: https://climada-python.readthedocs.io/en/latest/guide/Guide_Continuous_Integration_and_Testing.html
[linter]: https://climada-python.readthedocs.io/en/stable/guide/Guide_Continuous_Integration_and_Testing.html#3.C.--Static-Code-Analysis
