### PR TITLE
fixed bug in bounding_box_from_countries

### DIFF
--- a/climada/util/coordinates.py
+++ b/climada/util/coordinates.py
@@ -1726,7 +1726,7 @@ def bounding_box_from_countries(country_names, buffer=1.0):
     longitudes, latitudes = [], []
     for multipolygon in country_geometry:
         if isinstance(multipolygon, Polygon):  # if entry is polygon
-            for coord in polygon.exterior.coords:  # Extract exterior coordinates
+            for coord in multipolygon.exterior.coords:  # Extract exterior coordinates
                 longitudes.append(coord[0])
                 latitudes.append(coord[1])
         else:  # if entry is multipolygon


### PR DESCRIPTION
Changes proposed in this PR:
- Fixed bug in `util.coordinates.bounding_box_from_countries`, if the country is a polygon and not a multipolygon, e.g., isocode = 'CHE'.


### PR Author Checklist

- [ ] Read the [Contribution Guide][contrib]
- [ ] Correct target branch selected (if unsure, select `develop`)
- [ ] Descriptive pull request title added
- [ ] Source branch up-to-date with target branch
- [ ] [Documentation](https://climada-python.readthedocs.io/en/latest/guide/Guide_PythonDos-n-Donts.html#2.--Commenting-&-Documenting) updated
- [ ] [Tests][testing] updated
- [ ] [Tests][testing] passing
- [ ] No new [linter issues][linter]
- [ ] [Changelog](https://github.com/CLIMADA-project/climada_python/blob/main/CHANGELOG.md) updated

### PR Reviewer Checklist

- [ ] Read the [Contribution Guide][contrib]
- [ ] [CLIMADA Reviewer Checklist](https://climada-python.readthedocs.io/en/latest/guide/Guide_Reviewer_Checklist.html) passed
- [ ] [Tests][testing] passing
- [ ] No new [linter issues][linter]

[contrib]: https://github.com/CLIMADA-project/climada_python/blob/main/CONTRIBUTING.md
[testing]: https://climada-python.readthedocs.io/en/latest/guide/Guide_Continuous_Integration_and_Testing.html
[linter]: https://climada-python.readthedocs.io/en/stable/guide/Guide_Continuous_Integration_and_Testing.html#3.C.--Static-Code-Analysis
