### PR TITLE
update to xarray 2024.2

### DIFF
--- a/climada/hazard/base.py
+++ b/climada/hazard/base.py
@@ -840,7 +840,7 @@ class Hazard():
                 return array.dt.strftime("%Y-%m-%d").values
 
             # Handle access errors
-            except (ValueError, TypeError) as err:
+            except (ValueError, TypeError, AttributeError) as err:
                 if strict:
                     raise err
 

--- a/requirements/env_climada.yml
+++ b/requirements/env_climada.yml
@@ -38,6 +38,6 @@ dependencies:
   - tabulate>=0.9
   - tqdm>=4.66
   - unittest-xml-reporting>=3.2
-  - xarray>=2024.1,<2024.2  # 2024.2 introduced an unhandled AttributeError in Hazard.from_xarray_raster
+  - xarray>=2024.2
   - xlrd>=2.0
   - xlsxwriter>=3.1


### PR DESCRIPTION
Changes proposed in this PR:

- xarray 2024.2 introduced an AttributeError in `year_month_day_accessor` of `Hazard.from_xarray_raster` where: the `array` argument is not reallly a date-time array. This PR fixes the problem by simply adding the Exception type to the list of caught Exceptions.
- However, the update to xarray 2024.2 also seems to slow down the procedure significantly. On a personal computer the test `test_base_xarray.TestReadDefaultNetCDF.test_event_no_time` took between 6 and 8 seconds where it finished in 1 to 2 seconds with version 2024.1

This PR fixes #852

### PR Author Checklist

- [x] Read the [Contribution Guide][contrib]
- [x] Correct target branch selected (if unsure, select `develop`)
- [x] Descriptive pull request title added
- [x] Source branch up-to-date with target branch
- [ ] [Documentation](https://climada-python.readthedocs.io/en/latest/guide/Guide_PythonDos-n-Donts.html#2.--Commenting-&-Documenting) updated
- [ ] [Tests][testing] updated
- [ ] [Tests][testing] passing
- [ ] No new [linter issues][linter]
- [ ] [Changelog](https://github.com/CLIMADA-project/climada_python/blob/main/CHANGELOG.md) updated

### PR Reviewer Checklist

- [ ] Read the [Contribution Guide][contrib]
- [ ] [CLIMADA Reviewer Checklist](https://climada-python.readthedocs.io/en/latest/guide/Guide_Reviewer_Checklist.html) passed
- [ ] [Tests][testing] passing
- [ ] No new [linter issues][linter]

[contrib]: https://github.com/CLIMADA-project/climada_python/blob/main/CONTRIBUTING.md
[testing]: https://climada-python.readthedocs.io/en/latest/guide/Guide_Continuous_Integration_and_Testing.html
[linter]: https://climada-python.readthedocs.io/en/stable/guide/Guide_Continuous_Integration_and_Testing.html#3.C.--Static-Code-Analysis
