### PR TITLE
Remove pandas append to concat

### DIFF
--- a/climada/util/test/test_lines_polys_handler.py
+++ b/climada/util/test/test_lines_polys_handler.py
@@ -24,6 +24,7 @@ from unittest.mock import patch, DEFAULT
 
 import numpy as np
 import geopandas as gpd
+import pandas as pd
 import copy
 
 from shapely.geometry import Point
@@ -366,7 +367,7 @@ class TestGeomImpactCalcs(unittest.TestCase):
     def test_calc_geom_impact_mixed(self):
         """ test calc_geom_impact() with a mixed exp (points, lines and polygons) """
         # mixed exposures
-        gdf_mix = GDF_LINE.append(GDF_POLY).append(GDF_POINT).reset_index(drop=True)
+        gdf_mix = pd.concat([GDF_LINE, GDF_POLY, GDF_POINT]).reset_index(drop=True)
         exp_mix = Exposures(gdf_mix)
 
         imp1 = u_lp.calc_geom_impact(
@@ -444,7 +445,7 @@ class TestGeomImpactCalcs(unittest.TestCase):
 
     def test_impact_pnt_agg(self):
         """Test impact agreggation method"""
-        gdf_mix = GDF_LINE.append(GDF_POLY).append(GDF_POINT).reset_index(drop=True)
+        gdf_mix = pd.concat([GDF_LINE, GDF_POLY, GDF_POINT]).reset_index(drop=True)
         exp_mix = Exposures(gdf_mix)
 
         exp_pnt = u_lp.exp_geom_to_pnt(


### PR DESCRIPTION
Changes proposed in this PR:
- Solves upgrade pandas 1.5 -> 2.0 
- Replace `gdf.append` with `pd.concat`.

This PR fixes #700

### PR Author Checklist

- [ ] Read the [Contribution Guide][contrib]
- [ ] Correct target branch selected (if unsure, select `develop`)
- [ ] Descriptive pull request title added
- [ ] Source branch up-to-date with target branch
- [ ] [Documentation](https://climada-python.readthedocs.io/en/latest/guide/Guide_PythonDos-n-Donts.html#2.--Commenting-&-Documenting) updated
- [ ] [Tests][testing] updated
- [ ] [Tests][testing] passing
- [ ] No new [linter issues][linter]
- [ ] [Changelog](https://github.com/CLIMADA-project/climada_python/blob/main/CHANGELOG.md) updated

### PR Reviewer Checklist

- [ ] Read the [Contribution Guide][contrib]
- [ ] [CLIMADA Reviewer Checklist](https://climada-python.readthedocs.io/en/latest/guide/Guide_Reviewer_Checklist.html) passed
- [ ] [Tests][testing] passing
- [ ] No new [linter issues][linter]

[contrib]: https://github.com/CLIMADA-project/climada_python/blob/main/CONTRIBUTING.md
[testing]: https://climada-python.readthedocs.io/en/latest/guide/Guide_Continuous_Integration_and_Testing.html
[linter]: https://climada-python.readthedocs.io/en/stable/guide/Guide_Continuous_Integration_and_Testing.html#3.C.--Static-Code-Analysis
