### PR TITLE
New interpolation util functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ Code freeze date: YYYY-MM-DD
 ### Dependency Changes
 
 ### Added
-
+- `climada.util.interpolation` module for inter- and extrapolation util functions used in local exceedance intensity and return period functions [#930](https://github.com/CLIMADA-project/climada_python/pull/930)
+  
 ### Changed
 
 - In `climada.util.plot.geo_im_from_array`, NaNs are plotted in gray while cells with no centroid are not plotted [#929](https://github.com/CLIMADA-project/climada_python/pull/929)

--- a/climada/util/interpolation.py
+++ b/climada/util/interpolation.py
@@ -16,7 +16,7 @@ with CLIMADA. If not, see <https://www.gnu.org/licenses/>.
 
 ---
 
-define fit functionalities for (local) exceedance frequencies and return periods
+Define interpolation and extrapolation functions for calculating (local) exceedance frequencies and return periods
 """
 
 
@@ -53,9 +53,9 @@ def interpolate_ev(
         y_train : array_like
             1-D array of y-values of training data
         logx : bool, optional
-            If set to True, x_values are convert to log scale. Defaults to False.
+            If set to True, x_values are converted to log scale. Defaults to False.
         logy : bool, optional
-            If set to True, x_values are convert to log scale. Defaults to False.
+            If set to True, y_values are converted to log scale. Defaults to False.
         x_threshold : float, optional
             Lower threshold to filter x_train. Defaults to None.
         y_threshold : float, optional
@@ -146,7 +146,7 @@ def stepfunction_ev(
     if x_train.size < 2:
         return _interpolate_small_input(x_test, x_train, y_train, None, y_asymptotic)
 
-    # find indeces of x_test if sorted into x_train
+    # find indices of x_test if sorted into x_train
     if not all(sorted(x_train) == x_train):
         raise ValueError('Input array x_train must be sorted in ascending order.')
     indx = np.searchsorted(x_train, x_test)

--- a/climada/util/interpolation.py
+++ b/climada/util/interpolation.py
@@ -1,0 +1,270 @@
+"""
+This file is part of CLIMADA.
+
+Copyright (C) 2017 ETH Zurich, CLIMADA contributors listed in AUTHORS.
+
+CLIMADA is free software: you can redistribute it and/or modify it under the
+terms of the GNU General Public License as published by the Free
+Software Foundation, version 3.
+
+CLIMADA is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along
+with CLIMADA. If not, see <https://www.gnu.org/licenses/>.
+
+---
+
+define fit functionalities for (local) exceedance frequencies and return periods
+"""
+
+
+import logging
+
+import numpy as np
+from scipy import interpolate
+
+from climada.util.value_representation import sig_dig_list
+
+LOGGER = logging.getLogger(__name__)
+
+def interpolate_ev(
+        x_test,
+        x_train,
+        y_train,
+        x_scale = None,
+        y_scale = None,
+        x_threshold = None,
+        y_threshold = None,
+        y_asymptotic = np.nan,
+        fill_value = np.nan
+    ):
+    """
+    Util function to interpolate (and extrapolate) training data (x_train, y_train)
+    to new points x_test with several options (log scale, thresholds)
+
+    Parameters:
+    -------
+        x_test : array_like
+            1-D array of x-values for which training data should be interpolated
+        x_train : array_like
+            1-D array of x-values of training data
+        y_train : array_like
+            1-D array of y-values of training data
+        x_scale : str, optional
+            If set to 'log', x_values are convert to log scale. Defaults to None.
+        y_scale : str, optional
+            If set to 'log', x_values are convert to log scale. Defaults to None.
+        x_threshold : float, optional
+            Lower threshold to filter x_train. Defaults to None.
+        y_threshold : float, optional
+            Lower threshold to filter y_train. Defaults to None.
+        y_asymptotic : float, optional
+            Return value if x_test > x_train and if
+            x_train.size < 2. Defaults to np.nan.
+        fill_value : tuple, float, str
+            fill values to use when x_test outside of range of x_train.
+            If set to "extrapolate", values will be extrapolated. If set to a float, value will 
+            be used on both sides. If set to tuple, left value will be used for left side and 
+            right value will be used for right side. If tuple and left value is "maximum", the maximum 
+            of the cummulative frequencies will be used to compute exceedance intensities on the left.
+            Defaults to np.nan
+
+    Returns
+    -------
+    np.array
+        interpolated values y_test for the test points x_test
+    """
+
+    # # check if inputs are valid
+    # if method not in ['interpolate', 'stepfunction']:
+    #     raise ValueError(f'Unknown method: {method}. Use "interpolate" or "stepfunction" instead')
+    # if method == 'stepfunction': # x_scale and y_scale unnecessary if fitting stepfunction
+    #     x_scale, y_scale = None, None
+
+    # preprocess interpolation data
+    x_test, x_train, y_train = _preprocess_interpolation_data(
+        x_test, x_train, y_train, x_scale, y_scale, x_threshold, y_threshold
+    )
+
+      # handle case of small training data sizes
+    if x_train.size < 2:
+        LOGGER.warning('Data is being extrapolated.')
+        return _interpolate_small_input(x_test, x_train, y_train, y_scale, y_asymptotic)
+
+    # calculate fill values
+    if isinstance(fill_value, tuple):
+        if fill_value[0] == 'maximum':
+            fill_value = (
+                np.max(y_train),
+                np.log10(fill_value[1]) if y_scale == 'log' else fill_value[1]
+                )
+        elif y_scale == 'log':
+            fill_value = tuple(np.log10(fill_value))
+    elif isinstance(fill_value, (float, int)) and y_scale == 'log':
+        fill_value = np.log10(fill_value)
+    
+  
+    # warn if data is being extrapolated
+    if (
+        fill_value == 'extrapolate' and
+        ((np.min(x_test) < np.min(x_train)) or (np.max(x_test) > np.max(x_train)))
+    ):
+        LOGGER.warning('Data is being extrapolated.')
+
+    interpolation = interpolate.interp1d(x_train, y_train, fill_value=fill_value, bounds_error=False)
+    y_test = interpolation(x_test)
+
+    # adapt output scale
+    if y_scale == 'log':
+        y_test = np.power(10., y_test)
+    return y_test
+
+def stepfunction_ev(
+        x_test,
+        x_train,
+        y_train,
+        x_threshold = None,
+        y_threshold = None,
+        y_asymptotic = np.nan
+    ):
+    """
+    Util function to interpolate and extrapolate training data (x_train, y_train)
+    to new points x_test using a step function
+
+    Parameters:
+    -------
+        x_test : array_like
+            1-D array of x-values for which training data should be interpolated
+        x_train : array_like
+            1-D array of x-values of training data
+        y_train : array_like
+            1-D array of y-values of training data
+        x_threshold : float, optional
+            Lower threshold to filter x_train. Defaults to None.
+        y_threshold : float, optional
+            Lower threshold to filter y_train. Defaults to None.
+        y_asymptotic : float, optional
+            Return value if x_test > x_train. Defaults to np.nan.
+
+    Returns
+    -------
+    np.array
+        interpolated values y_test for the test points x_test
+    """
+
+    # preprocess interpolation data
+    x_test, x_train, y_train = _preprocess_interpolation_data(
+        x_test, x_train, y_train, None, None, x_threshold, y_threshold
+    )
+
+    # handle case of small training data sizes
+    if x_train.size < 2:
+        return _interpolate_small_input(x_test, x_train, y_train, None, y_asymptotic)
+    
+    # find indeces of x_test if sorted into x_train
+    if not all(sorted(x_train) == x_train):
+        raise ValueError('Input array x_train must be sorted in ascending order.')
+    indx = np.searchsorted(x_train, x_test)
+    y_test = y_train[indx.clip(max = len(x_train) - 1)]
+    y_test[indx == len(x_train)] = y_asymptotic
+
+    return y_test
+
+def _preprocess_interpolation_data(
+        x_test,
+        x_train,
+        y_train,
+        x_scale,
+        y_scale,
+        x_threshold,
+        y_threshold
+    ):
+    """
+    helper function to preprocess interpolation training and test data by filtering data below
+    thresholds and converting to log scale if required
+    """
+
+    if x_train.shape != y_train.shape:
+        raise ValueError(f'Incompatible shapes of input data, x_train {x_train.shape} '
+                         f'and y_train {y_train.shape}. Should be the same')
+
+    # transform input to float arrays
+    x_test, x_train, y_train = (np.array(x_test).astype(float),
+                                np.array(x_train).astype(float),
+                                np.array(y_train).astype(float))
+
+    # cut x and y above threshold
+    if x_threshold or x_threshold==0:
+        x_th = np.asarray(x_train > x_threshold).squeeze()
+        x_train = x_train[x_th]
+        y_train = y_train[x_th]
+
+    if y_threshold or y_threshold==0:
+        y_th = np.asarray(y_train > y_threshold).squeeze()
+        x_train = x_train[y_th]
+        y_train = y_train[y_th]
+
+    # convert to log scale
+    if x_scale == 'log':
+        x_train, x_test = np.log10(x_train), np.log10(x_test)
+    if y_scale == 'log':
+        y_train = np.log10(y_train)
+
+    return (x_test, x_train, y_train)
+
+def _interpolate_small_input(x_test, x_train, y_train, y_scale, y_asymptotic):
+    """
+    helper function to handle if interpolation data is small (empty or one point)
+    """
+    # return y_asymptotic if x_train and y_train empty
+    if x_train.size == 0:
+        return np.full_like(x_test, y_asymptotic)
+
+    # reconvert logarithmic y_scale to normal y_train
+    if y_scale == 'log':
+        y_train = np.power(10., y_train)
+
+    # if only one (x_train, y_train), return stepfunction with
+    # y_train if x_test < x_train and y_asymtotic if x_test > x_train
+    y_test = np.full_like(x_test, y_train[0])
+    y_test[np.squeeze(x_test) > np.squeeze(x_train)] = y_asymptotic
+    return y_test
+
+def group_frequency(frequency, value, n_sig_dig=2):
+    """
+    Util function to aggregate (add) frequencies for equal values
+
+    Parameters:
+    ------
+        frequency : array_like
+            Frequency array
+        value : array_like
+            Value array in ascending order
+        n_sig_dig : int
+            number of significant digits for value when grouping frequency.
+            Defaults to 2.
+
+    Returns:
+    ------
+        tuple
+            (frequency array after aggregation,
+            unique value array in ascending order)
+    """
+    frequency, value = np.array(frequency), np.array(value)
+    if frequency.size == 0 and value.size == 0:
+        return ([], [])
+
+    if len(value) != len(np.unique(sig_dig_list(value, n_sig_dig=n_sig_dig))):
+        #check ordering of value
+        if not all(sorted(value) == value):
+            raise ValueError('Value array must be sorted in ascending order.')
+        # add frequency for equal value
+        value, start_indices = np.unique(sig_dig_list(value, n_sig_dig=n_sig_dig), return_index=True)
+        start_indices = np.insert(start_indices, len(value), len(frequency))
+        frequency = np.array([
+            sum(frequency[start_indices[i]:start_indices[i+1]])
+            for i in range(len(value))
+        ])
+    return frequency, value

--- a/climada/util/interpolation.py
+++ b/climada/util/interpolation.py
@@ -77,12 +77,6 @@ def interpolate_ev(
         interpolated values y_test for the test points x_test
     """
 
-    # # check if inputs are valid
-    # if method not in ['interpolate', 'stepfunction']:
-    #     raise ValueError(f'Unknown method: {method}. Use "interpolate" or "stepfunction" instead')
-    # if method == 'stepfunction': # x_scale and y_scale unnecessary if fitting stepfunction
-    #     x_scale, y_scale = None, None
-
     # preprocess interpolation data
     x_test, x_train, y_train = _preprocess_interpolation_data(
         x_test, x_train, y_train, x_scale, y_scale, x_threshold, y_threshold

--- a/climada/util/interpolation.py
+++ b/climada/util/interpolation.py
@@ -65,11 +65,11 @@ def interpolate_ev(
             x_train.size < 2. Defaults to np.nan.
         fill_value : tuple, float, str
             fill values to use when x_test outside of range of x_train.
-            If set to "extrapolate", values will be extrapolated. If set to a float, value will 
-            be used on both sides. If set to tuple, left value will be used for left side and 
-            right value will be used for right side. If tuple and left value is "maximum", the maximum 
-            of the cummulative frequencies will be used to compute exceedance intensities on the left.
-            Defaults to np.nan
+            If set to "extrapolate", values will be extrapolated. If set to a float, value will
+            be used on both sides. If set to tuple, left value will be used for left side and
+            right value will be used for right side. If tuple and left value is "maximum",
+            the maximum of the cummulative frequencies will be used to compute exceedance
+            intensities on the left. Defaults to np.nan
 
     Returns
     -------
@@ -104,8 +104,7 @@ def interpolate_ev(
             fill_value = tuple(np.log10(fill_value))
     elif isinstance(fill_value, (float, int)) and y_scale == 'log':
         fill_value = np.log10(fill_value)
-    
-  
+
     # warn if data is being extrapolated
     if (
         fill_value == 'extrapolate' and
@@ -113,7 +112,8 @@ def interpolate_ev(
     ):
         LOGGER.warning('Data is being extrapolated.')
 
-    interpolation = interpolate.interp1d(x_train, y_train, fill_value=fill_value, bounds_error=False)
+    interpolation = interpolate.interp1d(
+        x_train, y_train, fill_value=fill_value, bounds_error=False)
     y_test = interpolation(x_test)
 
     # adapt output scale
@@ -162,7 +162,7 @@ def stepfunction_ev(
     # handle case of small training data sizes
     if x_train.size < 2:
         return _interpolate_small_input(x_test, x_train, y_train, None, y_asymptotic)
-    
+
     # find indeces of x_test if sorted into x_train
     if not all(sorted(x_train) == x_train):
         raise ValueError('Input array x_train must be sorted in ascending order.')
@@ -261,7 +261,8 @@ def group_frequency(frequency, value, n_sig_dig=2):
         if not all(sorted(value) == value):
             raise ValueError('Value array must be sorted in ascending order.')
         # add frequency for equal value
-        value, start_indices = np.unique(sig_dig_list(value, n_sig_dig=n_sig_dig), return_index=True)
+        value, start_indices = np.unique(
+            sig_dig_list(value, n_sig_dig=n_sig_dig), return_index=True)
         start_indices = np.insert(start_indices, len(value), len(frequency))
         frequency = np.array([
             sum(frequency[start_indices[i]:start_indices[i+1]])

--- a/climada/util/test/test_interpolation.py
+++ b/climada/util/test/test_interpolation.py
@@ -66,29 +66,29 @@ class TestFitMethods(unittest.TestCase):
         y_train = np.array([1., 3.])
         x_test = np.array([1e0, 1e2])
         np.testing.assert_allclose(
-            interpolate_ev(x_test, x_train, y_train, x_scale='log', fill_value='extrapolate'),
+            interpolate_ev(x_test, x_train, y_train, logx=True, fill_value='extrapolate'),
             np.array([0., 2.])
         )
         np.testing.assert_allclose(
-            interpolate_ev(x_test, x_train, y_train, x_scale='log'),
+            interpolate_ev(x_test, x_train, y_train, logx=True),
             np.array([np.nan, 2.])
         )
         x_train = np.array([1., 3.])
         y_train = np.array([1e1, 1e3])
         x_test = np.array([0., 2.])
         np.testing.assert_allclose(
-            interpolate_ev(x_test, x_train, y_train, y_scale='log', fill_value='extrapolate'),
+            interpolate_ev(x_test, x_train, y_train, logy=True, fill_value='extrapolate'),
             np.array([1e0, 1e2])
         )
         np.testing.assert_allclose(
-            interpolate_ev(x_test, x_train, y_train, y_scale='log'),
+            interpolate_ev(x_test, x_train, y_train, logy=True),
             np.array([np.nan, 1e2])
         )
         x_train = np.array([1e1, 1e3])
         y_train = np.array([1e1, 1e5])
         x_test = np.array([1e0, 1e2])
         np.testing.assert_allclose(
-            interpolate_ev(x_test, x_train, y_train, x_scale='log', y_scale='log', fill_value='extrapolate'),
+            interpolate_ev(x_test, x_train, y_train, logx=True, logy=True, fill_value='extrapolate'),
             np.array([1e-1, 1e3])
         )
 

--- a/climada/util/test/test_interpolation.py
+++ b/climada/util/test/test_interpolation.py
@@ -1,0 +1,187 @@
+"""
+This file is part of CLIMADA.
+
+Copyright (C) 2017 ETH Zurich, CLIMADA contributors listed in AUTHORS.
+
+CLIMADA is free software: you can redistribute it and/or modify it under the
+terms of the GNU General Public License as published by the Free
+Software Foundation, version 3.
+
+CLIMADA is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along
+with CLIMADA. If not, see <https://www.gnu.org/licenses/>.
+
+---
+
+Test of fit_methods module
+"""
+
+import unittest
+import numpy as np
+
+from climada.util.interpolation import interpolate_ev, stepfunction_ev, group_frequency
+
+
+class TestFitMethods(unittest.TestCase):
+    """Test different fit configurations"""
+
+    def test_interpolate_ev_linear_interp(self):
+        """Test linear interpolation"""
+        x_train = np.array([1., 3., 5.])
+        y_train = np.array([2., 4., 8.])
+        x_test = np.array([0., 3., 4.])
+        np.testing.assert_allclose(
+            interpolate_ev(x_test, x_train, y_train),
+            np.array([np.nan, 4., 6.])
+        )
+        np.testing.assert_allclose(
+            interpolate_ev(x_test, x_train, y_train, fill_value = -1),
+            np.array([-1., 4., 6.])
+        )
+
+    def test_interpolate_ev_threshold_parameters(self):
+        """Test input threshold parameters"""
+        x_train = np.array([0., 3., 6.])
+        y_train = np.array([4., 1., 4.])
+        x_test = np.array([-1., 3., 4.])
+        np.testing.assert_allclose(
+            interpolate_ev(x_test, x_train, y_train),
+            np.array([np.nan, 1., 2.])
+        )
+        np.testing.assert_allclose(
+            interpolate_ev(x_test, x_train, y_train, x_threshold=1.),
+            np.array([np.nan, 1., 2.])
+        )
+        np.testing.assert_allclose(
+            interpolate_ev(x_test, x_train, y_train, y_threshold=2.),
+            np.array([np.nan, 4., 4.])
+        )
+    
+    def test_interpolate_ev_scale_parameters(self):
+        """Test log scale parameters"""
+        x_train = np.array([1e1, 1e3])
+        y_train = np.array([1., 3.])
+        x_test = np.array([1e0, 1e2])
+        np.testing.assert_allclose(
+            interpolate_ev(x_test, x_train, y_train, x_scale='log', fill_value='extrapolate'),
+            np.array([0., 2.])
+        )
+        np.testing.assert_allclose(
+            interpolate_ev(x_test, x_train, y_train, x_scale='log'),
+            np.array([np.nan, 2.])
+        )
+        x_train = np.array([1., 3.])
+        y_train = np.array([1e1, 1e3])
+        x_test = np.array([0., 2.])
+        np.testing.assert_allclose(
+            interpolate_ev(x_test, x_train, y_train, y_scale='log', fill_value='extrapolate'),
+            np.array([1e0, 1e2])
+        )
+        np.testing.assert_allclose(
+            interpolate_ev(x_test, x_train, y_train, y_scale='log'),
+            np.array([np.nan, 1e2])
+        )
+        x_train = np.array([1e1, 1e3])
+        y_train = np.array([1e1, 1e5])
+        x_test = np.array([1e0, 1e2])
+        np.testing.assert_allclose(
+            interpolate_ev(x_test, x_train, y_train, x_scale='log', y_scale='log', fill_value='extrapolate'),
+            np.array([1e-1, 1e3])
+        )
+
+    def test_interpolate_ev_degenerate_input(self):
+        """Test interp to constant zeros"""
+        x_train = np.array([1., 3., 5.])
+        x_test = np.array([0., 2., 4.])
+        y_train = np.zeros(3)
+        np.testing.assert_allclose(
+            interpolate_ev(x_test, x_train, y_train),
+            np.array([np.nan, 0., 0.])
+        )
+
+    def test_interpolate_ev_small_input(self):
+        """Test small input"""
+        x_train = np.array([1.])
+        y_train = np.array([2.])
+        x_test = np.array([0., 1., 2.])
+        np.testing.assert_allclose(
+            interpolate_ev(x_test, x_train, y_train),
+            np.array([2., 2., np.nan])
+        )
+        np.testing.assert_allclose(
+            interpolate_ev(x_test, x_train, y_train, y_asymptotic=0),
+            np.array([2., 2., 0.])
+        )
+        x_train = np.array([])
+        y_train = np.array([])
+        x_test = np.array([0., 1., 2.])
+        np.testing.assert_allclose(
+            interpolate_ev(x_test, x_train, y_train),
+            np.full(3, np.nan)
+        )
+        np.testing.assert_allclose(
+            interpolate_ev(x_test, x_train, y_train, y_asymptotic=0),
+            np.zeros(3)
+        )
+
+    def test_stepfunction_ev(self):
+        """Test stepfunction method"""
+        x_train = np.array([1., 3., 5.])
+        y_train = np.array([8., 4., 2.])
+        x_test = np.array([0., 3., 4., 6.])
+        np.testing.assert_allclose(
+            stepfunction_ev(x_test, x_train, y_train),
+            np.array([8., 4., 2., np.nan])
+        )
+        np.testing.assert_allclose(
+            stepfunction_ev(x_test, x_train, y_train, y_asymptotic=0.),
+            np.array([8., 4., 2., 0.])
+        )
+
+    def test_stepfunction_ev_small_input(self):
+        """Test small input"""
+        x_train = np.array([1.])
+        y_train = np.array([2.])
+        x_test = np.array([0., 1., 2.])
+        np.testing.assert_allclose(
+            stepfunction_ev(x_test, x_train, y_train),
+            np.array([2., 2., np.nan])
+        )
+        np.testing.assert_allclose(
+            stepfunction_ev(x_test, x_train, y_train, y_asymptotic=0),
+            np.array([2., 2., 0.])
+        )
+        x_train = np.array([])
+        y_train = np.array([])
+        x_test = np.array([0., 1., 2.])
+        np.testing.assert_allclose(
+            stepfunction_ev(x_test, x_train, y_train),
+            np.full(3, np.nan)
+        )
+        np.testing.assert_allclose(
+            stepfunction_ev(x_test, x_train, y_train, y_asymptotic=0),
+            np.zeros(3)
+        )
+    
+    def test_frequency_group(self):
+        """Test frequency grouping method"""
+        frequency = np.ones(6)
+        intensity = np.array([1., 1., 1., 2., 3., 3])
+        np.testing.assert_allclose(
+            group_frequency(frequency, intensity), 
+            ([3, 1, 2], [1, 2, 3])
+        )
+        np.testing.assert_allclose(
+            group_frequency([], []), 
+            ([], [])
+        )
+        with self.assertRaises(ValueError):
+            group_frequency(frequency, intensity[::-1])
+
+# Execute Tests
+if __name__ == "__main__":
+    TESTS = unittest.TestLoader().loadTestsFromTestCase(TestFitMethods)
+    unittest.TextTestRunner(verbosity=2).run(TESTS)

--- a/climada/util/test/test_interpolation.py
+++ b/climada/util/test/test_interpolation.py
@@ -31,15 +31,15 @@ class TestFitMethods(unittest.TestCase):
     def test_interpolate_ev_linear_interp(self):
         """Test linear interpolation"""
         x_train = np.array([1., 3., 5.])
-        y_train = np.array([2., 4., 8.])
-        x_test = np.array([0., 3., 4.])
+        y_train = np.array([8., 4., 2.])
+        x_test = np.array([0., 3., 4., 6.])
         np.testing.assert_allclose(
             interpolate_ev(x_test, x_train, y_train),
-            np.array([np.nan, 4., 6.])
+            np.array([8., 4., 3., np.nan])
         )
         np.testing.assert_allclose(
-            interpolate_ev(x_test, x_train, y_train, fill_value = -1),
-            np.array([-1., 4., 6.])
+            interpolate_ev(x_test, x_train, y_train, y_asymptotic = 0),
+            np.array([8., 4., 3., 0.])
         )
 
     def test_interpolate_ev_threshold_parameters(self):
@@ -49,15 +49,15 @@ class TestFitMethods(unittest.TestCase):
         x_test = np.array([-1., 3., 4.])
         np.testing.assert_allclose(
             interpolate_ev(x_test, x_train, y_train),
-            np.array([np.nan, 1., 2.])
+            np.array([4., 1., 2.])
         )
         np.testing.assert_allclose(
             interpolate_ev(x_test, x_train, y_train, x_threshold=1.),
-            np.array([np.nan, 1., 2.])
+            np.array([1., 1., 2.])
         )
         np.testing.assert_allclose(
             interpolate_ev(x_test, x_train, y_train, y_threshold=2.),
-            np.array([np.nan, 4., 4.])
+            np.array([4., 4., 4.])
         )
     
     def test_interpolate_ev_scale_parameters(self):
@@ -66,29 +66,25 @@ class TestFitMethods(unittest.TestCase):
         y_train = np.array([1., 3.])
         x_test = np.array([1e0, 1e2])
         np.testing.assert_allclose(
-            interpolate_ev(x_test, x_train, y_train, logx=True, fill_value='extrapolate'),
+            interpolate_ev(x_test, x_train, y_train, logx=True, extrapolation=True),
             np.array([0., 2.])
         )
         np.testing.assert_allclose(
             interpolate_ev(x_test, x_train, y_train, logx=True),
-            np.array([np.nan, 2.])
+            np.array([1., 2.])
         )
         x_train = np.array([1., 3.])
         y_train = np.array([1e1, 1e3])
         x_test = np.array([0., 2.])
         np.testing.assert_allclose(
-            interpolate_ev(x_test, x_train, y_train, logy=True, fill_value='extrapolate'),
+            interpolate_ev(x_test, x_train, y_train, logy=True, extrapolation=True),
             np.array([1e0, 1e2])
-        )
-        np.testing.assert_allclose(
-            interpolate_ev(x_test, x_train, y_train, logy=True),
-            np.array([np.nan, 1e2])
         )
         x_train = np.array([1e1, 1e3])
         y_train = np.array([1e1, 1e5])
         x_test = np.array([1e0, 1e2])
         np.testing.assert_allclose(
-            interpolate_ev(x_test, x_train, y_train, logx=True, logy=True, fill_value='extrapolate'),
+            interpolate_ev(x_test, x_train, y_train, logx=True, logy=True, extrapolation=True),
             np.array([1e-1, 1e3])
         )
 
@@ -99,7 +95,7 @@ class TestFitMethods(unittest.TestCase):
         y_train = np.zeros(3)
         np.testing.assert_allclose(
             interpolate_ev(x_test, x_train, y_train),
-            np.array([np.nan, 0., 0.])
+            np.array([0., 0., 0.])
         )
 
     def test_interpolate_ev_small_input(self):


### PR DESCRIPTION
Changes proposed in this PR:
- new util module `interpolate.py` with which data can be linearly interpolated (and extrapolated) using the function `interpolate_ev` or interpolated with a stepfunction using the function `stepfunction_ev`. Options include thresholds and log scales. Also, a util function `group_frequency` is added to group frequencies for constant intensitity or impact values. These util functions will later be used in the functions `Impact.local_exceedance_impact`, `Hazard.local_exceedance_intensity`, `Hazard.local_return_period`, see PR #918. 

This PR is the first part of PR #918 (splitted for length reasons) that will fix #904, #915 and partially also #209.

### PR Author Checklist

- [x] Read the [Contribution Guide][contrib]
- [x] Correct target branch selected (if unsure, select `develop`)
- [x] Descriptive pull request title added
- [x] Source branch up-to-date with target branch
- [x] [Documentation](https://climada-python.readthedocs.io/en/latest/guide/Guide_PythonDos-n-Donts.html#2.--Commenting-&-Documenting) updated
- [x] [Tests][testing] updated
- [x] [Tests][testing] passing
- [x] No new [linter issues][linter]
- [x] [Changelog](https://github.com/CLIMADA-project/climada_python/blob/develop/CHANGELOG.md) updated

### PR Reviewer Checklist

- [x] Read the [Contribution Guide][contrib]
- [x] [CLIMADA Reviewer Checklist](https://climada-python.readthedocs.io/en/latest/guide/Guide_Review.html#reviewer-checklist) passed
- [x] [Tests][testing] passing
- [x] No new [linter issues][linter]

[contrib]: https://github.com/CLIMADA-project/climada_python/blob/develop/CONTRIBUTING.md
[testing]: https://climada-python.readthedocs.io/en/latest/guide/Guide_Testing.html
[linter]: https://climada-python.readthedocs.io/en/latest/guide/Guide_continuous_integration_GitHub_actions.html#static-code-analysis
