### PR TITLE
Avoid redundant calls to `np.unique` in `Impact.impact_at_reg`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ Removed:
 - In the TropCyclone class in the Holland model 2008 and 2010 implementation, a doublecounting of translational velocity is removed [#833](https://github.com/CLIMADA-project/climada_python/pull/833)
 - `climada.util.test.test_finance` and `climada.test.test_engine` updated to recent input data from worldbank [#841](https://github.com/CLIMADA-project/climada_python/pull/841)
 - Set `nodefaults` in Conda environment specs because `defaults` are not compatible with conda-forge [#845](https://github.com/CLIMADA-project/climada_python/pull/845)
+- Avoid redundant calls to `np.unique` in `Impact.impact_at_reg` [#848](https://github.com/CLIMADA-project/climada_python/pull/848)
 
 ### Deprecated
 

--- a/climada/engine/impact.py
+++ b/climada/engine/impact.py
@@ -451,12 +451,12 @@ class Impact():
         at_reg_event = np.hstack(
             [
                 self.imp_mat[:, np.where(agg_regions == reg)[0]].sum(1)
-                for reg in np.unique(agg_reg_unique)
+                for reg in agg_reg_unique
             ]
         )
 
         at_reg_event = pd.DataFrame(
-            at_reg_event, columns=np.unique(agg_reg_unique), index=self.event_id
+            at_reg_event, columns=agg_reg_unique, index=self.event_id
         )
 
         return at_reg_event


### PR DESCRIPTION
Changes proposed in this PR:
- Only call `np.unique` once in `Impact.impact_at_reg`.
- 

This seems to have been an oversight during the review of #642.

### PR Author Checklist

- [x] Read the [Contribution Guide][contrib]
- [x] Correct target branch selected (if unsure, select `develop`)
- [x] Descriptive pull request title added
- [x] Source branch up-to-date with target branch
- [ ] [Documentation](https://climada-python.readthedocs.io/en/latest/guide/Guide_PythonDos-n-Donts.html#2.--Commenting-&-Documenting) updated
- [ ] [Tests][testing] updated
- [x] [Tests][testing] passing
- [x] No new [linter issues][linter]
- [x] [Changelog](https://github.com/CLIMADA-project/climada_python/blob/main/CHANGELOG.md) updated

### PR Reviewer Checklist

- [x] Read the [Contribution Guide][contrib]
- [x] [CLIMADA Reviewer Checklist](https://climada-python.readthedocs.io/en/latest/guide/Guide_Reviewer_Checklist.html) passed
- [x] [Tests][testing] passing
- [x] No new [linter issues][linter]

[contrib]: https://github.com/CLIMADA-project/climada_python/blob/main/CONTRIBUTING.md
[testing]: https://climada-python.readthedocs.io/en/latest/guide/Guide_Continuous_Integration_and_Testing.html
[linter]: https://climada-python.readthedocs.io/en/stable/guide/Guide_Continuous_Integration_and_Testing.html#3.C.--Static-Code-Analysis
