### PR TITLE
Antimeridian issue in `get_country_code`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ Code freeze date: YYYY-MM-DD
 
 ### Fixed
 
+- `climada.util.coordinates.get_country_code` bug, occurring with non-standard longitudinal coordinates around the anti-meridian. [#770](https://github.com/CLIMADA-project/climada_python/issues/770)
+
 ### Deprecated
 
 ### Removed

--- a/climada/util/coordinates.py
+++ b/climada/util/coordinates.py
@@ -1506,49 +1506,6 @@ def natearth_country_to_int(country):
         return int(country.ISO_N3)
     return country_to_iso(str(country.NAME), representation="numeric")
 
-
-def longitudinal_extent(lon: np.ndarray):
-    """Calculate the extent of an array of longitudinal coordinates.
-    Since those are located around a circle, the widest gap between them is identified and the
-    extent is consideered the inverse part of the circle.
-
-    Parameters
-    ----------
-    lon : np.ndarray
-        longitude of points in epsg:4326
-
-    Returns
-    -------
-    (number, number)
-        the western and eastern longitudinal boundaries that define the extent,
-        the former is granted to be smaller than the latter, if necessary 360 degree will be added
-        or subtracted from either of the values.
-    """
-    arr = lon.copy()  ## unnecessary - if it wasn't for the next four lines
-    while (arr < -180).any():
-        arr[arr < -180] += 360  ## shouldn't happen, just in case...
-    while (arr > 180).any():
-        arr[arr > 180] -= 360  ## dito
-
-    sortd = arr.copy()
-    sortd.sort()
-    topdiff = (
-        np.append(sortd[1:], [sortd[0] + 360]) - sortd
-    ).argmax()
-
-    sorted_index = arr.argsort()
-    max_i = sorted_index[topdiff]
-    min_i = sorted_index[(topdiff + 1) % arr.size]
-
-    e_west = arr[min_i]
-    e_east = arr[max_i]
-    if e_west <= e_east:
-        return e_west, e_east
-    if 180 - e_west < e_east + 180:
-        return e_west - 360, e_east
-    return e_west, e_east + 360
-
-
 def get_country_code(lat, lon, gridded=False):
     """Provide numeric (ISO 3166) code for every point.
 
@@ -1557,9 +1514,9 @@ def get_country_code(lat, lon, gridded=False):
 
     Parameters
     ----------
-    lat : np.ndarray
+    lat : np.array
         latitude of points in epsg:4326
-    lon : np.ndarray
+    lon : np.array
         longitude of points in epsg:4326
     gridded : bool
         If True, interpolate precomputed gridded data which is usually much faster. Default: False.
@@ -1582,9 +1539,7 @@ def get_country_code(lat, lon, gridded=False):
                                        method='nearest', fill_value=0)
         region_id = region_id.astype(int)
     else:
-        lonmin, lonmax = longitudinal_extent(lon)
-        extent = (lonmin - 0.001, lonmax + 0.001,
-                  lat.min() - 0.001, lat.max() + 0.001)
+        extent = latlon_bounds(lat, lon, 0.001)
         countries = get_country_geometries(extent=extent)
         with warnings.catch_warnings():
             # in order to suppress the following

--- a/climada/util/coordinates.py
+++ b/climada/util/coordinates.py
@@ -1539,8 +1539,8 @@ def get_country_code(lat, lon, gridded=False):
                                        method='nearest', fill_value=0)
         region_id = region_id.astype(int)
     else:
-        extent = latlon_bounds(lat, lon, 0.001)
-        countries = get_country_geometries(extent=extent)
+        (lon_min, lat_min, lon_max, lat_max) = latlon_bounds(lat, lon, 0.001)
+        countries = get_country_geometries(extent=(lon_min, lon_max, lat_min, lat_max))
         with warnings.catch_warnings():
             # in order to suppress the following
             # UserWarning: Geometry is in a geographic CRS. Results from 'area' are likely

--- a/climada/util/coordinates.py
+++ b/climada/util/coordinates.py
@@ -1524,9 +1524,11 @@ def longitudinal_extent(lon: np.ndarray):
         the former is granted to be smaller than the latter, if necessary 360 degree will be added
         or subtracted from either of the values.
     """
-    arr = lon.copy()  ## unnecessary - if it wasn't for the next two lines
-    arr[arr < -180] += 360  ## shouldn't happen, just in case...
-    arr[arr > 180] -= 360  ## dito
+    arr = lon.copy()  ## unnecessary - if it wasn't for the next four lines
+    while (arr < -180).any():
+        arr[arr < -180] += 360  ## shouldn't happen, just in case...
+    while (arr > 180).any():
+        arr[arr > 180] -= 360  ## dito
 
     sortd = arr.copy()
     sortd.sort()

--- a/climada/util/test/test_coordinates.py
+++ b/climada/util/test/test_coordinates.py
@@ -492,6 +492,19 @@ class TestFunc(unittest.TestCase):
         self.assertEqual(u_coord.country_natid2iso(natid_list), al3_list)
         self.assertEqual(u_coord.country_natid2iso(natid_list[1]), al3_list[1])
 
+    def test_longitudinal_extent(self):
+        # test longitudinal extent calculation
+        # find the biggest gap
+        self.assertEqual((-100, 140), u_coord.longitudinal_extent(np.array([20, 80, 140, 260, 320])))
+        # adjust so that the western boundary is smaller than the eastern boundary
+        self.assertEqual((-181, -171), u_coord.longitudinal_extent(np.array([-171,179])))
+        self.assertEqual((171, 181), u_coord.longitudinal_extent(np.array([171,-179])))
+        self.assertEqual((175, 185), u_coord.longitudinal_extent(np.array([-175,175])))
+        # don't fail (completely) if all gaps are equal
+        arbitrary_extent = u_coord.longitudinal_extent(np.array([20, 80, 140, -160, -100, -40]))
+        self.assertEqual(300, arbitrary_extent[1] - arbitrary_extent[0])
+
+
 class TestAssign(unittest.TestCase):
     """Test coordinate assignment functions"""
 

--- a/climada/util/test/test_coordinates.py
+++ b/climada/util/test/test_coordinates.py
@@ -492,18 +492,6 @@ class TestFunc(unittest.TestCase):
         self.assertEqual(u_coord.country_natid2iso(natid_list), al3_list)
         self.assertEqual(u_coord.country_natid2iso(natid_list[1]), al3_list[1])
 
-    def test_longitudinal_extent(self):
-        # test longitudinal extent calculation
-        # find the biggest gap
-        self.assertEqual((-100, 140), u_coord.longitudinal_extent(np.array([20, 80, 140, 260, 320])))
-        # adjust so that the western boundary is smaller than the eastern boundary
-        self.assertEqual((-181, -171), u_coord.longitudinal_extent(np.array([-171,179])))
-        self.assertEqual((171, 181), u_coord.longitudinal_extent(np.array([171,-179])))
-        self.assertEqual((175, 185), u_coord.longitudinal_extent(np.array([-175,175])))
-        # don't fail (completely) if all gaps are equal
-        arbitrary_extent = u_coord.longitudinal_extent(np.array([20, 80, 140, -160, -100, -40]))
-        self.assertEqual(300, arbitrary_extent[1] - arbitrary_extent[0])
-
 
 class TestAssign(unittest.TestCase):
     """Test coordinate assignment functions"""


### PR DESCRIPTION
Changes proposed in this PR:
- use `latlon_bounds` in `climada.util.coordinates.get_country_code`, in order to avoid antimeridian problems

This PR fixes #770

### PR Author Checklist

- [ ] Read the [Contribution Guide][contrib]
- [x] Correct target branch selected (if unsure, select `develop`)
- [x] Descriptive pull request title added
- [x] Source branch up-to-date with target branch
- [ ] [Documentation](https://climada-python.readthedocs.io/en/latest/guide/Guide_PythonDos-n-Donts.html#2.--Commenting-&-Documenting) updated
- [ ] [Tests][testing] updated
- [x] [Tests][testing] passing
- [x] No new [linter issues][linter]
- [ ] [Changelog](https://github.com/CLIMADA-project/climada_python/blob/main/CHANGELOG.md) updated

### PR Reviewer Checklist

- [ ] Read the [Contribution Guide][contrib]
- [ ] [CLIMADA Reviewer Checklist](https://climada-python.readthedocs.io/en/latest/guide/Guide_Reviewer_Checklist.html) passed
- [ ] [Tests][testing] passing
- [ ] No new [linter issues][linter]

[contrib]: https://github.com/CLIMADA-project/climada_python/blob/main/CONTRIBUTING.md
[testing]: https://climada-python.readthedocs.io/en/latest/guide/Guide_Continuous_Integration_and_Testing.html
[linter]: https://climada-python.readthedocs.io/en/stable/guide/Guide_Continuous_Integration_and_Testing.html#3.C.--Static-Code-Analysis
