### PR TITLE
remove pyepsg from requirements

### DIFF
--- a/requirements/env_climada.yml
+++ b/requirements/env_climada.yml
@@ -24,7 +24,6 @@ dependencies:
   - pint>=0.24
   - pip
   - pycountry>=24.6
-  - pyepsg>=0.4
   - pyproj>=3.5
   - pytables>=3.7
   - pyxlsb>=1.0


### PR DESCRIPTION
Changes proposed in this PR:
- remove pyepsg entry from the requirements file
- it is not required anymore
- conda-forge builds start to fail with 'pyepsg 0.4.0 is not supported on this platform'

This PR fixes #

### PR Author Checklist

- [ ] Read the [Contribution Guide][contrib]
- [ ] Correct target branch selected (if unsure, select `develop`)
- [ ] Descriptive pull request title added
- [ ] Source branch up-to-date with target branch
- [ ] [Documentation](https://climada-python.readthedocs.io/en/latest/guide/Guide_PythonDos-n-Donts.html#2.--Commenting-&-Documenting) updated
- [ ] [Tests][testing] updated
- [ ] [Tests][testing] passing
- [ ] No new [linter issues][linter]
- [ ] [Changelog](https://github.com/CLIMADA-project/climada_python/blob/develop/CHANGELOG.md) updated

### PR Reviewer Checklist

- [ ] Read the [Contribution Guide][contrib]
- [ ] [CLIMADA Reviewer Checklist](https://climada-python.readthedocs.io/en/latest/guide/Guide_Review.html#reviewer-checklist) passed
- [ ] [Tests][testing] passing
- [ ] No new [linter issues][linter]

[contrib]: https://github.com/CLIMADA-project/climada_python/blob/develop/CONTRIBUTING.md
[testing]: https://climada-python.readthedocs.io/en/latest/guide/Guide_Testing.html
[linter]: https://climada-python.readthedocs.io/en/latest/guide/Guide_continuous_integration_GitHub_actions.html#static-code-analysis
