### PR TITLE
optimize concatenation of centroids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ Code freeze date: YYYY-MM-DD
 
 ### Fixed
 
+- Resolved an issue where windspeed computation was much slower than in Climada v3 [#989](https://github.com/CLIMADA-project/climada_python/pull/989)
 - File handles are being closed after reading netcdf files with `climada.hazard` modules [#953](https://github.com/CLIMADA-project/climada_python/pull/953)
 - Avoids a ValueError in the impact calculation for cases with a single exposure point and MDR values of 0, by explicitly removing zeros in `climada.hazard.Hazard.get_mdr` [#933](https://github.com/CLIMADA-project/climada_python/pull/948)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,9 +31,7 @@ Code freeze date: YYYY-MM-DD
 
 ### Changed
 
-- `climada.hazard.centroids.centr.union` and `climada.hazard.centroids.centr.append`[#989](https://github.com/CLIMADA-project/climada_python/pull/989). Results: computing windfields is 10 times faster.
-  - `union` does not iterate anymore over `append` but calls directly `append` with the entire list of centroids objects.
-  - `append` concatenate centroids only once, when all centroids have been appended, instead of concatenating after every centroid is appended.
+- `Centroids.append` now takes multiple arguments and provides a performance boost when doing so [#989](https://github.com/CLIMADA-project/climada_python/pull/989)
 - `climada.util.coordinates.get_country_geometries` function: Now throwing a ValueError if unregognized ISO country code is given (before, the invalid ISO code was ignored) [#980](https://github.com/CLIMADA-project/climada_python/pull/980)
 - Improved scaling factors implemented in `climada.hazard.trop_cyclone.apply_climate_scenario_knu` to model the impact of climate changes to tropical cyclones [#734](https://github.com/CLIMADA-project/climada_python/pull/734)
 - In `climada.util.plot.geo_im_from_array`, NaNs are plotted in gray while cells with no centroid are not plotted [#929](https://github.com/CLIMADA-project/climada_python/pull/929)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@ Code freeze date: YYYY-MM-DD
 
 ### Changed
 
+- `climada.hazard.centroids.centr.union` and `climada.hazard.centroids.centr.append`[#989](https://github.com/CLIMADA-project/climada_python/pull/989). Results: computing windfields is 10 times faster.
+  - `union` does not iterate anymore over `append` but calls directly `append` with the entire list of centroids objects.
+  - `append` concatenate centroids only once, when all centroids have been appended, instead of concatenating after every centroid is appended.
 - `climada.util.coordinates.get_country_geometries` function: Now throwing a ValueError if unregognized ISO country code is given (before, the invalid ISO code was ignored) [#980](https://github.com/CLIMADA-project/climada_python/pull/980)
 - Improved scaling factors implemented in `climada.hazard.trop_cyclone.apply_climate_scenario_knu` to model the impact of climate changes to tropical cyclones [#734](https://github.com/CLIMADA-project/climada_python/pull/734)
 - In `climada.util.plot.geo_im_from_array`, NaNs are plotted in gray while cells with no centroid are not plotted [#929](https://github.com/CLIMADA-project/climada_python/pull/929)

--- a/climada/hazard/centroids/centr.py
+++ b/climada/hazard/centroids/centr.py
@@ -344,8 +344,8 @@ class Centroids:
 
         Parameters
         ----------
-        centr : list
-            List of Centroids to append. The centroids need to have the same CRS.
+        centr : Centroids
+            Centroids to append. The centroids need to have the same CRS.
 
         Raises
         ------
@@ -374,8 +374,8 @@ class Centroids:
 
         Parameters
         ----------
-        others : list
-            List of Centroids contributing to the union.
+        others : Centroids
+            Centroids contributing to the union.
 
         Returns
         -------

--- a/climada/hazard/centroids/centr.py
+++ b/climada/hazard/centroids/centr.py
@@ -339,8 +339,8 @@ class Centroids:
         object with the union of all centroids.
 
         Note that the result might contain duplicate points if the object to append has an overlap
-        with the current object. Duplicates points will be removed in `union`
-        by calling `remove_duplicate_points`.
+        with the current object. Remove duplicates by either using :py:meth:`union`
+        or calling :py:meth:`remove_duplicate_points` after appending.
 
         Parameters
         ----------

--- a/climada/hazard/centroids/centr.py
+++ b/climada/hazard/centroids/centr.py
@@ -356,13 +356,13 @@ class Centroids:
         union : Union of Centroid objects.
         remove_duplicate_points : Remove duplicate points in a Centroids object.
         """
-        for cc in centr:
-            if not u_coord.equal_crs(self.crs, cc.crs):
+        for other in centr:
+            if not u_coord.equal_crs(self.crs, other.crs):
                 raise ValueError(
-                    f"The given centroids use different CRS: {self.crs}, {cc.crs}. "
+                    f"The given centroids use different CRS: {self.crs}, {other.crs}. "
                     "The centroids are incompatible and cannot be concatenated."
                 )
-        self.gdf = pd.concat([self.gdf] + [cc.gdf for cc in centr])
+        self.gdf = pd.concat([self.gdf] + [other.gdf for other in centr])
 
     def union(self, *others):
         """Create the union of the current Centroids object with one or more other centroids

--- a/climada/hazard/centroids/centr.py
+++ b/climada/hazard/centroids/centr.py
@@ -334,7 +334,7 @@ class Centroids:
     def append(self, *centr):
         """Append Centroids to the current centroid object for concatenation.
 
-        This method check that all centroids use the same CRS, append the list of centroids to
+        This method checks that all centroids use the same CRS, appends the list of centroids to
         the initial Centroid object and eventually concatenates them to create a single centroid
         object with the union of all centroids.
 

--- a/climada/hazard/centroids/centr.py
+++ b/climada/hazard/centroids/centr.py
@@ -344,8 +344,8 @@ class Centroids:
 
         Parameters
         ----------
-        centr : Centroids
-            Centroids to append. The centroids need to have the same CRS.
+        centr : list
+            List of Centroids to append. The centroids need to have the same CRS.
 
         Raises
         ------
@@ -366,7 +366,7 @@ class Centroids:
 
     def union(self, *others):
         """Create the union of the current Centroids object with one or more other centroids
-        objects by passing the list of centroids to `append` for concatenation and then
+        objects by passing the list of centroids to :py:meth:`append` for concatenation and then
         removes duplicates.
 
         All centroids must have the same CRS. Points that are contained in more than one of the
@@ -374,8 +374,8 @@ class Centroids:
 
         Parameters
         ----------
-        others : list of Centroids
-            Centroids contributing to the union.
+        others : list
+            List of Centroids contributing to the union.
 
         Returns
         -------

--- a/climada/hazard/centroids/centr.py
+++ b/climada/hazard/centroids/centr.py
@@ -335,7 +335,7 @@ class Centroids:
         """Append Centroids to the current centroid object for concatenation.
 
         This method check that all centroids use the same CRS, append the list of centroids to
-        the initial Centroid object and eventually concatenate them to create a single centroid
+        the initial Centroid object and eventually concatenates them to create a single centroid
         object with the union of all centroids.
 
         Note that the result might contain duplicate points if the object to append has an overlap

--- a/climada/hazard/centroids/test/test_centr.py
+++ b/climada/hazard/centroids/test/test_centr.py
@@ -817,7 +817,7 @@ class TestCentroidsMethods(unittest.TestCase):
             self.centr.append(centr2)
 
     def test_append_multiple_arguments(self):
-        """Test passing append multiple arguments in the form of a list of Centroids."""
+        """Test passing append() multiple arguments in the form of a list of Centroids."""
         # create a single centroid
         lat, lon = np.array([1, 2]), np.array([1, 2])
         centr = Centroids(lat=lat, lon=lon)

--- a/climada/hazard/centroids/test/test_centr.py
+++ b/climada/hazard/centroids/test/test_centr.py
@@ -827,14 +827,8 @@ class TestCentroidsMethods(unittest.TestCase):
 
         centr.append(*centroids_list)
 
-        self.assertEqual(centr.lat[0], 1)
-        self.assertEqual(centr.lat[1], 2)
-        self.assertEqual(centr.lat[2], 3)
-        self.assertEqual(centr.lat[3], 4)
-        self.assertEqual(centr.lon[0], 1)
-        self.assertEqual(centr.lon[1], 2)
-        self.assertEqual(centr.lon[2], 3)
-        self.assertEqual(centr.lon[3], 4)
+        np.testing.assert_array_equal(centr.lat, [1, 2, 3, 4])
+        np.testing.assert_array_equal(centr.lon, [1, 2, 3, 4])
 
     def test_remove_duplicate_pass(self):
         """Test remove_duplicate_points"""

--- a/climada/hazard/centroids/test/test_centr.py
+++ b/climada/hazard/centroids/test/test_centr.py
@@ -816,6 +816,26 @@ class TestCentroidsMethods(unittest.TestCase):
         with self.assertRaises(ValueError):
             self.centr.append(centr2)
 
+    def test_append_multiple_arguments(self):
+        """Test passing append multiple arguments in the form of a list of Centroids."""
+        # create a single centroid
+        lat, lon = np.array([1, 2]), np.array([1, 2])
+        centr = Centroids(lat=lat, lon=lon)
+        # create a list of centroids
+        coords = [(np.array([3, 4]), np.array([3, 4]))]
+        centroids_list = [Centroids(lat=lat, lon=lon) for lat, lon in coords]
+
+        centr.append(*centroids_list)
+
+        self.assertEqual(centr.lat[0], 1)
+        self.assertEqual(centr.lat[1], 2)
+        self.assertEqual(centr.lat[2], 3)
+        self.assertEqual(centr.lat[3], 4)
+        self.assertEqual(centr.lon[0], 1)
+        self.assertEqual(centr.lon[1], 2)
+        self.assertEqual(centr.lon[2], 3)
+        self.assertEqual(centr.lon[3], 4)
+
     def test_remove_duplicate_pass(self):
         """Test remove_duplicate_points"""
         centr = Centroids(


### PR DESCRIPTION
Changes proposed in this PR:

Refer to https://github.com/CLIMADA-project/climada_python/issues/988 for detailed information on the profiling results.

Modify `hazard.append()` function in `climada/hazard/centroids/centr.py` so that concatenation of centroids is made only once, when all centroids has already been appended, instead of concatenating every time a centroid is appended (extremely time consuming)

- Create centroid attribute `batch_gdf` in hazard.append()
- Append centroids to `batch_gdf`
- Define concatenation function: `finalize_append()`
- Call `finalize_append()` to concatenate at the end of the appending process
- Clear `batch_gdf` attribute

This PR fixes #988 

Optimize the function `TropCyclone.from_tracks` from 53 minutes to 4.03 minutes.

### PR Author Checklist

- [x] Read the [Contribution Guide][contrib]
- [x] Correct target branch selected (if unsure, select `develop`)
- [x] Descriptive pull request title added
- [x] Source branch up-to-date with target branch
- [x] [Documentation](https://climada-python.readthedocs.io/en/latest/guide/Guide_PythonDos-n-Donts.html#2.--Commenting-&-Documenting) updated
- [ ] [Tests][testing] updated
- [x] [Tests][testing] passing
- [ ] No new [linter issues][linter]
- [x] [Changelog](https://github.com/CLIMADA-project/climada_python/blob/develop/CHANGELOG.md) updated

### PR Reviewer Checklist

- [x] Read the [Contribution Guide][contrib]
- [x] [CLIMADA Reviewer Checklist](https://climada-python.readthedocs.io/en/latest/guide/Guide_Review.html#reviewer-checklist) passed
- [ ] [Tests][testing] passing
- [x] No new [linter issues][linter]

[contrib]: https://github.com/CLIMADA-project/climada_python/blob/develop/CONTRIBUTING.md
[testing]: https://climada-python.readthedocs.io/en/latest/guide/Guide_Testing.html
[linter]: https://climada-python.readthedocs.io/en/latest/guide/Guide_continuous_integration_GitHub_actions.html#static-code-analysis
