### PR TITLE
Create an empty centroids in Hazard.concat() with CRS from the first haz_list.

### DIFF
--- a/climada/hazard/base.py
+++ b/climada/hazard/base.py
@@ -816,9 +816,7 @@ class Hazard(HazardIO, HazardPlot):
         """
         if len(haz_list) == 0:
             return cls()
-        haz_concat = haz_list[0].__class__()
-        haz_concat.haz_type = haz_list[0].haz_type
-        haz_concat.centroids = Centroids(lat=[], lon=[], crs=haz_list[0].centroids.crs)
+        haz_concat = haz_list[0].__class__(centroids=Centroids(lat=[], lon=[], crs=haz_list[0].centroids.crs))
         for attr_name, attr_val in vars(haz_list[0]).items():
             # to save memory, only copy simple attributes like
             # "units" that are not explicitly handled by Hazard.append

--- a/climada/hazard/base.py
+++ b/climada/hazard/base.py
@@ -818,6 +818,7 @@ class Hazard(HazardIO, HazardPlot):
             return cls()
         haz_concat = haz_list[0].__class__()
         haz_concat.haz_type = haz_list[0].haz_type
+        haz_concat.centroids = Centroids(lat=[], lon=[], crs=haz_list[0].centroids.crs)
         for attr_name, attr_val in vars(haz_list[0]).items():
             # to save memory, only copy simple attributes like
             # "units" that are not explicitly handled by Hazard.append

--- a/climada/hazard/base.py
+++ b/climada/hazard/base.py
@@ -816,7 +816,8 @@ class Hazard(HazardIO, HazardPlot):
         """
         if len(haz_list) == 0:
             return cls()
-        haz_concat = haz_list[0].__class__(centroids=Centroids(lat=[], lon=[], crs=haz_list[0].centroids.crs))
+        haz_concat = haz_list[0].__class__(centroids=Centroids(lat=[], lon=[],
+                                                               crs=haz_list[0].centroids.crs))
         for attr_name, attr_val in vars(haz_list[0]).items():
             # to save memory, only copy simple attributes like
             # "units" that are not explicitly handled by Hazard.append

--- a/climada/hazard/centroids/centr.py
+++ b/climada/hazard/centroids/centr.py
@@ -366,7 +366,8 @@ class Centroids():
         """
         if not u_coord.equal_crs(self.crs, centr.crs):
             raise ValueError(
-                "The centroids have different Coordinate-Reference-Systems (CRS)"
+                f"The given centroids use different CRS: {self.crs}, {centr.crs}. "
+                "The centroids are incompatible and cannot be concatenated."
             )
         self.gdf = pd.concat([self.gdf, centr.gdf])
 

--- a/climada/hazard/test/test_base.py
+++ b/climada/hazard/test/test_base.py
@@ -908,15 +908,18 @@ class TestAppend(unittest.TestCase):
         haz1 = Hazard('TC', units='m/s',
                       centroids=Centroids(lat=[],lon=[], crs="epsg:4326"))
         haz3 = Hazard('EQ')
-        with self.assertRaises(ValueError):
+        with self.assertRaisesRegex(ValueError,
+                                    "different types"):
             Hazard.concat([haz1, haz3])
 
         haz4 = Hazard('TC', units='cm')
-        with self.assertRaises(ValueError):
+        with self.assertRaisesRegex(ValueError,
+                                    "different units"):
             Hazard.concat([haz1, haz4])
             
         haz5 = Hazard('TC', centroids=Centroids(lat=[],lon=[], crs="epsg:7777"))
-        with self.assertRaisesRegex(ValueError, "different Coordinate-Reference-Systems"):
+        with self.assertRaisesRegex(ValueError,
+                                    "different Coordinate-Reference-Systems (CRS)"):
             Hazard.concat([haz1, haz5])
 
     def test_change_centroids(self):

--- a/climada/hazard/test/test_base.py
+++ b/climada/hazard/test/test_base.py
@@ -904,8 +904,9 @@ class TestAppend(unittest.TestCase):
             haz1.append(haz2)
 
     def test_concat_raise_value_error(self):
-        """Raise error if hazards with different units of type"""
-        haz1 = Hazard('TC', units='m/s')
+        """Raise error if hazards with different units, type or crs"""
+        haz1 = Hazard('TC', units='m/s',
+                      centroids=Centroids(lat=[],lon=[], crs="epsg:4326"))
         haz3 = Hazard('EQ')
         with self.assertRaises(ValueError):
             Hazard.concat([haz1, haz3])
@@ -913,6 +914,10 @@ class TestAppend(unittest.TestCase):
         haz4 = Hazard('TC', units='cm')
         with self.assertRaises(ValueError):
             Hazard.concat([haz1, haz4])
+            
+        haz5 = Hazard('TC', centroids=Centroids(lat=[],lon=[], crs="epsg:7777"))
+        with self.assertRaises(ValueError):
+            Hazard.concat([haz1, haz5])
 
     def test_change_centroids(self):
         """Set new centroids for hazard"""

--- a/climada/hazard/test/test_base.py
+++ b/climada/hazard/test/test_base.py
@@ -919,7 +919,7 @@ class TestAppend(unittest.TestCase):
             
         haz5 = Hazard('TC', centroids=Centroids(lat=[],lon=[], crs="epsg:7777"))
         with self.assertRaisesRegex(ValueError,
-                                    "different Coordinate-Reference-Systems (CRS)"):
+                                    "different CRS"):
             Hazard.concat([haz1, haz5])
 
     def test_change_centroids(self):

--- a/climada/hazard/test/test_base.py
+++ b/climada/hazard/test/test_base.py
@@ -836,7 +836,8 @@ class TestAppend(unittest.TestCase):
 
         haz_1 = Hazard("TC",
                        centroids=Centroids(
-                           lat=np.array([1, 3, 5]), lon=np.array([2, 4, 6])),
+                           lat=np.array([1, 3, 5]), lon=np.array([2, 4, 6]),
+                           crs="epsg:4326"),
                        event_id=np.array([1]),
                        event_name=['ev1'],
                        date=np.array([1]),
@@ -848,7 +849,9 @@ class TestAppend(unittest.TestCase):
                        units='m/s')
 
         haz_2 = Hazard("TC",
-                       centroids=Centroids(lat=np.array([1, 3, 5]), lon=np.array([2, 4, 6])),
+                       centroids=Centroids(
+                           lat=np.array([1, 3, 5]), lon=np.array([2, 4, 6]),
+                           crs="epsg:4326"),
                        event_id=np.array([1]),
                        event_name=['ev2'],
                        date=np.array([2]),
@@ -880,6 +883,7 @@ class TestAppend(unittest.TestCase):
         self.assertEqual(haz.event_name, ['ev1', 'ev2'])
         self.assertTrue(np.array_equal(haz.centroids.coord, haz_1.centroids.coord))
         self.assertTrue(np.array_equal(haz.centroids.coord, haz_2.centroids.coord))
+        self.assertEqual(haz.centroids.crs, haz_1.centroids.crs)
 
     def test_append_new_var_pass(self):
         """New variable appears if hazard to append is empty."""

--- a/climada/hazard/test/test_base.py
+++ b/climada/hazard/test/test_base.py
@@ -916,7 +916,7 @@ class TestAppend(unittest.TestCase):
             Hazard.concat([haz1, haz4])
             
         haz5 = Hazard('TC', centroids=Centroids(lat=[],lon=[], crs="epsg:7777"))
-        with self.assertRaises(ValueError):
+        with self.assertRaisesRegex(ValueError, "different Coordinate-Reference-Systems"):
             Hazard.concat([haz1, haz5])
 
     def test_change_centroids(self):


### PR DESCRIPTION
Changes proposed in this PR:

This pull request is a fix for issue #879. 

An empty centroids is created in the `Hazard.concat()` function with the crs from the haz object from the haz_list.

This PR fixes #

### PR Author Checklist

- [x] Read the [Contribution Guide][contrib]
- [x] Correct target branch selected (if unsure, select `develop`)
- [x] Descriptive pull request title added
- [x] Source branch up-to-date with target branch
- [ ] [Documentation](https://climada-python.readthedocs.io/en/latest/guide/Guide_PythonDos-n-Donts.html#2.--Commenting-&-Documenting) updated
- [x] [Tests][testing] updated
- [x] [Tests][testing] passing
- [ ] No new [linter issues][linter]
- [ ] [Changelog](https://github.com/CLIMADA-project/climada_python/blob/main/CHANGELOG.md) updated

### PR Reviewer Checklist

- [ ] Read the [Contribution Guide][contrib]
- [ ] [CLIMADA Reviewer Checklist](https://climada-python.readthedocs.io/en/latest/guide/Guide_Reviewer_Checklist.html) passed
- [ ] [Tests][testing] passing
- [ ] No new [linter issues][linter]

[contrib]: https://github.com/CLIMADA-project/climada_python/blob/main/CONTRIBUTING.md
[testing]: https://climada-python.readthedocs.io/en/latest/guide/Guide_Continuous_Integration_and_Testing.html
[linter]: https://climada-python.readthedocs.io/en/stable/guide/Guide_Continuous_Integration_and_Testing.html#3.C.--Static-Code-Analysis
