### PR TITLE
Fix empty data frame concatenation in emdat_impact_yearlysum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ Code freeze date: YYYY-MM-DD
 
 ### Changed
 
+- Rearranged file-system structure: `data` is now a subdirectory of `climada_python` and not deployed to the environment root anymore. [#781](https://github.com/CLIMADA-project/climada_python/pull/781)
+
 ### Fixed
 
 ### Deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,6 @@ Code freeze date: YYYY-MM-DD
 
 ### Changed
 
-- Rearranged file-system structure: `data` is now a subdirectory of `climada_python` and not deployed to the environment root anymore. [#781](https://github.com/CLIMADA-project/climada_python/pull/781)
-
 ### Fixed
 
 ### Deprecated

--- a/climada/engine/impact_data.py
+++ b/climada/engine/impact_data.py
@@ -811,28 +811,37 @@ def emdat_impact_yearlysum(emdat_file_csv, countries=None, hazard=None, year_ran
             if not df_country.size:
                 continue
 
+            # Retrieve impact data for all years
             all_years = np.arange(min(df_data.Year), max(df_data.Year) + 1)
-            data_out = pd.DataFrame(index=np.arange(0, len(all_years)),
-                                    columns=['ISO', 'region_id', 'year', 'impact',
-                                             'impact_scaled', 'reference_year'])
-            for cnt, year in enumerate(all_years):
-                data_out.loc[cnt, 'year'] = year
-                data_out.loc[cnt, 'reference_year'] = reference_year
-                data_out.loc[cnt, 'ISO'] = country
-                data_out.loc[cnt, 'region_id'] = u_coord.country_to_iso(country, "numeric")
-                data_out.loc[cnt, 'impact'] = \
-                    np.nansum(df_country[df_country.Year.isin([year])][imp_str])
-                data_out.loc[cnt, 'impact_scaled'] = \
-                    np.nansum(df_country[df_country.Year.isin([year])][imp_str + " scaled"])
-                if '000 US' in imp_str:  # EM-DAT damages provided in '000 USD
-                    data_out.loc[cnt, 'impact'] = data_out.loc[cnt, 'impact'] * 1e3
-                    data_out.loc[cnt, 'impact_scaled'] = data_out.loc[cnt, 'impact_scaled'] * 1e3
+            data_out = pd.DataFrame.from_records(
+                [
+                    (
+                        year,
+                        np.nansum(df_country[df_country.Year.isin([year])][imp_str]),
+                        np.nansum(
+                            df_country[df_country.Year.isin([year])][
+                                imp_str + " scaled"
+                            ]
+                        ),
+                    )
+                    for year in all_years
+                ],
+                columns=["year", "impact", "impact_scaled"]
+            )
+
+            # Add static data
+            data_out["reference_year"] = reference_year
+            data_out["ISO"] = country
+            data_out["region_id"] = u_coord.country_to_iso(country, "numeric")
+
+            # EMDAT provides damage data in 1000 USD
+            if "000 US" in imp_str:
+                data_out["impact"] = data_out["impact"] * 1e3
+                data_out["impact_scaled"] = data_out["impact_scaled"] * 1e3
 
             yield data_out
 
-    out = pd.concat(list(country_df(df_data)))
-
-    out = out.reset_index(drop=True)
+    out = pd.concat(list(country_df(df_data)), ignore_index=True)
     return out
 
 

--- a/climada/engine/impact_data.py
+++ b/climada/engine/impact_data.py
@@ -802,29 +802,36 @@ def emdat_impact_yearlysum(emdat_file_csv, countries=None, hazard=None, year_ran
     df_data[imp_str + " scaled"] = scale_impact2refyear(df_data[imp_str].values,
                                                         df_data.Year.values, df_data.ISO.values,
                                                         reference_year=reference_year)
-    out = pd.DataFrame(columns=['ISO', 'region_id', 'year', 'impact',
-                                'impact_scaled', 'reference_year'])
-    for country in df_data.ISO.unique():
-        country = u_coord.country_to_iso(country, "alpha3")
-        if not df_data.loc[df_data.ISO == country].size:
-            continue
-        all_years = np.arange(min(df_data.Year), max(df_data.Year) + 1)
-        data_out = pd.DataFrame(index=np.arange(0, len(all_years)),
-                                columns=out.columns)
-        df_country = df_data.loc[df_data.ISO == country]
-        for cnt, year in enumerate(all_years):
-            data_out.loc[cnt, 'year'] = year
-            data_out.loc[cnt, 'reference_year'] = reference_year
-            data_out.loc[cnt, 'ISO'] = country
-            data_out.loc[cnt, 'region_id'] = u_coord.country_to_iso(country, "numeric")
-            data_out.loc[cnt, 'impact'] = \
-                np.nansum(df_country[df_country.Year.isin([year])][imp_str])
-            data_out.loc[cnt, 'impact_scaled'] = \
-                np.nansum(df_country[df_country.Year.isin([year])][imp_str + " scaled"])
-            if '000 US' in imp_str:  # EM-DAT damages provided in '000 USD
-                data_out.loc[cnt, 'impact'] = data_out.loc[cnt, 'impact'] * 1e3
-                data_out.loc[cnt, 'impact_scaled'] = data_out.loc[cnt, 'impact_scaled'] * 1e3
-        out = pd.concat([out, data_out])
+
+    def country_df(df_data):
+        for data_iso in df_data.ISO.unique():
+            country = u_coord.country_to_iso(data_iso, "alpha3")
+
+            df_country = df_data.loc[df_data.ISO == country]
+            if not df_country.size:
+                continue
+
+            all_years = np.arange(min(df_data.Year), max(df_data.Year) + 1)
+            data_out = pd.DataFrame(index=np.arange(0, len(all_years)),
+                                    columns=['ISO', 'region_id', 'year', 'impact',
+                                             'impact_scaled', 'reference_year'])
+            for cnt, year in enumerate(all_years):
+                data_out.loc[cnt, 'year'] = year
+                data_out.loc[cnt, 'reference_year'] = reference_year
+                data_out.loc[cnt, 'ISO'] = country
+                data_out.loc[cnt, 'region_id'] = u_coord.country_to_iso(country, "numeric")
+                data_out.loc[cnt, 'impact'] = \
+                    np.nansum(df_country[df_country.Year.isin([year])][imp_str])
+                data_out.loc[cnt, 'impact_scaled'] = \
+                    np.nansum(df_country[df_country.Year.isin([year])][imp_str + " scaled"])
+                if '000 US' in imp_str:  # EM-DAT damages provided in '000 USD
+                    data_out.loc[cnt, 'impact'] = data_out.loc[cnt, 'impact'] * 1e3
+                    data_out.loc[cnt, 'impact_scaled'] = data_out.loc[cnt, 'impact_scaled'] * 1e3
+
+            yield data_out
+
+    out = pd.concat(list(country_df(df_data)))
+
     out = out.reset_index(drop=True)
     return out
 

--- a/climada/engine/test/test_impact_data.py
+++ b/climada/engine/test/test_impact_data.py
@@ -156,8 +156,6 @@ class TestEmdatProcessing(unittest.TestCase):
                 reference_year=None,
                 imp_str="Total Affected",
             )
-            # TODO: pandas 2.1 will eventually raise a FutureWarning here, 
-            # but about array concatenation of empty entries. fix it!
 
     def test_emdat_affected_yearlysum(self):
         """test emdat_impact_yearlysum yearly impact data extraction"""


### PR DESCRIPTION
`impact_data.emdat_impact_yearlysum` used to concatenate empty data frames, starting with an empty one and then iteratively adding non-empty ones. This triggers a deprecation warning in pandas >= 2.1.

Changes proposed in this PR:
- Instead of starting with an empty DataFrame, all non-empty DatatFrames are gathered in a generator which is then concatenated at once.

This PR fixes #

### PR Author Checklist

- [ ] Read the [Contribution Guide][contrib]
- [x] Correct target branch selected (if unsure, select `develop`)
- [x] Descriptive pull request title added
- [x] Source branch up-to-date with target branch
- [ ] [Documentation](https://climada-python.readthedocs.io/en/latest/guide/Guide_PythonDos-n-Donts.html#2.--Commenting-&-Documenting) updated
- [ ] [Tests][testing] updated
- [x] [Tests][testing] passing
- [x] No new [linter issues][linter]
- [ ] [Changelog](https://github.com/CLIMADA-project/climada_python/blob/main/CHANGELOG.md) updated

### PR Reviewer Checklist

- [ ] Read the [Contribution Guide][contrib]
- [ ] [CLIMADA Reviewer Checklist](https://climada-python.readthedocs.io/en/latest/guide/Guide_Reviewer_Checklist.html) passed
- [ ] [Tests][testing] passing
- [ ] No new [linter issues][linter]

[contrib]: https://github.com/CLIMADA-project/climada_python/blob/main/CONTRIBUTING.md
[testing]: https://climada-python.readthedocs.io/en/latest/guide/Guide_Continuous_Integration_and_Testing.html
[linter]: https://climada-python.readthedocs.io/en/stable/guide/Guide_Continuous_Integration_and_Testing.html#3.C.--Static-Code-Analysis
