### PR TITLE
Allow reading Hazard events that are not dates from xarray

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Code freeze date: YYYY-MM-DD
 - Update `CONTRIBUTING.md` to better explain types of contributions to this repository [#797](https://github.com/CLIMADA-project/climada_python/pull/797)
 - The default tile layer in Exposures maps is not Stamen Terrain anymore, but [CartoDB Positron](https://github.com/CartoDB/basemap-styles). Affected methods are `climada.engine.Impact.plot_basemap_eai_exposure`,`climada.engine.Impact.plot_basemap_impact_exposure` and `climada.entity.Exposures.plot_basemap`. [#798](https://github.com/CLIMADA-project/climada_python/pull/798)
 - Recommend using Mamba instead of Conda for installing CLIMADA [#809](https://github.com/CLIMADA-project/climada_python/pull/809)
+- `Hazard.from_xarray_raster` now allows arbitrary values as 'event' coordinates [#837](https://github.com/CLIMADA-project/climada_python/pull/837)
 
 ### Fixed
 

--- a/climada/hazard/base.py
+++ b/climada/hazard/base.py
@@ -558,7 +558,7 @@ class Hazard():
           ``event_date`` will be broadcast to every event.
         * The ``event`` coordinate may take arbitrary values. In case these values
           cannot be interpreted as dates or date ordinals, the default values for
-          ``Hazard.date`` and ``Hazard.event_name`` will not be useful, see the
+          ``Hazard.date`` and ``Hazard.event_name`` are used, see the
           ``data_vars``` parameter documentation above.
         * To avoid confusion in the call signature, several parameters are keyword-only
           arguments.

--- a/climada/hazard/base.py
+++ b/climada/hazard/base.py
@@ -463,12 +463,13 @@ class Hazard():
     ):
         """Read raster-like data from an xarray Dataset
 
-        This method reads data that can be interpreted using three coordinates for event,
-        latitude, and longitude. The data and the coordinates themselves may be organized
-        in arbitrary dimensions in the Dataset (e.g. three dimensions 'year', 'month',
-        'day' for the coordinate 'event'). The three coordinates to be read can be
-        specified via the ``coordinate_vars`` parameter. See Notes and Examples if you
-        want to load single-event data that does not contain an event dimension.
+        This method reads data that can be interpreted using three coordinates: event,
+        latitude, and longitude. The names of the coordinates to be read from the
+        dataset can be specified via the ``coordinate_vars`` parameter. The data and the
+        coordinates themselves may be organized in arbitrary dimensions (e.g. two
+        dimensions 'year' and 'altitude' for the coordinate 'event').  See Notes and
+        Examples if you want to load single-event data that does not contain an event
+        dimension.
 
         The only required data is the intensity. For all other data, this method can
         supply sensible default values. By default, this method will try to find these
@@ -514,7 +515,7 @@ class Hazard():
             Default values are:
 
             * ``date``: The ``event`` coordinate interpreted as date or ordinal, or
-              zeros if that fails (which will issue a warning).
+              ones if that fails (which will issue a warning).
             * ``fraction``: ``None``, which results in a value of 1.0 everywhere, see
               :py:meth:`Hazard.__init__` for details.
             * ``hazard_type``: Empty string
@@ -555,7 +556,10 @@ class Hazard():
           and Examples) before loading the Dataset as Hazard.
         * Single-valued data for variables ``frequency``. ``event_name``, and
           ``event_date`` will be broadcast to every event.
-        * The ``event`` dimension need not be a time or date.
+        * The ``event`` coordinate may take arbitrary values. In case these values
+          cannot be interpreted as dates or date ordinals, the default values for
+          ``Hazard.date`` and ``Hazard.event_name`` will not be useful, see the
+          ``data_vars``` parameter documentation above.
         * To avoid confusion in the call signature, several parameters are keyword-only
           arguments.
         * The attributes ``Hazard.haz_type`` and ``Hazard.unit`` currently cannot be

--- a/climada/hazard/base.py
+++ b/climada/hazard/base.py
@@ -823,7 +823,8 @@ class Hazard():
 
                 LOGGER.warning(
                     "Failed to read values of '%s' as dates or ordinals. Hazard.date "
-                    "will be ones only" % array.name
+                    "will be ones only",
+                    array.name,
                 )
                 return np.ones(array.shape)
 
@@ -841,7 +842,8 @@ class Hazard():
 
                 LOGGER.warning(
                     "Failed to read values of '%s' as dates. Hazard.event_name will be "
-                    "empty strings" % array.name
+                    "empty strings",
+                    array.name,
                 )
                 return np.full(array.shape, "")
 

--- a/climada/hazard/base.py
+++ b/climada/hazard/base.py
@@ -823,9 +823,9 @@ class Hazard():
 
                 LOGGER.warning(
                     "Failed to read values of '%s' as dates or ordinals. Hazard.date "
-                    "will be zeros only" % array.name
+                    "will be ones only" % array.name
                 )
-                return np.zeros(array.shape)
+                return np.ones(array.shape)
 
         def year_month_day_accessor(
             array: xr.DataArray, strict: bool = True

--- a/climada/hazard/test/test_base_xarray.py
+++ b/climada/hazard/test/test_base_xarray.py
@@ -177,9 +177,7 @@ class TestReadDefaultNetCDF(unittest.TestCase):
                 hazard = Hazard.from_xarray_raster(dataset, "", "")
                 np.testing.assert_array_equal(hazard.date, np.zeros(size))
                 np.testing.assert_array_equal(hazard.event_name, np.full(size, ""))
-            self.assertIn(
-                "Failed to read values of 'time' as dates.", cm.output[0]
-            )
+            self.assertIn("Failed to read values of 'time' as dates.", cm.output[0])
             self.assertIn(
                 "Failed to read values of 'time' as dates or ordinals.", cm.output[1]
             )
@@ -388,9 +386,7 @@ class TestReadDefaultNetCDF(unittest.TestCase):
             ds = ds.expand_dims(time=[np.datetime64("2022-01-01")])
             hazard = Hazard.from_xarray_raster(ds, "", "")
             self._assert_default_types(hazard)
-            np.testing.assert_array_equal(
-                hazard.event_name, ["2022-01-01"]
-            )
+            np.testing.assert_array_equal(hazard.event_name, ["2022-01-01"])
             np.testing.assert_array_equal(
                 hazard.date, [dt.datetime(2022, 1, 1).toordinal()]
             )

--- a/climada/hazard/test/test_base_xarray.py
+++ b/climada/hazard/test/test_base_xarray.py
@@ -39,26 +39,26 @@ class TestReadDefaultNetCDF(unittest.TestCase):
     """Test reading a NetCDF file where the coordinates to read match the dimensions"""
 
     @classmethod
-    def setUp(self):
+    def setUpClass(cls):
         """Write a simple NetCDF file to read"""
-        self.tempdir = TemporaryDirectory()
-        self.netcdf_path = Path(self.tempdir.name) / "default.nc"
-        self.intensity = np.array([[[0, 1, 2], [3, 4, 5]], [[6, 7, 8], [9, 10, 11]]])
-        self.time = np.array([dt.datetime(1999, 1, 1), dt.datetime(2000, 1, 1)])
-        self.latitude = np.array([0, 1])
-        self.longitude = np.array([0, 1, 2])
+        cls.tempdir = TemporaryDirectory()
+        cls.netcdf_path = Path(cls.tempdir.name) / "default.nc"
+        cls.intensity = np.array([[[0, 1, 2], [3, 4, 5]], [[6, 7, 8], [9, 10, 11]]])
+        cls.time = np.array([dt.datetime(1999, 1, 1), dt.datetime(2000, 1, 1)])
+        cls.latitude = np.array([0, 1])
+        cls.longitude = np.array([0, 1, 2])
         dset = xr.Dataset(
             {
-                "intensity": (["time", "latitude", "longitude"], self.intensity),
+                "intensity": (["time", "latitude", "longitude"], cls.intensity),
             },
-            dict(time=self.time, latitude=self.latitude, longitude=self.longitude),
+            dict(time=cls.time, latitude=cls.latitude, longitude=cls.longitude),
         )
-        dset.to_netcdf(self.netcdf_path)
+        dset.to_netcdf(cls.netcdf_path)
 
     @classmethod
-    def tearDown(self):
+    def tearDownClass(cls):
         """Delete the NetCDF file"""
-        self.tempdir.cleanup()
+        cls.tempdir.cleanup()
 
     def _assert_default(self, hazard):
         """Assertions for the default hazard to be loaded"""


### PR DESCRIPTION
Changes proposed in this PR:
* Try interpreting values of the event coordinate as dates or ordinals for default values of `Hazard.date`. If that fails, issue a warning and set default values to zeros.
* Try interpreting values of the event coordinate as dates for default values of `Hazard.event_name`. If that fails, issue a warning and set default values to empty strings.
* Update tests.

The method still tries to read the values as dates but issues a warning if that does not work. The fallback is zeros in case of `Hazard.date` and empty strings for `Hazard.event_name`.

This extends #795, which actually introduced tighter restrictions for the 'event' coordinate. This causes several issues in my new flood module, see https://github.com/CLIMADA-project/climada_petals/pull/64.

This fixes #829.

### PR Author Checklist

- [x] Read the [Contribution Guide][contrib]
- [x] Correct target branch selected (if unsure, select `develop`)
- [x] Descriptive pull request title added
- [x] Source branch up-to-date with target branch
- [x] [Documentation](https://climada-python.readthedocs.io/en/latest/guide/Guide_PythonDos-n-Donts.html#2.--Commenting-&-Documenting) updated
- [x] [Tests][testing] updated
- [x] [Tests][testing] passing
- [x] No new [linter issues][linter]
- [ ] [Changelog](https://github.com/CLIMADA-project/climada_python/blob/main/CHANGELOG.md) updated

### PR Reviewer Checklist

- [ ] Read the [Contribution Guide][contrib]
- [ ] [CLIMADA Reviewer Checklist](https://climada-python.readthedocs.io/en/latest/guide/Guide_Reviewer_Checklist.html) passed
- [ ] [Tests][testing] passing
- [ ] No new [linter issues][linter]

[contrib]: https://github.com/CLIMADA-project/climada_python/blob/main/CONTRIBUTING.md
[testing]: https://climada-python.readthedocs.io/en/latest/guide/Guide_Continuous_Integration_and_Testing.html
[linter]: https://climada-python.readthedocs.io/en/stable/guide/Guide_Continuous_Integration_and_Testing.html#3.C.--Static-Code-Analysis
