### PR TITLE
Fix the exception tests for the latest version of xarray

### DIFF
--- a/climada/hazard/test/test_base_xarray.py
+++ b/climada/hazard/test/test_base_xarray.py
@@ -359,9 +359,8 @@ class TestReadDefaultNetCDF(unittest.TestCase):
 
             # Now drop variable altogether, should raise an error
             ds = ds.drop_vars("time")
-            with self.assertRaises(RuntimeError) as cm:
+            with self.assertRaisesRegex(RuntimeError, "time"):
                 Hazard.from_xarray_raster(ds, "", "")
-            self.assertIn("time", str(cm.exception))
 
             # Expand time again
             ds = ds.expand_dims(time=[np.datetime64("2022-01-01")])
@@ -564,15 +563,13 @@ class TestReadDimsCoordsNetCDF(unittest.TestCase):
         self.assertIn("Unknown coordinates passed: '['bar']'.", str(cm.exception))
 
         # Correctly specified, but the custom dimension does not exist
-        with self.assertRaises(RuntimeError) as cm:
+        with self.assertRaisesRegex(RuntimeError, "lalalatitude"):
             Hazard.from_xarray_raster_file(
                 self.netcdf_path,
                 "",
                 "",
                 coordinate_vars=dict(latitude="lalalatitude"),
             )
-        self.assertIn("lalalatitude", str(cm.exception))
-
 
 # Execute Tests
 if __name__ == "__main__":

--- a/climada/hazard/test/test_base_xarray.py
+++ b/climada/hazard/test/test_base_xarray.py
@@ -361,17 +361,13 @@ class TestReadDefaultNetCDF(unittest.TestCase):
             ds = ds.drop_vars("time")
             with self.assertRaises(RuntimeError) as cm:
                 Hazard.from_xarray_raster(ds, "", "")
-            self.assertIn(
-                "Dataset is missing dimension/coordinate: time", str(cm.exception)
-            )
+            self.assertIn("No variable named 'time'", str(cm.exception))
 
             # Expand time again
             ds = ds.expand_dims(time=[np.datetime64("2022-01-01")])
             hazard = Hazard.from_xarray_raster(ds, "", "")
             self._assert_default_types(hazard)
-            np.testing.assert_array_equal(
-                hazard.event_name, ["2022-01-01"]
-            )
+            np.testing.assert_array_equal(hazard.event_name, ["2022-01-01"])
             np.testing.assert_array_equal(
                 hazard.date, [dt.datetime(2022, 1, 1).toordinal()]
             )
@@ -575,9 +571,7 @@ class TestReadDimsCoordsNetCDF(unittest.TestCase):
                 "",
                 coordinate_vars=dict(latitude="lalalatitude"),
             )
-        self.assertIn(
-            "Dataset is missing dimension/coordinate: lalalatitude.", str(cm.exception)
-        )
+        self.assertIn("No variable named 'lalalatitude'", str(cm.exception))
 
 
 # Execute Tests

--- a/climada/hazard/test/test_base_xarray.py
+++ b/climada/hazard/test/test_base_xarray.py
@@ -361,7 +361,7 @@ class TestReadDefaultNetCDF(unittest.TestCase):
             ds = ds.drop_vars("time")
             with self.assertRaises(RuntimeError) as cm:
                 Hazard.from_xarray_raster(ds, "", "")
-            self.assertIn("No variable named 'time'", str(cm.exception))
+            self.assertIn("time", str(cm.exception))
 
             # Expand time again
             ds = ds.expand_dims(time=[np.datetime64("2022-01-01")])
@@ -571,7 +571,7 @@ class TestReadDimsCoordsNetCDF(unittest.TestCase):
                 "",
                 coordinate_vars=dict(latitude="lalalatitude"),
             )
-        self.assertIn("No variable named 'lalalatitude'", str(cm.exception))
+        self.assertIn("lalalatitude", str(cm.exception))
 
 
 # Execute Tests


### PR DESCRIPTION
Changes proposed in this PR:
- Update the tests because the latest version of xarray (?) changed the error messages slightly

### PR Author Checklist

- [x] Read the [Contribution Guide][contrib]
- [x] Correct target branch selected (if unsure, select `develop`)
- [x] Descriptive pull request title added
- [x] Source branch up-to-date with target branch
- [ ] [Documentation](https://climada-python.readthedocs.io/en/latest/guide/Guide_PythonDos-n-Donts.html#2.--Commenting-&-Documenting) updated
- [x] [Tests][testing] updated
- [x] [Tests][testing] passing
- [x] No new [linter issues][linter]
- [ ] [Changelog](https://github.com/CLIMADA-project/climada_python/blob/main/CHANGELOG.md) updated

### PR Reviewer Checklist

- [ ] Read the [Contribution Guide][contrib]
- [ ] [CLIMADA Reviewer Checklist](https://climada-python.readthedocs.io/en/latest/guide/Guide_Reviewer_Checklist.html) passed
- [ ] [Tests][testing] passing
- [ ] No new [linter issues][linter]

[contrib]: https://github.com/CLIMADA-project/climada_python/blob/main/CONTRIBUTING.md
[testing]: https://climada-python.readthedocs.io/en/latest/guide/Guide_Continuous_Integration_and_Testing.html
[linter]: https://climada-python.readthedocs.io/en/stable/guide/Guide_Continuous_Integration_and_Testing.html#3.C.--Static-Code-Analysis
