### PR TITLE
Explicitly convert `event_name` to strings in `Impact.from_hdf5`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,8 @@ CLIMADA tutorials. [#872](https://github.com/CLIMADA-project/climada_python/pull
 - Centroids complete overhaul. Most function should be backward compatible. Internal data is stored in a geodataframe attribute. Raster are now stored as points, and the meta attribute is removed. Several methds were deprecated or removed. [#787](https://github.com/CLIMADA-project/climada_python/pull/787)
 - Improved error messages produced by `ImpactCalc.impact()` in case impact function in the exposures is not found in impf_set [#863](https://github.com/CLIMADA-project/climada_python/pull/863)
 - Changed module structure: `climada.hazard.Hazard` has been split into the modules `base`, `io` and `plot` [#871](https://github.com/CLIMADA-project/climada_python/pull/871)
-- `Impact.from_hdf5` now supports `event_name` data that is not strings. It will read the raw data then and issue a warning [#894](https://github.com/CLIMADA-project/climada_python/pull/894)
+- `Impact.from_hdf5` now calls `str` on `event_name` data that is not strings, and issue a warning then [#894](https://github.com/CLIMADA-project/climada_python/pull/894)
+- `Impact.write_hdf5` now throws an error if `event_name` is does not contain strings exclusively [#894](https://github.com/CLIMADA-project/climada_python/pull/894)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ CLIMADA tutorials. [#872](https://github.com/CLIMADA-project/climada_python/pull
 - Centroids complete overhaul. Most function should be backward compatible. Internal data is stored in a geodataframe attribute. Raster are now stored as points, and the meta attribute is removed. Several methds were deprecated or removed. [#787](https://github.com/CLIMADA-project/climada_python/pull/787)
 - Improved error messages produced by `ImpactCalc.impact()` in case impact function in the exposures is not found in impf_set [#863](https://github.com/CLIMADA-project/climada_python/pull/863)
 - Changed module structure: `climada.hazard.Hazard` has been split into the modules `base`, `io` and `plot` [#871](https://github.com/CLIMADA-project/climada_python/pull/871)
+- `Impact.from_hdf5` now supports `event_name` data that is not strings. It will read the raw data then and issue a warning [#894](https://github.com/CLIMADA-project/climada_python/pull/894)
 
 ### Fixed
 

--- a/climada/engine/impact.py
+++ b/climada/engine/impact.py
@@ -1240,10 +1240,18 @@ class Impact():
             ).intersection(file.keys())
             kwargs.update({attr: file[attr][:] for attr in array_attrs})
 
-            # Special handling for 'event_name' because it's a list of strings
+            # Special handling for 'event_name' because it should be a list of strings
             if "event_name" in file:
                 # pylint: disable=no-member
-                kwargs["event_name"] = list(file["event_name"].asstr()[:])
+                try:
+                    event_name = file["event_name"].asstr()[:]
+                except TypeError:
+                    LOGGER.warn(
+                        "'event_name' could not be decoded to a string. Reading raw "
+                        "values instead."
+                    )
+                    event_name = file["event_name"][:]
+                kwargs["event_name"] = list(event_name)
 
         # Create the impact object
         return cls(**kwargs)

--- a/climada/engine/impact.py
+++ b/climada/engine/impact.py
@@ -937,11 +937,6 @@ class Impact():
 
         The impact matrix can be stored in a sparse or dense format.
 
-        Notes
-        -----
-        This writer does not support attributes with variable types. Please make sure
-        that ``event_name`` is a list of equally-typed values, e.g., all ``str``.
-
         Parameters
         ----------
         file_path : str or Path
@@ -950,6 +945,11 @@ class Impact():
             If ``True``, write the impact matrix as dense matrix that can be more easily
             interpreted by common H5 file readers but takes up (vastly) more space.
             Defaults to ``False``.
+
+        Raises
+        ------
+        TypeError
+            If :py:attr:`event_name` does not contain strings exclusively.
         """
         # Define writers for all types (will be filled later)
         type_writers = dict()
@@ -983,7 +983,7 @@ class Impact():
 
         def _str_type_helper(values: Collection):
             """Return string datatype if we assume 'values' contains strings"""
-            if isinstance(next(iter(values)), str):
+            if all((isinstance(val, str) for val in values)):
                 return h5py.string_dtype()
             return None
 

--- a/climada/engine/impact.py
+++ b/climada/engine/impact.py
@@ -1246,7 +1246,7 @@ class Impact():
                 try:
                     event_name = file["event_name"].asstr()[:]
                 except TypeError:
-                    LOGGER.warn(
+                    LOGGER.warning(
                         "'event_name' could not be decoded to a string. Reading raw "
                         "values instead."
                     )

--- a/climada/engine/impact.py
+++ b/climada/engine/impact.py
@@ -1037,6 +1037,8 @@ class Impact():
             # Now write all attributes
             # NOTE: Remove leading underscore to write '_tot_value' as regular attribute
             for name, value in self.__dict__.items():
+                if name == "event_name" and _str_type_helper(value) is None:
+                    raise TypeError("'event_name' must be a list of strings")
                 write(file, name.lstrip("_"), value)
 
     def write_sparse_csr(self, file_name):
@@ -1247,10 +1249,10 @@ class Impact():
                     event_name = file["event_name"].asstr()[:]
                 except TypeError:
                     LOGGER.warning(
-                        "'event_name' could not be decoded to a string. Reading raw "
-                        "values instead."
+                        "'event_name' is not stored as strings. Trying to decode "
+                        "values with 'str()' instead."
                     )
-                    event_name = file["event_name"][:]
+                    event_name = map(str, file["event_name"][:])
                 kwargs["event_name"] = list(event_name)
 
         # Create the impact object

--- a/climada/engine/test/test_impact.py
+++ b/climada/engine/test/test_impact.py
@@ -1019,7 +1019,7 @@ class TestImpactH5IO(unittest.TestCase):
 
     def test_write_hdf5_type_fail(self):
         """Test that writing attributes with varying types results in an error"""
-        self.impact.event_name = [1, "a", 1.0, "b", "c", "d"]
+        self.impact.event_name = ["a", 1, 1.0, "b", "c", "d"]
         with self.assertRaisesRegex(
             TypeError, "'event_name' must be a list of strings"
         ):

--- a/climada/engine/test/test_impact.py
+++ b/climada/engine/test/test_impact.py
@@ -1120,6 +1120,15 @@ class TestImpactH5IO(unittest.TestCase):
         impact = Impact.from_hdf5(self.filepath)
         npt.assert_array_equal(impact.imp_mat.toarray(), [[0, 1, 2], [3, 0, 0]])
 
+        # Check with non-string event_name
+        event_name = [1.2, 2]
+        with h5py.File(self.filepath, "r+") as file:
+            del file["event_name"]
+            file.create_dataset("event_name", data=event_name)
+        with self.assertLogs("climada.engine.impact", "WARNING") as cm:
+            impact = Impact.from_hdf5(self.filepath)
+        self.assertIn("'event_name' could not be decoded to a string", cm.output[0])
+        self.assertListEqual(impact.event_name, event_name)
 
 # Execute Tests
 if __name__ == "__main__":

--- a/climada/engine/test/test_impact.py
+++ b/climada/engine/test/test_impact.py
@@ -1020,9 +1020,10 @@ class TestImpactH5IO(unittest.TestCase):
     def test_write_hdf5_type_fail(self):
         """Test that writing attributes with varying types results in an error"""
         self.impact.event_name = [1, "a", 1.0, "b", "c", "d"]
-        with self.assertRaises(TypeError) as cm:
+        with self.assertRaisesRegex(
+            TypeError, "'event_name' must be a list of strings"
+        ):
             self.impact.write_hdf5(self.filepath)
-        self.assertIn("No conversion path for dtype", str(cm.exception))
 
     def test_cycle_hdf5(self):
         """Test writing and reading the same object"""
@@ -1127,8 +1128,8 @@ class TestImpactH5IO(unittest.TestCase):
             file.create_dataset("event_name", data=event_name)
         with self.assertLogs("climada.engine.impact", "WARNING") as cm:
             impact = Impact.from_hdf5(self.filepath)
-        self.assertIn("'event_name' could not be decoded to a string", cm.output[0])
-        self.assertListEqual(impact.event_name, event_name)
+        self.assertIn("'event_name' is not stored as strings", cm.output[0])
+        self.assertListEqual(impact.event_name, ["1.2", "2.0"])
 
 # Execute Tests
 if __name__ == "__main__":

--- a/climada/engine/test/test_impact.py
+++ b/climada/engine/test/test_impact.py
@@ -779,7 +779,8 @@ class TestSelect(unittest.TestCase):
         ent.exposures.assign_centroids(hazard)
 
         # Compute the impact over the whole exposures
-        imp = ImpactCalc(ent.exposures, ent.impact_funcs, hazard).impact(save_mat=True, assign_centroids=False)
+        imp = ImpactCalc(ent.exposures, ent.impact_funcs, hazard).impact(
+            save_mat=True, assign_centroids=False)
 
         sel_imp = imp.select(event_ids=imp.event_id,
                              event_names=imp.event_name,


### PR DESCRIPTION
Changes proposed in this PR:
- Call `str` on values if decoding strings from `event_name` fails, issue a warning in this case.
- Throw error during writing if `event_name` is not strings.
- Fix an issue where only the first value of `event_name` was checked.

This PR fixes  #807

### PR Author Checklist

- [x] Read the [Contribution Guide][contrib]
- [x] Correct target branch selected (if unsure, select `develop`)
- [x] Descriptive pull request title added
- [x] Source branch up-to-date with target branch
- [ ] [Documentation](https://climada-python.readthedocs.io/en/latest/guide/Guide_PythonDos-n-Donts.html#2.--Commenting-&-Documenting) updated
- [x] [Tests][testing] updated
- [x] [Tests][testing] passing
- [x] No new [linter issues][linter]
- [x] [Changelog](https://github.com/CLIMADA-project/climada_python/blob/main/CHANGELOG.md) updated

### PR Reviewer Checklist

- [ ] Read the [Contribution Guide][contrib]
- [ ] [CLIMADA Reviewer Checklist](https://climada-python.readthedocs.io/en/latest/guide/Guide_Reviewer_Checklist.html) passed
- [ ] [Tests][testing] passing
- [ ] No new [linter issues][linter]

[contrib]: https://github.com/CLIMADA-project/climada_python/blob/main/CONTRIBUTING.md
[testing]: https://climada-python.readthedocs.io/en/latest/guide/Guide_Continuous_Integration_and_Testing.html
[linter]: https://climada-python.readthedocs.io/en/stable/guide/Guide_Continuous_Integration_and_Testing.html#3.C.--Static-Code-Analysis
