### PR TITLE
Hotfix: plot NaNs in geo_im_from_array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Code freeze date: YYYY-MM-DD
 ### Changed
 - `Hazard.local_exceedance_intensity`, `Hazard.local_return_period` and `Impact.local_exceedance_impact`, `Impact.local_return_period`, using the `climada.util.interpolation` module: New default (no binning), binning on decimals, and faster implementation [#1012](https://github.com/CLIMADA-project/climada_python/pull/1012)
 ### Fixed
+- NaN plotting issues in `geo_im_from_array`[#1038](https://github.com/CLIMADA-project/climada_python/pull/1038)
 
 ### Deprecated
 

--- a/climada/util/plot.py
+++ b/climada/util/plot.py
@@ -375,6 +375,11 @@ def geo_im_from_array(
     -------
     cartopy.mpl.geoaxes.GeoAxesSubplot
 
+    Notes
+    -----
+    Data points with NaN or inf are plotted in gray. White regions correspond to
+    regions outside the convex hull of the given coordinates.
+
     Raises
     ------
     ValueError
@@ -472,7 +477,7 @@ def geo_im_from_array(
         )
         # handle NaNs in griddata
         color_nan = "gainsboro"
-        if np.any(np.isnan(grid_im)):
+        if np.any(np.isnan(x) for x in grid_im):
             no_data_patch = mpatches.Patch(
                 facecolor=color_nan, edgecolor="black", label="NaN"
             )

--- a/climada/util/plot.py
+++ b/climada/util/plot.py
@@ -473,7 +473,9 @@ def geo_im_from_array(
         # handle NaNs in griddata
         color_nan = "gainsboro"
         if np.any(np.isnan(grid_im)):
-            no_data_patch = mpatches.Patch(color=color_nan, label="NaN")
+            no_data_patch = mpatches.Patch(
+                facecolor=color_nan, edgecolor="black", label="NaN"
+            )
             axis.legend(
                 handles=[no_data_patch] + axis.get_legend_handles_labels()[0],
                 loc="lower right",

--- a/climada/util/plot.py
+++ b/climada/util/plot.py
@@ -37,6 +37,7 @@ from textwrap import wrap
 import cartopy.crs as ccrs
 import geopandas as gpd
 import matplotlib as mpl
+import matplotlib.patches as mpatches
 import matplotlib.pyplot as plt
 import numpy as np
 import requests
@@ -420,8 +421,7 @@ def geo_im_from_array(
 
     # prepare colormap
     cmap = plt.get_cmap(kwargs.pop("cmap", CMAP_RASTER))
-    cmap.set_bad("gainsboro")  # For NaNs and infs
-    cmap.set_under("white", alpha=0)  # For values below vmin
+    cmap.set_under("white")  # For values below vmin
 
     # Generate each subplot
     for array_im, axis, tit, name in zip(
@@ -470,6 +470,15 @@ def geo_im_from_array(
             cmap=cmap,
             **kwargs,
         )
+        # handle NaNs in griddata
+        color_nan = "gainsboro"
+        if np.any(np.isnan(grid_im)):
+            no_data_patch = mpatches.Patch(color=color_nan, label="NaN")
+            axis.legend(
+                handles=[no_data_patch] + axis.get_legend_handles_labels()[0],
+                loc="lower right",
+            )
+        axis.set_facecolor(color_nan)
         cbar = plt.colorbar(img, cax=cbax, orientation="vertical")
         cbar.set_label(name)
         axis.set_title("\n".join(wrap(tit)))


### PR DESCRIPTION
Context:
In PR #929, we introduced that in `util.plot.geo_im_from_array`, locations with NaN are plotted in gray and locations without a centroid (more precisely, outside the convex hull of the given centroids) are plotted in white. This created problems with `matplotlib.pyplot.pcolormesh`, which, for some proj inputs, created NaNs inside the given data that covered the values that should be plotted.

Changes proposed in this PR:
- The background color of the plot is now gray (NaN color), using axis.set_facecolor, and values without centroid (ie outside convex hull) are plotted in white with cmap.set_under. Like this, locations with only NaNs are plotted in gray, and locations with NaNs and a valid value are plotted with the valid value. Before, NaNs were plotted in gray using cmap.set_bad, and values without centroid were plotted in white with cmap.set_under 
- If there are NaNs in the plotted data, a legend is added to the plot saying that gray means NaN. 

Notes:
- the function `util.plot.geo_im_from_array` is used in
`util.plot.plot_from_gdf`, which is used in `hazard.plot_rp_intensity` and `impact.plot_rp_imp`, and in
`hazard.plot.HazardPlot._event_plot`, which is used in `hazard.plot_intensity` and `hazard.plot_fraction`.

This PR fixes #1028

Example:
````
import numpy as np
from climada.hazard import Hazard
from climada.util import HAZ_DEMO_H5 # CLIMADA's Python file
haz_tc_fl = Hazard.from_hdf5(HAZ_DEMO_H5) # Historic tropical cyclones in Florida from 1990 to 2004
haz_tc_fl.check() # Use always the check() method to see if the hazard has been loaded correctly

centroids_mask = np.array(
[ (i + j > 10) for j in range(50) for i in range(50)]
)
haz_tc_fl.centroids = haz_tc_fl.centroids.select(sel_cen=centroids_mask)
haz_tc_fl.intensity = haz_tc_fl.intensity[:, -2434:]

return_periods, label, column_label = haz_tc_fl.local_return_period([30, 40])

from climada.util.plot import plot_from_gdf
plot_from_gdf(return_periods, colorbar_name=label, title_subplots=column_label)
````
![plot_nan](https://github.com/user-attachments/assets/97c6cbca-7c72-4eda-96b3-3e7a55a92551)


### PR Author Checklist

- [x] Read the [Contribution Guide][contrib]
- [x] Correct target branch selected (if unsure, select `develop`)
- [x] Descriptive pull request title added
- [x] Source branch up-to-date with target branch
- [x] [Documentation](https://climada-python.readthedocs.io/en/latest/guide/Guide_PythonDos-n-Donts.html#2.--Commenting-&-Documenting) updated
- [x] [Tests][testing] updated
- [ ] [Tests][testing] passing
- [x] No new [linter issues][linter]
- [ ] [Changelog](https://github.com/CLIMADA-project/climada_python/blob/main/CHANGELOG.md) updated

### PR Reviewer Checklist

- [ ] Read the [Contribution Guide][contrib]
- [ ] [CLIMADA Reviewer Checklist](https://climada-python.readthedocs.io/en/latest/guide/Guide_Reviewer_Checklist.html) passed
- [ ] [Tests][testing] passing
- [ ] No new [linter issues][linter]

[contrib]: https://github.com/CLIMADA-project/climada_python/blob/main/CONTRIBUTING.md
[testing]: https://climada-python.readthedocs.io/en/latest/guide/Guide_Continuous_Integration_and_Testing.html
[linter]: https://climada-python.readthedocs.io/en/stable/guide/Guide_Continuous_Integration_and_Testing.html#3.C.--Static-Code-Analysis
