### PR TITLE
Use position-based index to avoid reaggregation issues in lines_polys_handler

### DIFF
--- a/climada/util/lines_polys_handler.py
+++ b/climada/util/lines_polys_handler.py
@@ -228,7 +228,7 @@ def _aggregate_impact_mat(imp_pnt, gdf_pnt, agg_met):
 
     col_geom = gdf_pnt.index.get_level_values(level=0)
     # Converts string multi-index level 0 to integer index
-    # col_geom = np.sort(np.unique(col_geom, return_inverse=True)[1])
+    col_geom = np.sort(np.unique(col_geom, return_inverse=True)[1])
     row_pnt = np.arange(len(col_geom))
 
     if agg_met is AggMethod.SUM:
@@ -238,7 +238,7 @@ def _aggregate_impact_mat(imp_pnt, gdf_pnt, agg_met):
             f"The available aggregation methods are {AggMethod._member_names_}"
         )  # pylint: disable=no-member, protected-access
     csr_mask = sp.sparse.csr_matrix(
-        (mask, (row_pnt, row_pnt)), shape=(len(row_pnt), len(row_pnt))
+        (mask, (row_pnt, row_pnt)), shape=(len(row_pnt), len(np.unique(row_pnt)))
     )
 
     return imp_pnt.imp_mat.dot(csr_mask)
@@ -962,7 +962,7 @@ def _line_to_pnts(gdf_lines, res, to_meters):
         LOGGER.warning(
             "%d lines with a length < 10*resolution were found. "
             "Each of these lines is disaggregate to one point. "
-            "Reaggregating values will thus likely lead to overestimation. "
+            "Reaggregatint values will thus likely lead to overestimattion. "
             "Consider chosing a smaller resolution or filter out the short lines. ",
             failing_res_check_count,
         )

--- a/climada/util/lines_polys_handler.py
+++ b/climada/util/lines_polys_handler.py
@@ -228,7 +228,7 @@ def _aggregate_impact_mat(imp_pnt, gdf_pnt, agg_met):
 
     col_geom = gdf_pnt.index.get_level_values(level=0)
     # Converts string multi-index level 0 to integer index
-    col_geom = np.sort(np.unique(col_geom, return_inverse=True)[1])
+    # col_geom = np.sort(np.unique(col_geom, return_inverse=True)[1])
     row_pnt = np.arange(len(col_geom))
 
     if agg_met is AggMethod.SUM:
@@ -238,7 +238,7 @@ def _aggregate_impact_mat(imp_pnt, gdf_pnt, agg_met):
             f"The available aggregation methods are {AggMethod._member_names_}"
         )  # pylint: disable=no-member, protected-access
     csr_mask = sp.sparse.csr_matrix(
-        (mask, (row_pnt, row_pnt)), shape=(len(row_pnt), len(np.unique(row_pnt)))
+        (mask, (row_pnt, row_pnt)), shape=(len(row_pnt), len(row_pnt))
     )
 
     return imp_pnt.imp_mat.dot(csr_mask)

--- a/climada/util/lines_polys_handler.py
+++ b/climada/util/lines_polys_handler.py
@@ -232,13 +232,13 @@ def _aggregate_impact_mat(imp_pnt, gdf_pnt, agg_met):
     row_pnt = np.arange(len(col_geom))
 
     if agg_met is AggMethod.SUM:
-        mask = np.ones(len(col_geom))
+        mask = np.ones(len(row_pnt))
     else:
         raise NotImplementedError(
             f"The available aggregation methods are {AggMethod._member_names_}"
         )  # pylint: disable=no-member, protected-access
     csr_mask = sp.sparse.csr_matrix(
-        (mask, (row_pnt, col_geom)), shape=(len(row_pnt), len(np.unique(col_geom)))
+        (mask, (row_pnt, row_pnt)), shape=(len(row_pnt), len(np.unique(row_pnt)))
     )
 
     return imp_pnt.imp_mat.dot(csr_mask)

--- a/climada/util/lines_polys_handler.py
+++ b/climada/util/lines_polys_handler.py
@@ -962,7 +962,7 @@ def _line_to_pnts(gdf_lines, res, to_meters):
         LOGGER.warning(
             "%d lines with a length < 10*resolution were found. "
             "Each of these lines is disaggregate to one point. "
-            "Reaggregatint values will thus likely lead to overestimattion. "
+            "Reaggregating values will thus likely lead to overestimation. "
             "Consider chosing a smaller resolution or filter out the short lines. ",
             failing_res_check_count,
         )


### PR DESCRIPTION
Changes proposed in this PR:
- User-inputted exposures indices are ignored during re-aggregation phase of the `lines_polys_handler` module

This PR fixes #992 

Hi!
As discussed in #992 , I tried to implement a quick fix to avoid erreoneous re-aggregation of disaggregated exposures to their original shape which was caused by non-unique index in the exposures GeoDataFrame. To fix it, I simply replaced the original indices by positional indices in the `csr_mask` used for the `impact_mat` reaggregation in `_aggregate_impact_mat`. This fix seems to do the job for this specific case but I am not entirely sure it works as intended as I was a bit confused about what was going on in the `_aggregate_impact_mat` function. For instance, why did we use the original index values to make the `csr_mask` as anyways the csr matrices work with positional indices to my understanding. Also, @peanutfun, you can let me know if this fix corresponds to the best solution you mentionned in #992 or not.

As a reminder, this is the code that used to create the error (showing up when plotting):

```
from shapely.geometry import Point, LineString, Polygon
import geopandas as gpd
gdf_test = gpd.GeoDataFrame
data = {
    "name": ["A", "B", "C"],
    "value": [10, 20, 30],
    "geometry": [
        Point(4, 51),            
        Point(4, 52),
        Point(4, 53)
    ],
}
gdf_test = gpd.GeoDataFrame(data, crs="EPSG:4326") 
gdf_test.index = [0,1,0] #need to specify non-unique index to cause the error!

#hazard and impf
from climada.util.api_client import Client
import climada.util.lines_polys_handler as u_lp
from climada.entity.impact_funcs import ImpactFuncSet
from climada.entity.impact_funcs.storm_europe import ImpfStormEurope
from climada.entity import Exposures
from climada.engine import ImpactCalc


haz = Client().get_hazard("storm_europe", name="test_haz_WS_nl", status="test_dataset")

#exposures
exp_line = Exposures(gdf_test)

#impact function
impf_line = ImpfStormEurope.from_welker()
impf_set = ImpactFuncSet([impf_line])

exp_line.data["impf_WS"] = 1  # specify impact function

#Break down calc_geom_impact
# disaggregate exposure
exp_pnt = u_lp.exp_geom_to_pnt(
    exp=exp_line,
    res=500,
    to_meters=True,
    disagg_met=u_lp.DisaggMethod.FIX,
    disagg_val=1e5,
)
exp_pnt.assign_centroids(haz)

# compute point impact
calc = ImpactCalc(exp_pnt, impf_set, haz)
impact_pnt = calc.impact(save_mat=True, assign_centroids=False)

# re-aggregate impact to original exposure geometry
impact_agg = u_lp.impact_pnt_agg(impact_pnt, exp_pnt.gdf, u_lp.AggMethod.SUM)

# plot
u_lp.plot_eai_exp_geom(impact_agg);
```


### PR Author Checklist

- [x] Read the [Contribution Guide][contrib]
- [x] Correct target branch selected (if unsure, select `develop`)
- [x] Descriptive pull request title added
- [x] Source branch up-to-date with target branch
- [ ] [Documentation](https://climada-python.readthedocs.io/en/latest/guide/Guide_PythonDos-n-Donts.html#2.--Commenting-&-Documenting) updated
- [ ] [Tests][testing] updated
- [ ] [Tests][testing] passing
- [ ] No new [linter issues][linter]
- [ ] [Changelog](https://github.com/CLIMADA-project/climada_python/blob/develop/CHANGELOG.md) updated

### PR Reviewer Checklist

- [ ] Read the [Contribution Guide][contrib]
- [ ] [CLIMADA Reviewer Checklist](https://climada-python.readthedocs.io/en/latest/guide/Guide_Review.html#reviewer-checklist) passed
- [ ] [Tests][testing] passing
- [ ] No new [linter issues][linter]

[contrib]: https://github.com/CLIMADA-project/climada_python/blob/develop/CONTRIBUTING.md
[testing]: https://climada-python.readthedocs.io/en/latest/guide/Guide_Testing.html
[linter]: https://climada-python.readthedocs.io/en/latest/guide/Guide_continuous_integration_GitHub_actions.html#static-code-analysis
