### PR TITLE
Change default Hazard.event_name to string of event_id

### DIFF
--- a/climada/hazard/base.py
+++ b/climada/hazard/base.py
@@ -518,7 +518,7 @@ class Hazard():
               :py:meth:`Hazard.__init__` for details.
             * ``hazard_type``: Empty string
             * ``frequency``: 1.0 for every event
-            * ``event_name``: String representation of the event time
+            * ``event_name``: String representation of the event id
             * ``event_id``: Consecutive integers starting at 1 and increasing with time
         crs : str, optional
             Identifier for the coordinate reference system of the coordinates. Defaults
@@ -840,7 +840,7 @@ class Hazard():
                     None,
                     np.ones(num_events),
                     np.array(range(num_events), dtype=int) + 1,
-                    list(data[coords["event"]].values),
+                    [str(x) for x in np.array(range(num_events), dtype=int) + 1],
                     np.array(u_dt.datetime64_to_ordinal(data[coords["event"]].values)),
                 ],
                 # The accessor for the data in the Dataset

--- a/climada/hazard/test/test_base_xarray.py
+++ b/climada/hazard/test/test_base_xarray.py
@@ -72,7 +72,7 @@ class TestReadDefaultNetCDF(unittest.TestCase):
         self.assertEqual(hazard.units, "")
         np.testing.assert_array_equal(hazard.event_id, [1, 2])
         np.testing.assert_array_equal(
-            hazard.event_name, [np.datetime64(val) for val in self.time]
+            hazard.event_name, [str(x) for x in hazard.event_id]
         )
         np.testing.assert_array_equal(
             hazard.date, [val.toordinal() for val in self.time]
@@ -342,9 +342,7 @@ class TestReadDefaultNetCDF(unittest.TestCase):
             ds = ds.isel(time=0).squeeze()
             hazard = Hazard.from_xarray_raster(ds, "", "")
             self._assert_default_types(hazard)
-            np.testing.assert_array_equal(
-                hazard.event_name, [np.datetime64(self.time[0])]
-            )
+
             np.testing.assert_array_equal(hazard.date, [self.time[0].toordinal()])
             np.testing.assert_array_equal(hazard.centroids.lat, [0, 0, 0, 1, 1, 1])
             np.testing.assert_array_equal(hazard.centroids.lon, [0, 1, 2, 0, 1, 2])
@@ -369,9 +367,6 @@ class TestReadDefaultNetCDF(unittest.TestCase):
             ds = ds.expand_dims(time=[np.datetime64("2022-01-01")])
             hazard = Hazard.from_xarray_raster(ds, "", "")
             self._assert_default_types(hazard)
-            np.testing.assert_array_equal(
-                hazard.event_name, [np.datetime64("2022-01-01")]
-            )
             np.testing.assert_array_equal(
                 hazard.date, [dt.datetime(2022, 1, 1).toordinal()]
             )


### PR DESCRIPTION
Changes proposed in this PR:
- changed default Hazard.event_name to string representation of event_id
- changed Hazard test_base_xarray.py accordingly

This PR fixes #789 

### PR Author Checklist

- [x] Read the [Contribution Guide][contrib]
- [x] Correct target branch selected (if unsure, select `develop`)
- [x] Descriptive pull request title added
- [x] Source branch up-to-date with target branch
- [x] [Documentation](https://climada-python.readthedocs.io/en/latest/guide/Guide_PythonDos-n-Donts.html#2.--Commenting-&-Documenting) updated
- [x] [Tests][testing] updated
- [x] [Tests][testing] passing
- [ ] No new [linter issues][linter]
- [ ] [Changelog](https://github.com/CLIMADA-project/climada_python/blob/main/CHANGELOG.md) updated

### PR Reviewer Checklist

- [ ] Read the [Contribution Guide][contrib]
- [ ] [CLIMADA Reviewer Checklist](https://climada-python.readthedocs.io/en/latest/guide/Guide_Reviewer_Checklist.html) passed
- [ ] [Tests][testing] passing
- [ ] No new [linter issues][linter]

[contrib]: https://github.com/CLIMADA-project/climada_python/blob/main/CONTRIBUTING.md
[testing]: https://climada-python.readthedocs.io/en/latest/guide/Guide_Continuous_Integration_and_Testing.html
[linter]: https://climada-python.readthedocs.io/en/stable/guide/Guide_Continuous_Integration_and_Testing.html#3.C.--Static-Code-Analysis
