### PR TITLE
default installation with python 3.11

### DIFF
--- a/doc/guide/install.rst
+++ b/doc/guide/install.rst
@@ -161,7 +161,7 @@ For advanced Python users or developers of CLIMADA, we recommed cloning the CLIM
 
    .. code-block:: shell
 
-      mamba create -n climada_env "python=3.9.*"
+      mamba create -n climada_env "python=3.11.*"
 
    .. hint::
 
@@ -177,7 +177,7 @@ For advanced Python users or developers of CLIMADA, we recommed cloning the CLIM
          :width: 60%
 
          * - **Supported Version**
-           - ``3.9``
+           - ``3.11``
          * - Allowed Versions
            - ``3.9``, ``3.10``, ``3.11``
 

--- a/script/jenkins/install_env.sh
+++ b/script/jenkins/install_env.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 
 mamba remove --name climada_env --all
-mamba create -n climada_env python=3.9
+mamba create -n climada_env python=3.11
 mamba env update -n climada_env -f requirements/env_climada.yml
 
 source activate climada_env

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
 
     classifiers=[
         'Development Status :: 4 - Beta',
-        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3',
         'Topic :: Scientific/Engineering :: Atmospheric Science',
         'Topic :: Scientific/Engineering :: GIS',
         'Topic :: Scientific/Engineering :: Mathematics',


### PR DESCRIPTION
Changes proposed in this PR:
- Adjust doc and config file so that they point to python 3.11 as the default version

This PR fixes #

### PR Author Checklist

- [ ] Read the [Contribution Guide][contrib]
- [x] Correct target branch selected (if unsure, select `develop`)
- [x] Descriptive pull request title added
- [x] Source branch up-to-date with target branch
- [ ] [Documentation](https://climada-python.readthedocs.io/en/latest/guide/Guide_PythonDos-n-Donts.html#2.--Commenting-&-Documenting) updated
- [ ] [Tests][testing] updated
- [ ] [Tests][testing] passing
- [ ] No new [linter issues][linter]
- [ ] [Changelog](https://github.com/CLIMADA-project/climada_python/blob/develop/CHANGELOG.md) updated

### PR Reviewer Checklist

- [ ] Read the [Contribution Guide][contrib]
- [ ] [CLIMADA Reviewer Checklist](https://climada-python.readthedocs.io/en/latest/guide/Guide_Review.html#reviewer-checklist) passed
- [ ] [Tests][testing] passing
- [ ] No new [linter issues][linter]

[contrib]: https://github.com/CLIMADA-project/climada_python/blob/develop/CONTRIBUTING.md
[testing]: https://climada-python.readthedocs.io/en/latest/guide/Guide_Testing.html
[linter]: https://climada-python.readthedocs.io/en/latest/guide/Guide_continuous_integration_GitHub_actions.html#static-code-analysis
