### PR TITLE
Improve impact calc error messages when there is a mismatch of impf ids between exposures and impfset

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -32,3 +32,4 @@
 * Kam Lam Yeung
 * Sarah Hülsen
 * Timo Schmid
+* Luca Severino

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ Code freeze date: YYYY-MM-DD
 
 ### Changed
 
+- Improved error messages produced by `ImpactCalc.impact()` in case impact function in the exposures is not found in impf_set [#863](https://github.com/CLIMADA-project/climada_python/pull/863)
+
 ### Fixed
 
 ### Deprecated

--- a/climada/engine/impact_calc.py
+++ b/climada/engine/impact_calc.py
@@ -134,9 +134,9 @@ class ImpactCalc():
         if any(if_id not in self.impfset.get_ids(haz_type=self.hazard.haz_type) for
                if_id in np.unique(self.exposures.gdf[impf_col].values)):
             raise AttributeError(
-                f"At least one impact function specified in the exposures has no match in the impact function set.\n "
-                f"The impact functions in the set for haztype {self.hazard.haz_type} have ids {self.impfset.get_ids(haz_type=self.hazard.haz_type)}. "
-                f"The exposures have associated {impf_col} ids {np.unique(self.exposures.gdf[impf_col].values)}.\n" 
+                f"At least one impact function associated to the exposures has no match in the impact function set.\n "
+                f"The impact functions in the impact function set for hazard type \"{self.hazard.haz_type}\" have ids {self.impfset.get_ids(haz_type=self.hazard.haz_type)}. "
+                f"The column \"{impf_col}\" in the exposures contains the ids {np.unique(self.exposures.gdf[impf_col].values).astype(int).tolist()}.\n" 
                 f"Please make sure that all exposure points are associated with an impact function that is included in the impact function set.")
         exp_gdf = self.minimal_exp_gdf(impf_col, assign_centroids, ignore_cover, ignore_deductible)
         if exp_gdf.size == 0:

--- a/climada/engine/impact_calc.py
+++ b/climada/engine/impact_calc.py
@@ -129,6 +129,15 @@ class ImpactCalc():
                 )
 
         impf_col = self.exposures.get_impf_column(self.hazard.haz_type)
+
+        # check for compability of impact function id between impact function set and exposure
+        if any(if_id not in self.impfset.get_ids(haz_type=self.hazard.haz_type) for
+               if_id in np.unique(self.exposures.gdf[impf_col].values)):
+            raise AttributeError(
+                f"At least one impact function specified in the exposures has no match in the impact function set.\n "
+                f"The impact functions in the set for haztype {self.hazard.haz_type} have ids {self.impfset.get_ids(haz_type=self.hazard.haz_type)}. "
+                f"The exposures have associated {impf_col} ids {np.unique(self.exposures.gdf[impf_col].values)}.\n" 
+                f"Please make sure that all exposure points are associated with an impact function that is included in the impact function set.")
         exp_gdf = self.minimal_exp_gdf(impf_col, assign_centroids, ignore_cover, ignore_deductible)
         if exp_gdf.size == 0:
             return self._return_empty(save_mat)

--- a/climada/engine/impact_calc.py
+++ b/climada/engine/impact_calc.py
@@ -112,7 +112,7 @@ class ImpactCalc():
         apply_deductible_to_mat : apply deductible to impact matrix
         apply_cover_to_mat : apply cover to impact matrix
         """
-        # check for compability of exposures and hazard type
+        # check for compatibility of exposures and hazard type
         if all(name not in self.exposures.gdf.columns for
                name in ['if_', f'if_{self.hazard.haz_type}',
                         'impf_', f'impf_{self.hazard.haz_type}']):
@@ -121,7 +121,7 @@ class ImpactCalc():
                 f"for hazard type {self.hazard.haz_type} in exposures."
                 )
 
-        # check for compability of impact function and hazard type
+        # check for compatibility of impact function and hazard type
         if not self.impfset.get_func(haz_type=self.hazard.haz_type):
             raise AttributeError(
                 "Impact calculation not possible. No impact functions found "
@@ -129,19 +129,19 @@ class ImpactCalc():
                 )
 
         impf_col = self.exposures.get_impf_column(self.hazard.haz_type)
+        known_impact_functions = self.impfset.get_ids(haz_type=self.hazard.haz_type)
 
-        # check for compability of impact function id between impact function set and exposure
-        if any(impf_id not in self.impfset.get_ids(haz_type=self.hazard.haz_type) for
-               impf_id in np.unique(self.exposures.gdf[impf_col].values)):
-            raise AttributeError(
-                "At least one impact function associated to the exposures has no match "
-                "in the impact function set.\nThe impact functions in the impact function"
-                f" set for hazard type \"{self.hazard.haz_type}\" have ids "
-                f"{self.impfset.get_ids(haz_type=self.hazard.haz_type)}. The column "
-                f"\"{impf_col}\" in the exposures contains the ids "
-                f"{np.unique(self.exposures.gdf[impf_col].values).astype(int).tolist()}.\n"
+        # check for compatibility of impact function id between impact function set and exposure
+        if not all(self.exposures.gdf[impf_col].isin(known_impact_functions)):
+            unknown_impact_functions = list(self.exposures.gdf[
+                    ~self.exposures.gdf[impf_col].isin(known_impact_functions)
+                ][impf_col].drop_duplicates().astype(int).astype(str))
+            raise ValueError(
+                f"The associated impact function(s) with id(s) {', '.join(unknown_impact_functions)}"
+                f" have no match in impact function set for hazard type \'{self.hazard.haz_type}\'.\n"
                 "Please make sure that all exposure points are associated with an impact "
                 "function that is included in the impact function set.")
+
         exp_gdf = self.minimal_exp_gdf(impf_col, assign_centroids, ignore_cover, ignore_deductible)
         if exp_gdf.size == 0:
             return self._return_empty(save_mat)

--- a/climada/engine/impact_calc.py
+++ b/climada/engine/impact_calc.py
@@ -134,10 +134,14 @@ class ImpactCalc():
         if any(if_id not in self.impfset.get_ids(haz_type=self.hazard.haz_type) for
                if_id in np.unique(self.exposures.gdf[impf_col].values)):
             raise AttributeError(
-                f"At least one impact function associated to the exposures has no match in the impact function set.\n "
-                f"The impact functions in the impact function set for hazard type \"{self.hazard.haz_type}\" have ids {self.impfset.get_ids(haz_type=self.hazard.haz_type)}. "
-                f"The column \"{impf_col}\" in the exposures contains the ids {np.unique(self.exposures.gdf[impf_col].values).astype(int).tolist()}.\n" 
-                f"Please make sure that all exposure points are associated with an impact function that is included in the impact function set.")
+                "At least one impact function associated to the exposures has no match "
+                "in the impact function set.\nThe impact functions in the impact function"
+                f" set for hazard type \"{self.hazard.haz_type}\" have ids "
+                f"{self.impfset.get_ids(haz_type=self.hazard.haz_type)}. The column "
+                f"\"{impf_col}\" in the exposures contains the ids "
+                f"{np.unique(self.exposures.gdf[impf_col].values).astype(int).tolist()}.\n"
+                "Please make sure that all exposure points are associated with an impact "
+                "function that is included in the impact function set.")
         exp_gdf = self.minimal_exp_gdf(impf_col, assign_centroids, ignore_cover, ignore_deductible)
         if exp_gdf.size == 0:
             return self._return_empty(save_mat)

--- a/climada/engine/impact_calc.py
+++ b/climada/engine/impact_calc.py
@@ -131,8 +131,8 @@ class ImpactCalc():
         impf_col = self.exposures.get_impf_column(self.hazard.haz_type)
 
         # check for compability of impact function id between impact function set and exposure
-        if any(if_id not in self.impfset.get_ids(haz_type=self.hazard.haz_type) for
-               if_id in np.unique(self.exposures.gdf[impf_col].values)):
+        if any(impf_id not in self.impfset.get_ids(haz_type=self.hazard.haz_type) for
+               impf_id in np.unique(self.exposures.gdf[impf_col].values)):
             raise AttributeError(
                 "At least one impact function associated to the exposures has no match "
                 "in the impact function set.\nThe impact functions in the impact function"

--- a/climada/engine/impact_calc.py
+++ b/climada/engine/impact_calc.py
@@ -137,10 +137,11 @@ class ImpactCalc():
                     ~self.exposures.gdf[impf_col].isin(known_impact_functions)
                 ][impf_col].drop_duplicates().astype(int).astype(str))
             raise ValueError(
-                f"The associated impact function(s) with id(s) {', '.join(unknown_impact_functions)}"
-                f" have no match in impact function set for hazard type \'{self.hazard.haz_type}\'.\n"
-                "Please make sure that all exposure points are associated with an impact "
-                "function that is included in the impact function set.")
+                f"The associated impact function(s) with id(s) "
+                f"{', '.join(unknown_impact_functions)} have no match in impact function set for"
+                f" hazard type \'{self.hazard.haz_type}\'.\nPlease make sure that all exposure "
+                "points are associated with an impact function that is included in the impact "
+                "function set.")
 
         exp_gdf = self.minimal_exp_gdf(impf_col, assign_centroids, ignore_cover, ignore_deductible)
         if exp_gdf.size == 0:

--- a/climada/engine/test/test_impact_calc.py
+++ b/climada/engine/test/test_impact_calc.py
@@ -152,15 +152,14 @@ class TestImpactCalc(unittest.TestCase):
         impf_noexp.id = 3
         impfset = ImpactFuncSet([impf_exp, impf_noexp])
 
-        with self.assertRaises(AttributeError) as cm:
+        with self.assertRaises(ValueError) as cm:
             ImpactCalc(exp, impfset, haz).impact()
         the_exception = cm.exception
-        self.assertEqual(the_exception.args[0], "At least one impact function "
-        "associated to the exposures has no match in the impact function set.\n"
-        "The impact functions in the impact function set for hazard type \"TC\" "
-        "have ids [1, 3]. The column \"impf_TC\" in the exposures contains the ids"
-        " [1, 2].\nPlease make sure that all exposure points are associated with an "
-        "impact function that is included in the impact function set.")
+        self.assertEqual(the_exception.args[0],
+                         "The associated impact function(s) with id(s) 2 have no match in "
+                         "impact function set for hazard type \'TC\'.\nPlease make sure "
+                         "that all exposure points are associated with an impact "
+                         "function that is included in the impact function set.")
 
     def test_calc_impact_TC_pass(self):
         """Test compute impact"""

--- a/climada/engine/test/test_impact_calc.py
+++ b/climada/engine/test/test_impact_calc.py
@@ -135,6 +135,27 @@ class TestImpactCalc(unittest.TestCase):
         except Exception as e:
             self.assertEqual(str(e), "Impact calculation not possible. No impact "
                              "functions found for hazard type TC in impf_set.")
+    def test_error_handling_mismatch_impf_ids(self):
+        """Test error handling in case impf ids in exposures
+        does not appear in impf_set"""
+        haz = Hazard('TC')
+        exp = Exposures()
+        exp.gdf.loc[0,'impf_TC'] = 1
+        impf = ImpactFunc()
+        impf.id = 2
+        impf.intensity = np.array([0, 20])
+        impf.paa = np.array([0, 1])
+        impf.mdd = np.array([0, 0.5])
+        impf.haz_type = 'TC'
+        impfset = ImpactFuncSet([impf])
+        
+        try:
+            ImpactCalc(exp, impfset, haz).impact()
+        except Exception as e:
+            self.assertEqual(str(e),  "At least one impact function associated to the exposures has no match in the impact function set.\n "
+                "The impact functions in the impact function set for hazard type \"TC\" have ids [2]. "
+                "The column \"impf_TC\" in the exposures contains the ids [1].\n" 
+                "Please make sure that all exposure points are associated with an impact function that is included in the impact function set.")
 
     def test_calc_impact_TC_pass(self):
         """Test compute impact"""

--- a/climada/engine/test/test_impact_calc.py
+++ b/climada/engine/test/test_impact_calc.py
@@ -142,12 +142,7 @@ class TestImpactCalc(unittest.TestCase):
         exp = Exposures()
         exp.gdf.loc[0,'impf_TC'] = 1
         exp.gdf.loc[1,'impf_TC'] = 2
-        impf_exp = ImpactFunc()
-        impf_exp.id = 1
-        impf_exp.intensity = np.array([0, 20])
-        impf_exp.paa = np.array([0, 1])
-        impf_exp.mdd = np.array([0, 0.5])
-        impf_exp.haz_type = 'TC'
+        impf_exp = ImpactFunc(haz_type='TC', id=1)
         impf_noexp = deepcopy(impf_exp)
         impf_noexp.id = 3
         impfset = ImpactFuncSet([impf_exp, impf_noexp])

--- a/climada/engine/test/test_impact_calc.py
+++ b/climada/engine/test/test_impact_calc.py
@@ -152,15 +152,15 @@ class TestImpactCalc(unittest.TestCase):
         impf_noexp.id = 3
         impfset = ImpactFuncSet([impf_exp, impf_noexp])
 
-        try:
+        with self.assertRaises(AttributeError) as cm:
             ImpactCalc(exp, impfset, haz).impact()
-        except Exception as e:
-            self.assertEqual(str(e),  "At least one impact function associated to"
-                             " the exposures has no match in the impact function set.\n"
-                "The impact functions in the impact function set for hazard type \"TC\" "
-                "have ids [1, 3]. The column \"impf_TC\" in the exposures contains the ids"
-                " [1, 2].\nPlease make sure that all exposure points are associated with an "
-                "impact function that is included in the impact function set.")
+        the_exception = cm.exception
+        self.assertEqual(the_exception.args[0], "At least one impact function "
+        "associated to the exposures has no match in the impact function set.\n"
+        "The impact functions in the impact function set for hazard type \"TC\" "
+        "have ids [1, 3]. The column \"impf_TC\" in the exposures contains the ids"
+        " [1, 2].\nPlease make sure that all exposure points are associated with an "
+        "impact function that is included in the impact function set.")
 
     def test_calc_impact_TC_pass(self):
         """Test compute impact"""

--- a/climada/engine/test/test_impact_calc.py
+++ b/climada/engine/test/test_impact_calc.py
@@ -141,21 +141,26 @@ class TestImpactCalc(unittest.TestCase):
         haz = Hazard('TC')
         exp = Exposures()
         exp.gdf.loc[0,'impf_TC'] = 1
-        impf = ImpactFunc()
-        impf.id = 2
-        impf.intensity = np.array([0, 20])
-        impf.paa = np.array([0, 1])
-        impf.mdd = np.array([0, 0.5])
-        impf.haz_type = 'TC'
-        impfset = ImpactFuncSet([impf])
-        
+        exp.gdf.loc[1,'impf_TC'] = 2
+        impf_exp = ImpactFunc()
+        impf_exp.id = 1
+        impf_exp.intensity = np.array([0, 20])
+        impf_exp.paa = np.array([0, 1])
+        impf_exp.mdd = np.array([0, 0.5])
+        impf_exp.haz_type = 'TC'
+        impf_noexp = deepcopy(impf_exp)
+        impf_noexp.id = 3
+        impfset = ImpactFuncSet([impf_exp, impf_noexp])
+
         try:
             ImpactCalc(exp, impfset, haz).impact()
         except Exception as e:
-            self.assertEqual(str(e),  "At least one impact function associated to the exposures has no match in the impact function set.\n"
-                "The impact functions in the impact function set for hazard type \"TC\" have ids [2]. "
-                "The column \"impf_TC\" in the exposures contains the ids [1].\n" 
-                "Please make sure that all exposure points are associated with an impact function that is included in the impact function set.")
+            self.assertEqual(str(e),  "At least one impact function associated to"
+                             " the exposures has no match in the impact function set.\n"
+                "The impact functions in the impact function set for hazard type \"TC\" "
+                "have ids [1, 3]. The column \"impf_TC\" in the exposures contains the ids"
+                " [1, 2].\nPlease make sure that all exposure points are associated with an "
+                "impact function that is included in the impact function set.")
 
     def test_calc_impact_TC_pass(self):
         """Test compute impact"""

--- a/climada/engine/test/test_impact_calc.py
+++ b/climada/engine/test/test_impact_calc.py
@@ -152,7 +152,7 @@ class TestImpactCalc(unittest.TestCase):
         try:
             ImpactCalc(exp, impfset, haz).impact()
         except Exception as e:
-            self.assertEqual(str(e),  "At least one impact function associated to the exposures has no match in the impact function set.\n "
+            self.assertEqual(str(e),  "At least one impact function associated to the exposures has no match in the impact function set.\n"
                 "The impact functions in the impact function set for hazard type \"TC\" have ids [2]. "
                 "The column \"impf_TC\" in the exposures contains the ids [1].\n" 
                 "Please make sure that all exposure points are associated with an impact function that is included in the impact function set.")


### PR DESCRIPTION
Changes proposed in this PR:
- Add a test in `ImpactCalc.impact(exposures, impfset, hazard)` to handle AttributeError arising when an impact function id contained in the exposures has no matching impact function in the impact function set.
- Change previous `AttributeError: 'list' has no attribute 'calc_mdr'` to a more explanatory error message

This PR fixes #669 (reopened)

### PR Author Checklist

- [x] Read the [Contribution Guide][contrib]
- [x] Correct target branch selected (if unsure, select `develop`)
- [x] Descriptive pull request title added
- [x] Source branch up-to-date with target branch
- [x] [Documentation](https://climada-python.readthedocs.io/en/latest/guide/Guide_PythonDos-n-Donts.html#2.--Commenting-&-Documenting) updated
- [x] [Tests][testing] updated
- [x] [Tests][testing] passing
- [x] No new [linter issues][linter]
- [x] [Changelog](https://github.com/CLIMADA-project/climada_python/blob/main/CHANGELOG.md) updated

### PR Reviewer Checklist

- [x] Read the [Contribution Guide][contrib]
- [x] [CLIMADA Reviewer Checklist](https://climada-python.readthedocs.io/en/latest/guide/Guide_Reviewer_Checklist.html) passed
- [x] [Tests][testing] passing
- [x] No new [linter issues][linter]

[contrib]: https://github.com/CLIMADA-project/climada_python/blob/main/CONTRIBUTING.md
[testing]: https://climada-python.readthedocs.io/en/latest/guide/Guide_Continuous_Integration_and_Testing.html
[linter]: https://climada-python.readthedocs.io/en/stable/guide/Guide_Continuous_Integration_and_Testing.html#3.C.--Static-Code-Analysis
