### PR TITLE
Add shapes argument to geo_im_from_array() in climada.util.plot

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -29,3 +29,4 @@
 * Raphael Portmann
 * Nicolas Colombi
 * Leonie Villiger
+* Kam Lam Yeung

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Code freeze date: YYYY-MM-DD
 ### Dependency Changes
 
 ### Added
+- Add `shapes` argument to `geo_im_from_array` to allow flexible turning on/off of plotting coastline in `plot_intensity`.
+[#805](https://github.com/CLIMADA-project/climada_python/pull/805)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,10 @@ Code freeze date: YYYY-MM-DD
 ### Dependency Changes
 
 ### Added
-- Add `shapes` argument to `geo_im_from_array` to allow flexible turning on/off of plotting coastline in `plot_intensity`.
-[#805](https://github.com/CLIMADA-project/climada_python/pull/805)
 
 ### Changed
 
+- Add `shapes` argument to `geo_im_from_array` to allow flexible turning on/off of plotting coastline in `plot_intensity`. [#805](https://github.com/CLIMADA-project/climada_python/pull/805)
 - Update `CONTRIBUTING.md` to better explain types of contributions to this repository [#797](https://github.com/CLIMADA-project/climada_python/pull/797)
 - The default tile layer in Exposures maps is not Stamen Terrain anymore, but [CartoDB Positron](https://github.com/CartoDB/basemap-styles). Affected methods are `climada.engine.Impact.plot_basemap_eai_exposure`,`climada.engine.Impact.plot_basemap_impact_exposure` and `climada.entity.Exposures.plot_basemap`. [#798](https://github.com/CLIMADA-project/climada_python/pull/798)
 

--- a/climada/util/plot.py
+++ b/climada/util/plot.py
@@ -251,7 +251,7 @@ def _plot_scattered_data(method, array_sub, geo_coord, var_name, title,
 
 
 def geo_im_from_array(array_sub, coord, var_name, title,
-                      proj=None, smooth=True, axes=None, figsize=(9, 13), adapt_fontsize=True,
+                      proj=None, smooth=True, shapes=True, axes=None, figsize=(9, 13), adapt_fontsize=True,
                       **kwargs):
     """Image(s) plot defined in array(s) over input coordinates.
 
@@ -272,6 +272,9 @@ def geo_im_from_array(array_sub, coord, var_name, title,
         coordinate reference system used in coordinates, by default None
     smooth : bool, optional
         smooth plot to RESOLUTIONxRESOLUTION, by default True
+    shapes : bool, optional
+        Overlay Earth's countries coastlines to matplotlib.pyplot axis.
+        The default is True
     axes : Axes or ndarray(Axes), optional
         by default None
     figsize : tuple, optional
@@ -349,7 +352,8 @@ def geo_im_from_array(array_sub, coord, var_name, title,
                          extent[2], extent[3]), crs=proj)
 
         # Add coastline to axis
-        add_shapes(axis)
+        if shapes:
+            add_shapes(axis)
         # Create colormesh, colorbar and labels in axis
         cbax = make_axes_locatable(axis).append_axes('right', size="6.5%",
                                                      pad=0.1, axes_class=plt.Axes)


### PR DESCRIPTION
Changes proposed in this PR:
- Add shapes argument to [geo_im_from_array][geo_im_from_array] to allow flexible turning on/off of plotting coastline in [plot_intensity][plot_intensity]

This PR fixes [geo_im_from_array][geo_im_from_array]#

### PR Author Checklist

- [x] Read the [Contribution Guide][contrib]
- [x] Correct target branch selected (if unsure, select `develop`)
- [x] Descriptive pull request title added
- [x] Source branch up-to-date with target branch
- [ ] [Documentation](https://climada-python.readthedocs.io/en/latest/guide/Guide_PythonDos-n-Donts.html#2.--Commenting-&-Documenting) updated
- [ ] [Tests][testing] updated
- [ ] [Tests][testing] passing
- [ ] No new [linter issues][linter]
- [x] [Changelog](https://github.com/CLIMADA-project/climada_python/blob/main/CHANGELOG.md) updated

### PR Reviewer Checklist

- [ ] Read the [Contribution Guide][contrib]
- [ ] [CLIMADA Reviewer Checklist](https://climada-python.readthedocs.io/en/latest/guide/Guide_Reviewer_Checklist.html) passed
- [ ] [Tests][testing] passing
- [ ] No new [linter issues][linter]

[contrib]: https://github.com/CLIMADA-project/climada_python/blob/main/CONTRIBUTING.md
[testing]: https://climada-python.readthedocs.io/en/latest/guide/Guide_Continuous_Integration_and_Testing.html
[linter]: https://climada-python.readthedocs.io/en/stable/guide/Guide_Continuous_Integration_and_Testing.html#3.C.--Static-Code-Analysis
[geo_im_from_array]: https://climada-python.readthedocs.io/en/stable/_modules/climada/util/plot.html
[plot_intensity]: https://climada-python.readthedocs.io/en/stable/climada/climada.hazard.html
