### PR TITLE
add impact.select reset_frequency option

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -31,3 +31,4 @@
 * Leonie Villiger
 * Kam Lam Yeung
 * Sarah Hülsen
+* Timo Schmid

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Code freeze date: YYYY-MM-DD
 
 - Convenience method `api_client.Client.get_dataset_file`, combining `get_dataset_info` and `download_dataset`, returning a single file objet. [#821](https://github.com/CLIMADA-project/climada_python/pull/821)
 - Read and Write methods to and from csv files for the `DiscRates` class. [#818](ttps://github.com/CLIMADA-project/climada_python/pull/818)
+- Add reset_frequency option for the impact.select() function. [#847](https://github.com/CLIMADA-project/climada_python/pull/847)
 
 ### Changed
 

--- a/climada/engine/impact.py
+++ b/climada/engine/impact.py
@@ -1477,7 +1477,7 @@ class Impact():
 
     def select(self,
                event_ids=None, event_names=None, dates=None,
-               coord_exp=None):
+               coord_exp=None,reset_frequency=False):
         """
         Select a subset of events and/or exposure points from the impact.
         If multiple input variables are not None, it returns all the impacts
@@ -1509,6 +1509,9 @@ class Impact():
         coord_exp : np.array, optional
             Selection of exposures coordinates [lat, lon] (in degrees)
             The default is None.
+        reset_frequency : bool, optional
+            Change frequency of events proportional to difference between first and last
+            year (old and new). Default: False.
 
         Raises
         ------
@@ -1579,6 +1582,19 @@ class Impact():
             imp.tot_value = None
             LOGGER.info("The total value cannot be re-computed for a "
                         "subset of exposures and is set to None.")
+
+        # reset frequency if date span has changed (optional):
+        if reset_frequency:
+            if self.frequency_unit not in ['1/year', 'annual', '1/y', '1/a']:
+                LOGGER.warning("Resetting the frequency is based on the calendar year of given"
+                    " dates but the frequency unit here is %s. Consider setting the frequency"
+                    " manually for the selection or changing the frequency unit to %s.",
+                    self.frequency_unit, DEF_FREQ_UNIT)
+            year_span_old = np.abs(dt.datetime.fromordinal(self.date.max()).year -
+                                   dt.datetime.fromordinal(self.date.min()).year) + 1
+            year_span_new = np.abs(dt.datetime.fromordinal(imp.date.max()).year -
+                                   dt.datetime.fromordinal(imp.date.min()).year) + 1
+            imp.frequency = imp.frequency * year_span_old / year_span_new
 
         # cast frequency vector into 2d array for sparse matrix multiplication
         freq_mat = imp.frequency.reshape(len(imp.frequency), 1)

--- a/climada/engine/impact.py
+++ b/climada/engine/impact.py
@@ -1475,9 +1475,14 @@ class Impact():
 
         return imp_fit
 
-    def select(self,
-               event_ids=None, event_names=None, dates=None,
-               coord_exp=None,reset_frequency=False):
+    def select(
+        self,
+        event_ids=None,
+        event_names=None,
+        dates=None,
+        coord_exp=None,
+        reset_frequency=False
+    ):
         """
         Select a subset of events and/or exposure points from the impact.
         If multiple input variables are not None, it returns all the impacts
@@ -1511,7 +1516,7 @@ class Impact():
             The default is None.
         reset_frequency : bool, optional
             Change frequency of events proportional to difference between first and last
-            year (old and new). Default: False.
+            year (old and new). Assumes annual frequency values. Default: False.
 
         Raises
         ------

--- a/climada/engine/test/test_impact.py
+++ b/climada/engine/test/test_impact.py
@@ -896,24 +896,9 @@ class TestSelect(unittest.TestCase):
         n_yr = 4
         sel_imp = imp.select(dates=(imp.date[0],imp.date[n_yr-1]), reset_frequency=True)
 
-        # check unchanged attributes
-        self.assertTrue(u_coord.equal_crs(sel_imp.crs, imp.crs))
-        self.assertEqual(sel_imp.unit, imp.unit)
-        self.assertEqual(sel_imp.frequency_unit, imp.frequency_unit)
-        np.testing.assert_array_equal(sel_imp.coord_exp, imp.coord_exp)
-
-        # check sub-selected attributes
-        np.testing.assert_array_equal(sel_imp.event_id, imp.event_id[0:n_yr])
-        self.assertEqual(sel_imp.event_name, imp.event_name[0:n_yr])
-        np.testing.assert_array_equal(sel_imp.date, imp.date[0:n_yr])
-        np.testing.assert_array_equal(sel_imp.at_event, imp.at_event[0:n_yr])
-        np.testing.assert_array_equal(sel_imp.imp_mat.todense(),
-                                      imp.imp_mat[0:n_yr,:].todense())
-
         # check frequency-related attributes
         np.testing.assert_array_equal(sel_imp.frequency, [1/n_yr]*n_yr)
         self.assertEqual(sel_imp.aai_agg,imp.at_event[0:n_yr].sum()/n_yr)
-
         np.testing.assert_array_equal(sel_imp.eai_exp,
                                       imp.imp_mat[0:n_yr,:].todense().sum(axis=0).A1/n_yr)
 

--- a/climada/engine/test/test_impact.py
+++ b/climada/engine/test/test_impact.py
@@ -27,6 +27,7 @@ from scipy import sparse
 import h5py
 from pyproj import CRS
 from rasterio.crs import CRS as rCRS
+import datetime as dt
 
 from climada.entity.entity_def import Entity
 from climada.hazard.base import Hazard
@@ -66,6 +67,24 @@ def dummy_impact():
         ),
         haz_type="TC",
     )
+
+def dummy_impact_yearly():
+    """Return an impact containing events in multiple years"""
+    imp = dummy_impact()
+
+    years = np.arange(2010,2010+len(imp.date))
+
+    # Edit the date and frequency
+    imp.date = np.array([dt.date(year,1,1).toordinal() for year in years])
+    imp.frequency_unit = "1/year"
+    imp.frequency = np.ones(len(years))/len(years)
+
+    # Calculate the correct expected annual impact
+    freq_mat = imp.frequency.reshape(len(imp.frequency), 1)
+    imp.eai_exp = imp.imp_mat.multiply(freq_mat).sum(axis=0).A1
+    imp.aai_agg = imp.eai_exp.sum()
+
+    return imp
 
 
 class TestImpact(unittest.TestCase):
@@ -867,6 +886,37 @@ class TestSelect(unittest.TestCase):
         imp.imp_mat = sparse.csr_matrix(np.empty((0, 0)))
         with self.assertRaises(ValueError):
             imp.select(event_ids=[0], event_names=[1, 'two'], dates=(0, 2))
+
+    def test_select_reset_frequency(self):
+        """Test that reset_frequency option works correctly"""
+
+        imp = dummy_impact_yearly() # 6 events, 1 per year
+
+        # select first 4 events
+        n_yr = 4
+        sel_imp = imp.select(dates=(imp.date[0],imp.date[n_yr-1]), reset_frequency=True)
+
+        # check unchanged attributes
+        self.assertTrue(u_coord.equal_crs(sel_imp.crs, imp.crs))
+        self.assertEqual(sel_imp.unit, imp.unit)
+        self.assertEqual(sel_imp.frequency_unit, imp.frequency_unit)
+        np.testing.assert_array_equal(sel_imp.coord_exp, imp.coord_exp)
+
+        # check sub-selected attributes
+        np.testing.assert_array_equal(sel_imp.event_id, imp.event_id[0:n_yr])
+        self.assertEqual(sel_imp.event_name, imp.event_name[0:n_yr])
+        np.testing.assert_array_equal(sel_imp.date, imp.date[0:n_yr])
+        np.testing.assert_array_equal(sel_imp.at_event, imp.at_event[0:n_yr])
+        np.testing.assert_array_equal(sel_imp.imp_mat.todense(),
+                                      imp.imp_mat[0:n_yr,:].todense())
+
+        # check frequency-related attributes
+        np.testing.assert_array_equal(sel_imp.frequency, [1/n_yr]*n_yr)
+        self.assertEqual(sel_imp.aai_agg,imp.at_event[0:n_yr].sum()/n_yr)
+
+        np.testing.assert_array_equal(sel_imp.eai_exp,
+                                      imp.imp_mat[0:n_yr,:].todense().sum(axis=0).A1/n_yr)
+
 
 class TestConvertExp(unittest.TestCase):
     def test__build_exp(self):


### PR DESCRIPTION
Changes proposed in this PR:
- add a reset_frequency option in impact.select(), analogue to [hazard.select()](https://github.com/CLIMADA-project/climada_python/blob/e41222210bfb99e92829c0a86f1db2f31355abf5/climada/hazard/base.py#L1300)
- 

This PR fixes #830 

### PR Author Checklist

- [x] Read the [Contribution Guide][contrib]
- [x] Correct target branch selected (if unsure, select `develop`)
- [x] Descriptive pull request title added
- [x] Source branch up-to-date with target branch
- [x] [Documentation](https://climada-python.readthedocs.io/en/latest/guide/Guide_PythonDos-n-Donts.html#2.--Commenting-&-Documenting) updated
- [x] [Tests][testing] updated
- [x] [Tests][testing] passing
- [x] No new [linter issues][linter]
- [x] [Changelog](https://github.com/CLIMADA-project/climada_python/blob/main/CHANGELOG.md) updated

### PR Reviewer Checklist

- [ ] Read the [Contribution Guide][contrib]
- [ ] [CLIMADA Reviewer Checklist](https://climada-python.readthedocs.io/en/latest/guide/Guide_Reviewer_Checklist.html) passed
- [ ] [Tests][testing] passing
- [ ] No new [linter issues][linter]

[contrib]: https://github.com/CLIMADA-project/climada_python/blob/main/CONTRIBUTING.md
[testing]: https://climada-python.readthedocs.io/en/latest/guide/Guide_Continuous_Integration_and_Testing.html
[linter]: https://climada-python.readthedocs.io/en/stable/guide/Guide_Continuous_Integration_and_Testing.html#3.C.--Static-Code-Analysis
