### PR TITLE
Bug fix in Hazard.get_mdr and impact calculation in case of a single exposure point and MDR values of 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ Code freeze date: YYYY-MM-DD
 
 ### Fixed
 
+- Avoids a ValueError in the impact calculation for cases with a single exposure point and MDR values of 0, by explicitly removing zeros in `climada.hazard.Hazard.get_mdr` [#933](https://github.com/CLIMADA-project/climada_python/pull/948)
+
 ### Deprecated
 
 ### Removed

--- a/climada/hazard/base.py
+++ b/climada/hazard/base.py
@@ -1103,7 +1103,9 @@ class Hazard(HazardIO, HazardPlot):
             impf.id)
             mdr_array = impf.calc_mdr(mdr.toarray().ravel()).reshape(mdr.shape)
             mdr = sparse.csr_matrix(mdr_array)
-        return mdr[:, indices]
+        mdr_out = mdr[:, indices]
+        mdr_out.eliminate_zeros()
+        return mdr_out
 
     def get_paa(self, cent_idx, impf):
         """

--- a/climada/hazard/test/test_base.py
+++ b/climada/hazard/test/test_base.py
@@ -1176,6 +1176,14 @@ class TestImpactFuncs(unittest.TestCase):
             true_mdr = np.digitize(haz.intensity[:, idx].toarray(), [0, 1])
             np.testing.assert_array_almost_equal(mdr.toarray(), true_mdr)
 
+        # #case with zeros everywhere
+        cent_idx = np.array([0, 0, 1])
+        impf.mdd=np.array([0,0,0,1])
+        # how many non-zeros values are expected
+        num_nz_values = 5
+        mdr = haz.get_mdr(cent_idx, impf)
+        self.assertEqual(mdr.nnz, num_nz_values)
+
     def test_get_paa(self):
         haz = dummy_hazard()
         impf = dummy_step_impf(haz)


### PR DESCRIPTION
Changes proposed in this PR:
- Fixes a bug in the impact calculation for cases with a single exposure point and a zero MDR value.

This PR fixes #933

### PR Author Checklist

- [x] Read the [Contribution Guide][contrib]
- [x] Correct target branch selected (if unsure, select `develop`)
- [x] Descriptive pull request title added
- [x] Source branch up-to-date with target branch
- [x] [Documentation](https://climada-python.readthedocs.io/en/latest/guide/Guide_PythonDos-n-Donts.html#2.--Commenting-&-Documenting) updated
- [x] [Tests][testing] updated
- [x] [Tests][testing] passing
- [x] No new [linter issues][linter]
- [x] [Changelog](https://github.com/CLIMADA-project/climada_python/blob/develop/CHANGELOG.md) updated

### PR Reviewer Checklist

- [ ] Read the [Contribution Guide][contrib]
- [ ] [CLIMADA Reviewer Checklist](https://climada-python.readthedocs.io/en/latest/guide/Guide_Review.html#reviewer-checklist) passed
- [ ] [Tests][testing] passing
- [ ] No new [linter issues][linter]

[contrib]: https://github.com/CLIMADA-project/climada_python/blob/develop/CONTRIBUTING.md
[testing]: https://climada-python.readthedocs.io/en/latest/guide/Guide_Testing.html
[linter]: https://climada-python.readthedocs.io/en/latest/guide/Guide_continuous_integration_GitHub_actions.html#static-code-analysis
