### PR TITLE
Make `Impact.impact_at_reg` support all zero impacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ Removed:
 - Problem with `pyproj.CRS` as `Impact` attribute, [#706](https://github.com/CLIMADA-project/climada_python/issues/706). Now CRS is always stored as `str` in WKT format.
 - Correctly handle assertion errors in `Centroids.values_from_vector_files` and fix the associated test [#768](https://github.com/CLIMADA-project/climada_python/pull/768/)
 - Text in `Forecast` class plots can now be adjusted [#769](https://github.com/CLIMADA-project/climada_python/issues/769)
+- `Impact.impact_at_reg` now supports impact matrices where all entries are zero [#773](https://github.com/CLIMADA-project/climada_python/pull/773)
 
 ### Deprecated
 

--- a/climada/engine/impact.py
+++ b/climada/engine/impact.py
@@ -434,7 +434,7 @@ class Impact():
             Contains the aggregated data per event.
             Rows: Hazard events. Columns: Aggregation regions.
         """
-        if self.imp_mat.nnz == 0:
+        if np.prod(self.imp_mat.shape) == 0:
             raise ValueError(
                 "The aggregated impact cannot be computed as no Impact.imp_mat was "
                 "stored during the impact calculation"

--- a/climada/engine/test/test_impact.py
+++ b/climada/engine/test/test_impact.py
@@ -562,9 +562,13 @@ class TestImpactReg(unittest.TestCase):
 
     def test_no_imp_mat(self):
         """Check error if no impact matrix is stored"""
-        # Test error when no imp_mat is stored
-        self.imp.imp_mat = sparse.csr_matrix((0, 0))
+        # A matrix with only zeros should work!
+        self.imp.imp_mat = sparse.csr_matrix(np.zeros_like(self.imp.imp_mat.toarray()))
+        at_reg = self.imp.impact_at_reg(["A", "A"])
+        self.assertEqual(at_reg["A"].sum(), 0)
 
+        # An empty matrix should not work
+        self.imp.imp_mat = sparse.csr_matrix((0, 0))
         with self.assertRaises(ValueError) as cm:
             self.imp.impact_at_reg()
         self.assertIn("no Impact.imp_mat was stored", str(cm.exception))


### PR DESCRIPTION
Changes proposed in this PR:
- Detect if the shape product of the impact matrix is zero instead of the nonzero entries. The latter could also be the case for a correctly-shaped matrix whose values are all zero.

### PR Author Checklist

- [x] Read the [Contribution Guide][contrib]
- [x] Correct target branch selected (if unsure, select `develop`)
- [x] Descriptive pull request title added
- [x] Source branch up-to-date with target branch
- [ ] [Documentation](https://climada-python.readthedocs.io/en/latest/guide/Guide_PythonDos-n-Donts.html#2.--Commenting-&-Documenting) updated
- [x] [Tests][testing] updated
- [x] [Tests][testing] passing
- [x] No new [linter issues][linter]
- [x] [Changelog](https://github.com/CLIMADA-project/climada_python/blob/main/CHANGELOG.md) updated

### PR Reviewer Checklist

- [x] Read the [Contribution Guide][contrib]
- [x] [CLIMADA Reviewer Checklist](https://climada-python.readthedocs.io/en/latest/guide/Guide_Reviewer_Checklist.html) passed
- [x] [Tests][testing] passing
- [x] No new [linter issues][linter]

[contrib]: https://github.com/CLIMADA-project/climada_python/blob/main/CONTRIBUTING.md
[testing]: https://climada-python.readthedocs.io/en/latest/guide/Guide_Continuous_Integration_and_Testing.html
[linter]: https://climada-python.readthedocs.io/en/stable/guide/Guide_Continuous_Integration_and_Testing.html#3.C.--Static-Code-Analysis
