### PR TITLE
Implements equality methods for impf and impfset

### DIFF
--- a/climada/entity/impact_funcs/base.py
+++ b/climada/entity/impact_funcs/base.py
@@ -97,6 +97,20 @@ class ImpactFunc:
         self.mdd = mdd if mdd is not None else np.array([])
         self.paa = paa if paa is not None else np.array([])
 
+    def __eq__(self, value: object, /) -> bool:
+        if isinstance(value, ImpactFunc):
+            return (
+                self.haz_type == value.haz_type
+                and self.id == value.id
+                and self.name == value.name
+                and self.intensity_unit == value.intensity_unit
+                and np.array_equal(self.intensity, value.intensity)
+                and np.array_equal(self.mdd, value.mdd)
+                and np.array_equal(self.paa, value.paa)
+            )
+        else:
+            return False
+
     def calc_mdr(self, inten: Union[float, np.ndarray]) -> np.ndarray:
         """Interpolate impact function to a given intensity.
 
@@ -177,7 +191,7 @@ class ImpactFunc:
         mdd: tuple[float, float] = (0, 1),
         paa: tuple[float, float] = (1, 1),
         impf_id: int = 1,
-        **kwargs
+        **kwargs,
     ):
         """Step function type impact function.
 
@@ -218,7 +232,7 @@ class ImpactFunc:
             intensity=intensity,
             mdd=mdd,
             paa=paa,
-            **kwargs
+            **kwargs,
         )
 
     def set_step_impf(self, *args, **kwargs):
@@ -238,7 +252,7 @@ class ImpactFunc:
         x0: float,
         haz_type: str,
         impf_id: int = 1,
-        **kwargs
+        **kwargs,
     ):
         r"""Sigmoid type impact function hinging on three parameter.
 
@@ -287,7 +301,7 @@ class ImpactFunc:
             intensity=intensity,
             paa=paa,
             mdd=mdd,
-            **kwargs
+            **kwargs,
         )
 
     def set_sigmoid_impf(self, *args, **kwargs):
@@ -308,7 +322,7 @@ class ImpactFunc:
         exponent: float,
         haz_type: str,
         impf_id: int = 1,
-        **kwargs
+        **kwargs,
     ):
         r"""S-shape polynomial impact function hinging on four parameter.
 

--- a/climada/entity/impact_funcs/impact_func_set.py
+++ b/climada/entity/impact_funcs/impact_func_set.py
@@ -109,6 +109,23 @@ class ImpactFuncSet:
             for impf in impact_funcs:
                 self.append(impf)
 
+    def __eq__(self, value: object, /) -> bool:
+        if not isinstance(value, ImpactFuncSet):
+            return False
+
+        if self._data.keys() != value._data.keys():
+            return False
+
+        for haz_type1, id_map1 in self._data.items():
+            id_map2 = value._data[haz_type1]
+            if id_map1.keys() != id_map2.keys():
+                return False
+            for fid, func1 in id_map1.items():
+                if not func1 == id_map2[fid]:
+                    return False
+
+        return True
+
     def clear(self):
         """Reinitialize attributes."""
         self._data = dict()  # {hazard_type : {id:ImpactFunc}}


### PR DESCRIPTION
While working on the Cost Benefit refactoring I need to test the equality between diverse climada objects,
ImpactFuncSet among other. I thought it would be worth to implement the functions as `__eq__` methods.

-------

Changes proposed in this PR:
- Implements an `__eq__` methods (==) for ImpactFunc
- Implements an `__eq__` methods (==) for ImpactFuncSet


### PR Author Checklist

- [x] Read the [Contribution Guide][contrib]
- [x] Correct target branch selected (if unsure, select `develop`)
- [x] Descriptive pull request title added
- [x] Source branch up-to-date with target branch
- [x] [Documentation](https://climada-python.readthedocs.io/en/latest/guide/Guide_PythonDos-n-Donts.html#2.--Commenting-&-Documenting) updated
- [ ] [Tests][testing] updated
- [ ] [Tests][testing] passing
- [ ] No new [linter issues][linter]
- [ ] [Changelog](https://github.com/CLIMADA-project/climada_python/blob/develop/CHANGELOG.md) updated

### PR Reviewer Checklist

- [ ] Read the [Contribution Guide][contrib]
- [ ] [CLIMADA Reviewer Checklist](https://climada-python.readthedocs.io/en/latest/guide/Guide_Review.html#reviewer-checklist) passed
- [ ] [Tests][testing] passing
- [ ] No new [linter issues][linter]

[contrib]: https://github.com/CLIMADA-project/climada_python/blob/develop/CONTRIBUTING.md
[testing]: https://climada-python.readthedocs.io/en/latest/guide/Guide_Testing.html
[linter]: https://climada-python.readthedocs.io/en/latest/guide/Guide_continuous_integration_GitHub_actions.html#static-code-analysis