### PR TITLE
fix wrong url test in climada.util.test.test_files

### DIFF
--- a/climada/util/test/test_files.py
+++ b/climada/util/test/test_files.py
@@ -36,7 +36,7 @@ class TestDownloadUrl(unittest.TestCase):
 
     def test_wrong_url_fail(self):
         """Error raised when wrong url."""
-        url = "https://ngdc.noaa.gov/eog/data/web_data/v4composites/F172012.v4.tar"
+        url = "https://climada.ethz.ch/F172012.v4.tar"
         try:
             with self.assertRaises(ValueError):
                 download_file(url)


### PR DESCRIPTION
Changes proposed in this PR:
- the TestDownloadUrl.test_wrong_url_fail fails because nooa doesn't read the url when in maintenance mode
   So we just replace one non-valid url by another one.

This PR fixes #1004

### PR Author Checklist

- [ ] Read the [Contribution Guide][contrib]
- [ ] Correct target branch selected (if unsure, select `develop`)
- [ ] Descriptive pull request title added
- [ ] Source branch up-to-date with target branch
- [ ] [Documentation](https://climada-python.readthedocs.io/en/latest/guide/Guide_PythonDos-n-Donts.html#2.--Commenting-&-Documenting) updated
- [ ] [Tests][testing] updated
- [ ] [Tests][testing] passing
- [ ] No new [linter issues][linter]
- [ ] [Changelog](https://github.com/CLIMADA-project/climada_python/blob/develop/CHANGELOG.md) updated

### PR Reviewer Checklist

- [ ] Read the [Contribution Guide][contrib]
- [ ] [CLIMADA Reviewer Checklist](https://climada-python.readthedocs.io/en/latest/guide/Guide_Review.html#reviewer-checklist) passed
- [ ] [Tests][testing] passing
- [ ] No new [linter issues][linter]

[contrib]: https://github.com/CLIMADA-project/climada_python/blob/develop/CONTRIBUTING.md
[testing]: https://climada-python.readthedocs.io/en/latest/guide/Guide_Testing.html
[linter]: https://climada-python.readthedocs.io/en/latest/guide/Guide_continuous_integration_GitHub_actions.html#static-code-analysis
