### PR TITLE
plot NaNs in gray color and use log color bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ Code freeze date: YYYY-MM-DD
 
 ### Changed
 
+- In `climada.util.plot.geom_im_from_array`, NaNs are plotted in gray while cells with no centroid are not plotted, and renamed `climada.util.plot.subplots_from_gdf` to `climada.util.plot.plot_from_gdf` [#929](https://github.com/CLIMADA-project/climada_python/pull/929)
+
 ### Fixed
 
 ### Deprecated
@@ -89,6 +91,8 @@ CLIMADA tutorials. [#872](https://github.com/CLIMADA-project/climada_python/pull
 - climada.hazard.centroids.centr.Centroids.to_default_crs
 - climada.hazard.centroids.centr.Centroids.write_csv
 - climada.hazard.centroids.centr.Centroids.write_excel
+- climada.hazard.local_return_period [#898](https://github.com/CLIMADA-project/climada_python/pull/898)
+- climada.util.plot.subplots_from_gdf [#898](https://github.com/CLIMADA-project/climada_python/pull/898)
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ Code freeze date: YYYY-MM-DD
 
 ### Changed
 
-- In `climada.util.plot.geo_im_from_array`, NaNs are plotted in gray while cells with no centroid are not plotted, and renamed `climada.util.plot.subplots_from_gdf` to `climada.util.plot.plot_from_gdf` [#929](https://github.com/CLIMADA-project/climada_python/pull/929)
+- In `climada.util.plot.geo_im_from_array`, NaNs are plotted in gray while cells with no centroid are not plotted [#929](https://github.com/CLIMADA-project/climada_python/pull/929)
+ - Renamed `climada.util.plot.subplots_from_gdf` to `climada.util.plot.plot_from_gdf` [#929](https://github.com/CLIMADA-project/climada_python/pull/929)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Code freeze date: YYYY-MM-DD
 
 ### Changed
 
-- In `climada.util.plot.geom_im_from_array`, NaNs are plotted in gray while cells with no centroid are not plotted, and renamed `climada.util.plot.subplots_from_gdf` to `climada.util.plot.plot_from_gdf` [#929](https://github.com/CLIMADA-project/climada_python/pull/929)
+- In `climada.util.plot.geo_im_from_array`, NaNs are plotted in gray while cells with no centroid are not plotted, and renamed `climada.util.plot.subplots_from_gdf` to `climada.util.plot.plot_from_gdf` [#929](https://github.com/CLIMADA-project/climada_python/pull/929)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ Code freeze date: YYYY-MM-DD
 ### Changed
 
 - In `climada.util.plot.geo_im_from_array`, NaNs are plotted in gray while cells with no centroid are not plotted [#929](https://github.com/CLIMADA-project/climada_python/pull/929)
- - Renamed `climada.util.plot.subplots_from_gdf` to `climada.util.plot.plot_from_gdf` [#929](https://github.com/CLIMADA-project/climada_python/pull/929)
+- Renamed `climada.util.plot.subplots_from_gdf` to `climada.util.plot.plot_from_gdf` [#929](https://github.com/CLIMADA-project/climada_python/pull/929)
 
 ### Fixed
 

--- a/climada/util/plot.py
+++ b/climada/util/plot.py
@@ -342,6 +342,9 @@ def geo_im_from_array(array_sub, coord, var_name, title,
                 extent[2]: extent[3]: complex(0, RESOLUTION)]
             grid_im = griddata((coord[:, 1], coord[:, 0]), array_im,
                                (grid_x, grid_y))
+            # Create mask for original NaN values in the data
+            nan_mask = griddata((coord[:, 1], coord[:, 0]), np.isnan(array_im.astype(float)),
+                                (grid_x, grid_y), fill_value=0).astype(bool)
         else:
             grid_x = coord[:, 1].reshape((width, height)).transpose()
             grid_y = coord[:, 0].reshape((width, height)).transpose()
@@ -350,6 +353,7 @@ def geo_im_from_array(array_sub, coord, var_name, title,
                 grid_y = np.flip(grid_y)
                 grid_im = np.flip(grid_im, 1)
             grid_im = np.resize(grid_im, (height, width, 1))
+            nan_mask = np.isnan(grid_im)
         axis.set_extent((extent[0] - mid_lon, extent[1] - mid_lon,
                          extent[2], extent[3]), crs=proj)
 
@@ -361,6 +365,9 @@ def geo_im_from_array(array_sub, coord, var_name, title,
                                                      pad=0.1, axes_class=plt.Axes)
         img = axis.pcolormesh(grid_x - mid_lon, grid_y, np.squeeze(grid_im),
                               transform=proj, **kwargs)
+        # Add gray color for NaN values
+        axis.pcolormesh(grid_x - mid_lon, grid_y, np.squeeze(nan_mask),
+                              transform=proj, cmap=mpl.colors.ListedColormap(['none', 'gainsboro']))
         cbar = plt.colorbar(img, cax=cbax, orientation='vertical')
         cbar.set_label(name)
         axis.set_title("\n".join(wrap(tit)))
@@ -876,7 +883,7 @@ def multibar_plot(ax, data, colors=None, total_width=0.8, single_width=1,
     if legend:
         ax.legend(bars, data.keys())
 
-def subplots_from_gdf(
+def plot_from_gdf(
         gdf: gpd.GeoDataFrame,
         colorbar_name: str = None,
         title_subplots: callable = None,
@@ -918,6 +925,7 @@ def subplots_from_gdf(
     if not isinstance(gdf, gpd.GeoDataFrame):
         raise ValueError("gdf is not a GeoDataFrame")
     gdf = gdf[['geometry', *[col for col in gdf.columns if col != 'geometry']]]
+    gdf_values = gdf.values[:,1:].T
 
     # read meta data for fig and axis labels
     if not isinstance(colorbar_name, str):
@@ -927,20 +935,29 @@ def subplots_from_gdf(
         print("Unknown subplot-title-generation function. Subplot titles will be column names.")
         title_subplots = lambda cols: [f"{col}" for col in cols]
 
-    # change default plot kwargs if plotting return periods
-    if colorbar_name.strip().startswith('Return Period'):
-        if 'cmap' not in kwargs.keys():
-            kwargs.update({'cmap': 'viridis_r'})
-        if 'norm' not in kwargs.keys():
-            kwargs.update(
-                {'norm': mpl.colors.LogNorm(
-                    vmin=gdf.values[:,1:].min(), vmax=gdf.values[:,1:].max()
-                    ),
-                'vmin': None, 'vmax': None}
-            )
+    # use log colorbar for return periods and impact
+    if (
+        colorbar_name.strip().startswith(('Return Period', 'Impact')) and
+        'norm' not in kwargs.keys() and
+        # check if there are no zeros values in gdf
+        np.sum(gdf_values == 0) == 0 and
+        # check if value range too small for logarithmic colorscale
+        (np.log10(np.nanmax(gdf_values)) - np.log10(np.nanmin(gdf_values))) > 2
+    ):
+        kwargs.update(
+            {'norm': mpl.colors.LogNorm(
+                vmin=gdf.values[:,1:].min(), vmax=gdf.values[:,1:].max()
+                ),
+            'vmin': None, 'vmax': None}
+        )
+
+    # use inverted color bar for return periods
+    if (colorbar_name.strip().startswith('Return Period') and
+        'cmap' not in kwargs.keys()):
+        kwargs.update({'cmap': 'viridis_r'})
 
     axis = geo_im_from_array(
-        gdf.values[:,1:].T,
+        gdf_values,
         gdf.geometry.get_coordinates().values[:,::-1],
         colorbar_name,
         title_subplots(gdf.columns[1:]),

--- a/climada/util/plot.py
+++ b/climada/util/plot.py
@@ -974,7 +974,7 @@ def plot_from_gdf(
         gdf_values,
         gdf.geometry.get_coordinates().values[:,::-1],
         colorbar_name,
-        title_subplots(gdf.columns[1:]),
+        title_subplots(gdf.drop(columns="geometry").columns),
         smooth=smooth,
         axes=axis,
         figsize=figsize,

--- a/doc/tutorial/climada_hazard_Hazard.ipynb
+++ b/doc/tutorial/climada_hazard_Hazard.ipynb
@@ -577,7 +577,7 @@
     "<a id='Part5'></a> \n",
     "## Part 5: Visualize Hazards\n",
     "\n",
-    "There are three different plot functions: `plot_intensity()`, `plot_fraction()`, and `plot_rp_intensity()`. Depending on the inputs, different properties can be visualized. Check the documentation of the functions. Using the function `local_return_period()` and the util function `subplots_from_gdf()`, one can plot local return periods for specific hazard intensities."
+    "There are three different plot functions: `plot_intensity()`, `plot_fraction()`, and `plot_rp_intensity()`. Depending on the inputs, different properties can be visualized. Check the documentation of the functions. Using the function `local_return_period()` and the util function `plot_from_gdf()`, one can plot local return periods for specific hazard intensities."
    ]
   },
   {
@@ -759,8 +759,8 @@
     "\n",
     "# 5. tropical cyclone return period maps for the threshold intensities [30, 40]\n",
     "return_periods, label, column_label = haz_tc_fl.local_return_period([30, 40])\n",
-    "from climada.util.plot import subplots_from_gdf\n",
-    "subplots_from_gdf(return_periods, colorbar_name=label, title_subplots=column_label)\n",
+    "from climada.util.plot import plot_from_gdf\n",
+    "plot_from_gdf(return_periods, colorbar_name=label, title_subplots=column_label)\n",
     "\n",
     "# 6. intensities of all the events in centroid with id 50\n",
     "haz_tc_fl.plot_intensity(centr=50)\n",


### PR DESCRIPTION
Changes proposed in this PR:
- In the plot function `geo_im_from_array`, NaN values in the data will be plotted in gray. Before, NaN value were not plotted (i.e. transparent), making them indistinguishable from plot regions for which there is no data (no centroids).
- In the plot function `plot_from_gdf`, the colorbar with will be shown on a logarithmic scale if a) the gdf is about return periods or impacts, b) there are no zeros in the data, c) the span of the data's values are at least two orders of magnitude

### PR Author Checklist

- [x] Read the [Contribution Guide][contrib]
- [x] Correct target branch selected (if unsure, select `develop`)
- [x] Descriptive pull request title added
- [x] Source branch up-to-date with target branch
- [x] [Documentation](https://climada-python.readthedocs.io/en/latest/guide/Guide_PythonDos-n-Donts.html#2.--Commenting-&-Documenting) updated
- [x] [Tests][testing] updated
- [x] [Tests][testing] passing
- [x] No new [linter issues][linter]
- [x] [Changelog](https://github.com/CLIMADA-project/climada_python/blob/develop/CHANGELOG.md) updated

### PR Reviewer Checklist

- [ ] Read the [Contribution Guide][contrib]
- [ ] [CLIMADA Reviewer Checklist](https://climada-python.readthedocs.io/en/latest/guide/Guide_Review.html#reviewer-checklist) passed
- [ ] [Tests][testing] passing
- [ ] No new [linter issues][linter]

[contrib]: https://github.com/CLIMADA-project/climada_python/blob/develop/CONTRIBUTING.md
[testing]: https://climada-python.readthedocs.io/en/latest/guide/Guide_Testing.html
[linter]: https://climada-python.readthedocs.io/en/latest/guide/Guide_continuous_integration_GitHub_actions.html#static-code-analysis
