### PR TITLE
Add option in raster plot to crop around centroids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ Removed:
 - `pandas-datareader`
 
 ### Added
+- Added optional parameter to `geo_im_from_array`, `plot_from_gdf`, `plot_rp_imp`, `plot_rp_intensity`,
+`plot_intensity`, `plot_fraction`, `_event_plot` to mask plotting when regions are too far from data points [#1047](https://github.com/CLIMADA-project/climada_python/pull/1047).
 - Added instructions to install Climada petals on Euler cluster in `doc.guide.Guide_Euler.ipynb` [#1029](https://github.com/CLIMADA-project/climada_python/pull/1029)
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Removed:
 
 ### Added
 - Added optional parameter to `geo_im_from_array`, `plot_from_gdf`, `plot_rp_imp`, `plot_rp_intensity`,
-`plot_intensity`, `plot_fraction`, `_event_plot` to mask plotting when regions are too far from data points [#1047](https://github.com/CLIMADA-project/climada_python/pull/1047).
+`plot_intensity`, `plot_fraction`, `_event_plot` to mask plotting when regions are too far from data points [#1047](https://github.com/CLIMADA-project/climada_python/pull/1047). To recreate previous plots (no masking), the parameter can be set to None.
 - Added instructions to install Climada petals on Euler cluster in `doc.guide.Guide_Euler.ipynb` [#1029](https://github.com/CLIMADA-project/climada_python/pull/1029)
 
 ### Changed

--- a/climada/engine/impact.py
+++ b/climada/engine/impact.py
@@ -1178,6 +1178,7 @@ class Impact:
         return_periods=(25, 50, 100, 250),
         log10_scale=True,
         axis=None,
+        mask_rel_distance=None,
         kwargs_local_exceedance_impact=None,
         **kwargs,
     ):
@@ -1242,7 +1243,12 @@ class Impact:
             )
 
         axis = u_plot.plot_from_gdf(
-            impacts_stats, title, column_labels, axis=axis, **kwargs
+            impacts_stats,
+            title,
+            column_labels,
+            axis=axis,
+            mask_rel_distance=mask_rel_distance,
+            **kwargs,
         )
         return axis, impacts_stats_vals
 

--- a/climada/engine/impact.py
+++ b/climada/engine/impact.py
@@ -1195,6 +1195,11 @@ class Impact:
             plot impact as log10(impact). Default: True
         smooth : bool, optional
             smooth plot to plot.RESOLUTIONxplot.RESOLUTION. Default: True
+        mask_rel_distance: float, optional
+            Relative distance (with respect to maximal map extent in longitude or latitude) to data
+            points above which plot should not display values. For instance, to only plot values
+            at the centroids, use mask_rel_distance=0.01. If None, the plot is not masked.
+            Default is None.
         kwargs_local_exceedance_impact: dict
             Dictionary of keyword arguments for the method impact.local_exceedance_impact.
         kwargs : dict, optional

--- a/climada/engine/impact.py
+++ b/climada/engine/impact.py
@@ -1178,7 +1178,7 @@ class Impact:
         return_periods=(25, 50, 100, 250),
         log10_scale=True,
         axis=None,
-        mask_rel_distance=None,
+        mask_relative_distance=None,
         kwargs_local_exceedance_impact=None,
         **kwargs,
     ):
@@ -1195,10 +1195,10 @@ class Impact:
             plot impact as log10(impact). Default: True
         smooth : bool, optional
             smooth plot to plot.RESOLUTIONxplot.RESOLUTION. Default: True
-        mask_rel_distance: float, optional
+        mask_relative_distance: float, optional
             Relative distance (with respect to maximal map extent in longitude or latitude) to data
             points above which plot should not display values. For instance, to only plot values
-            at the centroids, use mask_rel_distance=0.01. If None, the plot is not masked.
+            at the centroids, use mask_relative_distance=0.01. If None, the plot is not masked.
             Default is None.
         kwargs_local_exceedance_impact: dict
             Dictionary of keyword arguments for the method impact.local_exceedance_impact.
@@ -1252,7 +1252,7 @@ class Impact:
             title,
             column_labels,
             axis=axis,
-            mask_rel_distance=mask_rel_distance,
+            mask_relative_distance=mask_relative_distance,
             **kwargs,
         )
         return axis, impacts_stats_vals

--- a/climada/engine/impact.py
+++ b/climada/engine/impact.py
@@ -1178,7 +1178,7 @@ class Impact:
         return_periods=(25, 50, 100, 250),
         log10_scale=True,
         axis=None,
-        mask_relative_distance=None,
+        mask_distance=None,
         kwargs_local_exceedance_impact=None,
         **kwargs,
     ):
@@ -1195,10 +1195,10 @@ class Impact:
             plot impact as log10(impact). Default: True
         smooth : bool, optional
             smooth plot to plot.RESOLUTIONxplot.RESOLUTION. Default: True
-        mask_relative_distance: float, optional
-            Relative distance (with respect to maximal map extent in longitude or latitude) to data
-            points above which plot should not display values. For instance, to only plot values
-            at the centroids, use mask_relative_distance=0.01. If None, the plot is not masked.
+        mask_distance: float, optional
+            Only regions are plotted that are closer to any of the data points than this distance,
+            relative to overall plot size. For instance, to only plot values
+            at the centroids, use mask_distance=0.01. If None, the plot is not masked.
             Default is None.
         kwargs_local_exceedance_impact: dict
             Dictionary of keyword arguments for the method impact.local_exceedance_impact.
@@ -1252,7 +1252,7 @@ class Impact:
             title,
             column_labels,
             axis=axis,
-            mask_relative_distance=mask_relative_distance,
+            mask_distance=mask_distance,
             **kwargs,
         )
         return axis, impacts_stats_vals

--- a/climada/engine/impact.py
+++ b/climada/engine/impact.py
@@ -1178,7 +1178,7 @@ class Impact:
         return_periods=(25, 50, 100, 250),
         log10_scale=True,
         axis=None,
-        mask_distance=None,
+        mask_distance=0.01,
         kwargs_local_exceedance_impact=None,
         **kwargs,
     ):
@@ -1199,7 +1199,7 @@ class Impact:
             Only regions are plotted that are closer to any of the data points than this distance,
             relative to overall plot size. For instance, to only plot values
             at the centroids, use mask_distance=0.01. If None, the plot is not masked.
-            Default is None.
+            Default is 0.01.
         kwargs_local_exceedance_impact: dict
             Dictionary of keyword arguments for the method impact.local_exceedance_impact.
         kwargs : dict, optional

--- a/climada/hazard/plot.py
+++ b/climada/hazard/plot.py
@@ -40,7 +40,7 @@ class HazardPlot:
         self,
         return_periods=(25, 50, 100, 250),
         axis=None,
-        mask_rel_distance=None,
+        mask_relative_distance=None,
         kwargs_local_exceedance_intensity=None,
         **kwargs,
     ):
@@ -57,10 +57,10 @@ class HazardPlot:
             axis to use
         kwargs_local_exceedance_intensity: dict
             Dictionary of keyword arguments for the method hazard.local_exceedance_intensity.
-        mask_rel_distance: float, optional
+        mask_relative_distance: float, optional
             Relative distance (with respect to maximal map extent in longitude or latitude) to data
             points above which plot should not display values. For instance, to only plot values
-            at the centroids, use mask_rel_distance=0.01. If None, the plot is not masked.
+            at the centroids, use mask_relative_distance=0.01. If None, the plot is not masked.
             Default is None.
         kwargs: optional
             arguments for pcolormesh matplotlib function used in event plots
@@ -99,7 +99,7 @@ class HazardPlot:
             title,
             column_labels,
             axis=axis,
-            mask_rel_distance=mask_rel_distance,
+            mask_relative_distance=mask_relative_distance,
             **kwargs,
         )
         return axis, inten_stats.values[:, 1:].T.astype(float)
@@ -111,7 +111,7 @@ class HazardPlot:
         smooth=True,
         axis=None,
         adapt_fontsize=True,
-        mask_rel_distance=None,
+        mask_relative_distance=None,
         **kwargs,
     ):
         """Plot intensity values for a selected event or centroid.
@@ -135,10 +135,10 @@ class HazardPlot:
             in module `climada.util.plot`)
         axis: matplotlib.axes._subplots.AxesSubplot, optional
             axis to use
-        mask_rel_distance: float, optional
+        mask_relative_distance: float, optional
             Relative distance (with respect to maximal map extent in longitude or latitude) to data
             points above which plot should not display values. For instance, to only plot values
-            at the centroids, use mask_rel_distance=0.01. If None, the plot is not masked.
+            at the centroids, use mask_relative_distance=0.01. If None, the plot is not masked.
             Default is None.
         kwargs: optional
             arguments for pcolormesh matplotlib function
@@ -165,7 +165,7 @@ class HazardPlot:
                 crs_epsg,
                 axis,
                 adapt_fontsize=adapt_fontsize,
-                mask_rel_distance=mask_rel_distance,
+                mask_relative_distance=mask_relative_distance,
                 **kwargs,
             )
         if centr is not None:
@@ -181,7 +181,7 @@ class HazardPlot:
         centr=None,
         smooth=True,
         axis=None,
-        mask_rel_distance=None,
+        mask_relative_distance=None,
         **kwargs,
     ):
         """Plot fraction values for a selected event or centroid.
@@ -205,10 +205,10 @@ class HazardPlot:
             in module `climada.util.plot`)
         axis: matplotlib.axes._subplots.AxesSubplot, optional
             axis to use
-        mask_rel_distance: float, optional
+        mask_relative_distance: float, optional
             Relative distance (with respect to maximal map extent in longitude or latitude) to data
             points above which plot should not display values. For instance, to only plot values
-            at the centroids, use mask_rel_distance=0.01. If None, the plot is not masked.
+            at the centroids, use mask_relative_distance=0.01. If None, the plot is not masked.
             Default is None.
         kwargs: optional
             arguments for pcolormesh matplotlib function
@@ -232,7 +232,7 @@ class HazardPlot:
                 col_label,
                 smooth,
                 axis,
-                mask_rel_distance=mask_rel_distance,
+                mask_relative_distance=mask_relative_distance,
                 **kwargs,
             )
         if centr is not None:
@@ -252,7 +252,7 @@ class HazardPlot:
         axis=None,
         figsize=(9, 13),
         adapt_fontsize=True,
-        mask_rel_distance=None,
+        mask_relative_distance=None,
         **kwargs,
     ):
         """Plot an event of the input matrix.
@@ -274,10 +274,10 @@ class HazardPlot:
             axis to use
         figsize: tuple, optional
             figure size for plt.subplots
-        mask_rel_distance: float, optional
+        mask_relative_distance: float, optional
             Relative distance (with respect to maximal map extent in longitude or latitude) to data
             points above which plot should not display values. For instance, to only plot values
-            at the centroids, use mask_rel_distance=0.01. If None, the plot is not masked.
+            at the centroids, use mask_relative_distance=0.01. If None, the plot is not masked.
             Default is None.
         kwargs: optional
             arguments for pcolormesh matplotlib function
@@ -326,7 +326,7 @@ class HazardPlot:
             figsize=figsize,
             proj=crs_espg,
             adapt_fontsize=adapt_fontsize,
-            mask_rel_distance=mask_rel_distance,
+            mask_relative_distance=mask_relative_distance,
             **kwargs,
         )
 

--- a/climada/hazard/plot.py
+++ b/climada/hazard/plot.py
@@ -57,6 +57,11 @@ class HazardPlot:
             axis to use
         kwargs_local_exceedance_intensity: dict
             Dictionary of keyword arguments for the method hazard.local_exceedance_intensity.
+        mask_rel_distance: float, optional
+            Relative distance (with respect to maximal map extent in longitude or latitude) to data
+            points above which plot should not display values. For instance, to only plot values
+            at the centroids, use mask_rel_distance=0.01. If None, the plot is not masked.
+            Default is None.
         kwargs: optional
             arguments for pcolormesh matplotlib function used in event plots
 
@@ -130,6 +135,11 @@ class HazardPlot:
             in module `climada.util.plot`)
         axis: matplotlib.axes._subplots.AxesSubplot, optional
             axis to use
+        mask_rel_distance: float, optional
+            Relative distance (with respect to maximal map extent in longitude or latitude) to data
+            points above which plot should not display values. For instance, to only plot values
+            at the centroids, use mask_rel_distance=0.01. If None, the plot is not masked.
+            Default is None.
         kwargs: optional
             arguments for pcolormesh matplotlib function
             used in event plots or for plot function used in centroids plots
@@ -165,7 +175,15 @@ class HazardPlot:
 
         raise ValueError("Provide one event id or one centroid id.")
 
-    def plot_fraction(self, event=None, centr=None, smooth=True, axis=None, **kwargs):
+    def plot_fraction(
+        self,
+        event=None,
+        centr=None,
+        smooth=True,
+        axis=None,
+        mask_rel_distance=None,
+        **kwargs,
+    ):
         """Plot fraction values for a selected event or centroid.
 
         Parameters
@@ -187,6 +205,11 @@ class HazardPlot:
             in module `climada.util.plot`)
         axis: matplotlib.axes._subplots.AxesSubplot, optional
             axis to use
+        mask_rel_distance: float, optional
+            Relative distance (with respect to maximal map extent in longitude or latitude) to data
+            points above which plot should not display values. For instance, to only plot values
+            at the centroids, use mask_rel_distance=0.01. If None, the plot is not masked.
+            Default is None.
         kwargs: optional
             arguments for pcolormesh matplotlib function
             used in event plots or for plot function used in centroids plots
@@ -204,7 +227,13 @@ class HazardPlot:
             if isinstance(event, str):
                 event = self.get_event_id(event)
             return self._event_plot(
-                event, self.fraction, col_label, smooth, axis, **kwargs
+                event,
+                self.fraction,
+                col_label,
+                smooth,
+                axis,
+                mask_rel_distance=mask_rel_distance,
+                **kwargs,
             )
         if centr is not None:
             if isinstance(centr, tuple):
@@ -245,6 +274,11 @@ class HazardPlot:
             axis to use
         figsize: tuple, optional
             figure size for plt.subplots
+        mask_rel_distance: float, optional
+            Relative distance (with respect to maximal map extent in longitude or latitude) to data
+            points above which plot should not display values. For instance, to only plot values
+            at the centroids, use mask_rel_distance=0.01. If None, the plot is not masked.
+            Default is None.
         kwargs: optional
             arguments for pcolormesh matplotlib function
 

--- a/climada/hazard/plot.py
+++ b/climada/hazard/plot.py
@@ -40,7 +40,7 @@ class HazardPlot:
         self,
         return_periods=(25, 50, 100, 250),
         axis=None,
-        mask_relative_distance=None,
+        mask_distance=None,
         kwargs_local_exceedance_intensity=None,
         **kwargs,
     ):
@@ -57,10 +57,10 @@ class HazardPlot:
             axis to use
         kwargs_local_exceedance_intensity: dict
             Dictionary of keyword arguments for the method hazard.local_exceedance_intensity.
-        mask_relative_distance: float, optional
-            Relative distance (with respect to maximal map extent in longitude or latitude) to data
-            points above which plot should not display values. For instance, to only plot values
-            at the centroids, use mask_relative_distance=0.01. If None, the plot is not masked.
+        mask_distance: float, optional
+            Only regions are plotted that are closer to any of the data points than this distance,
+            relative to overall plot size. For instance, to only plot values
+            at the centroids, use mask_distance=0.01. If None, the plot is not masked.
             Default is None.
         kwargs: optional
             arguments for pcolormesh matplotlib function used in event plots
@@ -99,7 +99,7 @@ class HazardPlot:
             title,
             column_labels,
             axis=axis,
-            mask_relative_distance=mask_relative_distance,
+            mask_distance=mask_distance,
             **kwargs,
         )
         return axis, inten_stats.values[:, 1:].T.astype(float)
@@ -111,7 +111,7 @@ class HazardPlot:
         smooth=True,
         axis=None,
         adapt_fontsize=True,
-        mask_relative_distance=None,
+        mask_distance=None,
         **kwargs,
     ):
         """Plot intensity values for a selected event or centroid.
@@ -135,10 +135,10 @@ class HazardPlot:
             in module `climada.util.plot`)
         axis: matplotlib.axes._subplots.AxesSubplot, optional
             axis to use
-        mask_relative_distance: float, optional
-            Relative distance (with respect to maximal map extent in longitude or latitude) to data
-            points above which plot should not display values. For instance, to only plot values
-            at the centroids, use mask_relative_distance=0.01. If None, the plot is not masked.
+        mask_distance: float, optional
+            Only regions are plotted that are closer to any of the data points than this distance,
+            relative to overall plot size. For instance, to only plot values
+            at the centroids, use mask_distance=0.01. If None, the plot is not masked.
             Default is None.
         kwargs: optional
             arguments for pcolormesh matplotlib function
@@ -165,7 +165,7 @@ class HazardPlot:
                 crs_epsg,
                 axis,
                 adapt_fontsize=adapt_fontsize,
-                mask_relative_distance=mask_relative_distance,
+                mask_distance=mask_distance,
                 **kwargs,
             )
         if centr is not None:
@@ -181,7 +181,7 @@ class HazardPlot:
         centr=None,
         smooth=True,
         axis=None,
-        mask_relative_distance=None,
+        mask_distance=None,
         **kwargs,
     ):
         """Plot fraction values for a selected event or centroid.
@@ -205,10 +205,10 @@ class HazardPlot:
             in module `climada.util.plot`)
         axis: matplotlib.axes._subplots.AxesSubplot, optional
             axis to use
-        mask_relative_distance: float, optional
+        mask_distance: float, optional
             Relative distance (with respect to maximal map extent in longitude or latitude) to data
             points above which plot should not display values. For instance, to only plot values
-            at the centroids, use mask_relative_distance=0.01. If None, the plot is not masked.
+            at the centroids, use mask_distance=0.01. If None, the plot is not masked.
             Default is None.
         kwargs: optional
             arguments for pcolormesh matplotlib function
@@ -232,7 +232,7 @@ class HazardPlot:
                 col_label,
                 smooth,
                 axis,
-                mask_relative_distance=mask_relative_distance,
+                mask_distance=mask_distance,
                 **kwargs,
             )
         if centr is not None:
@@ -252,7 +252,7 @@ class HazardPlot:
         axis=None,
         figsize=(9, 13),
         adapt_fontsize=True,
-        mask_relative_distance=None,
+        mask_distance=None,
         **kwargs,
     ):
         """Plot an event of the input matrix.
@@ -274,10 +274,10 @@ class HazardPlot:
             axis to use
         figsize: tuple, optional
             figure size for plt.subplots
-        mask_relative_distance: float, optional
-            Relative distance (with respect to maximal map extent in longitude or latitude) to data
-            points above which plot should not display values. For instance, to only plot values
-            at the centroids, use mask_relative_distance=0.01. If None, the plot is not masked.
+        mask_distance: float, optional
+            Only regions are plotted that are closer to any of the data points than this distance,
+            relative to overall plot size. For instance, to only plot values
+            at the centroids, use mask_distance=0.01. If None, the plot is not masked.
             Default is None.
         kwargs: optional
             arguments for pcolormesh matplotlib function
@@ -326,7 +326,7 @@ class HazardPlot:
             figsize=figsize,
             proj=crs_espg,
             adapt_fontsize=adapt_fontsize,
-            mask_relative_distance=mask_relative_distance,
+            mask_distance=mask_distance,
             **kwargs,
         )
 

--- a/climada/hazard/plot.py
+++ b/climada/hazard/plot.py
@@ -40,7 +40,7 @@ class HazardPlot:
         self,
         return_periods=(25, 50, 100, 250),
         axis=None,
-        mask_distance=None,
+        mask_distance=0.01,
         kwargs_local_exceedance_intensity=None,
         **kwargs,
     ):
@@ -61,7 +61,7 @@ class HazardPlot:
             Only regions are plotted that are closer to any of the data points than this distance,
             relative to overall plot size. For instance, to only plot values
             at the centroids, use mask_distance=0.01. If None, the plot is not masked.
-            Default is None.
+            Default is 0.01.
         kwargs: optional
             arguments for pcolormesh matplotlib function used in event plots
 
@@ -111,7 +111,7 @@ class HazardPlot:
         smooth=True,
         axis=None,
         adapt_fontsize=True,
-        mask_distance=None,
+        mask_distance=0.01,
         **kwargs,
     ):
         """Plot intensity values for a selected event or centroid.
@@ -139,7 +139,7 @@ class HazardPlot:
             Only regions are plotted that are closer to any of the data points than this distance,
             relative to overall plot size. For instance, to only plot values
             at the centroids, use mask_distance=0.01. If None, the plot is not masked.
-            Default is None.
+            Default is 0.01.
         kwargs: optional
             arguments for pcolormesh matplotlib function
             used in event plots or for plot function used in centroids plots
@@ -181,7 +181,7 @@ class HazardPlot:
         centr=None,
         smooth=True,
         axis=None,
-        mask_distance=None,
+        mask_distance=0.01,
         **kwargs,
     ):
         """Plot fraction values for a selected event or centroid.
@@ -252,7 +252,7 @@ class HazardPlot:
         axis=None,
         figsize=(9, 13),
         adapt_fontsize=True,
-        mask_distance=None,
+        mask_distance=0.01,
         **kwargs,
     ):
         """Plot an event of the input matrix.

--- a/climada/hazard/plot.py
+++ b/climada/hazard/plot.py
@@ -40,6 +40,7 @@ class HazardPlot:
         self,
         return_periods=(25, 50, 100, 250),
         axis=None,
+        mask_rel_distance=None,
         kwargs_local_exceedance_intensity=None,
         **kwargs,
     ):
@@ -89,7 +90,12 @@ class HazardPlot:
         )
 
         axis = u_plot.plot_from_gdf(
-            inten_stats, title, column_labels, axis=axis, **kwargs
+            inten_stats,
+            title,
+            column_labels,
+            axis=axis,
+            mask_rel_distance=mask_rel_distance,
+            **kwargs,
         )
         return axis, inten_stats.values[:, 1:].T.astype(float)
 
@@ -100,6 +106,7 @@ class HazardPlot:
         smooth=True,
         axis=None,
         adapt_fontsize=True,
+        mask_rel_distance=None,
         **kwargs,
     ):
         """Plot intensity values for a selected event or centroid.
@@ -148,6 +155,7 @@ class HazardPlot:
                 crs_epsg,
                 axis,
                 adapt_fontsize=adapt_fontsize,
+                mask_rel_distance=mask_rel_distance,
                 **kwargs,
             )
         if centr is not None:
@@ -215,6 +223,7 @@ class HazardPlot:
         axis=None,
         figsize=(9, 13),
         adapt_fontsize=True,
+        mask_rel_distance=None,
         **kwargs,
     ):
         """Plot an event of the input matrix.
@@ -283,6 +292,7 @@ class HazardPlot:
             figsize=figsize,
             proj=crs_espg,
             adapt_fontsize=adapt_fontsize,
+            mask_rel_distance=mask_rel_distance,
             **kwargs,
         )
 

--- a/climada/util/plot.py
+++ b/climada/util/plot.py
@@ -338,7 +338,7 @@ def geo_im_from_array(
     axes=None,
     figsize=(9, 13),
     adapt_fontsize=True,
-    mask_distance=None,
+    mask_distance=0.01,
     **kwargs,
 ):
     """Image(s) plot defined in array(s) over input coordinates.
@@ -374,7 +374,7 @@ def geo_im_from_array(
         Only regions are plotted that are closer to any of the data points than this distance,
         relative to overall plot size. For instance, to only plot values
         at the centroids, use mask_distance=0.01. If None, the plot is not masked.
-        Default is None.
+        Default is 0.01.
     **kwargs
         arbitrary keyword arguments for pcolormesh matplotlib function
 
@@ -1104,7 +1104,7 @@ def plot_from_gdf(
     axis=None,
     figsize=(9, 13),
     adapt_fontsize=True,
-    mask_distance=None,
+    mask_distance=0.01,
     **kwargs,
 ):
     """Plot several subplots from different columns of a GeoDataFrame, e.g., for
@@ -1131,7 +1131,7 @@ def plot_from_gdf(
         Relative distance (with respect to maximal map extent in longitude or latitude) to data
         points above which plot should not display values. For instance, to only plot values
         at the centroids, use mask_distance=0.01. If None, the plot is not masked.
-        Default is None.
+        Default is 0.01.
     kwargs: optional
         Arguments for pcolormesh matplotlib function used in event plots.
 

--- a/climada/util/plot.py
+++ b/climada/util/plot.py
@@ -338,7 +338,7 @@ def geo_im_from_array(
     axes=None,
     figsize=(9, 13),
     adapt_fontsize=True,
-    mask_relative_distance=None,
+    mask_distance=None,
     **kwargs,
 ):
     """Image(s) plot defined in array(s) over input coordinates.
@@ -370,10 +370,10 @@ def geo_im_from_array(
     adapt_fontsize : bool, optional
         If set to true, the size of the fonts will be adapted to the size of the figure. Otherwise
         the default matplotlib font size is used. Default is True.
-    mask_relative_distance: float, optional
-        Relative distance (with respect to maximal map extent in longitude or latitude) to data
-        points above which plot should not display values. For instance, to only plot values
-        at the centroids, use mask_relative_distance=0.01. If None, the plot is not masked.
+    mask_distance: float, optional
+        Only regions are plotted that are closer to any of the data points than this distance,
+        relative to overall plot size. For instance, to only plot values
+        at the centroids, use mask_distance=0.01. If None, the plot is not masked.
         Default is None.
     **kwargs
         arbitrary keyword arguments for pcolormesh matplotlib function
@@ -456,15 +456,14 @@ def geo_im_from_array(
                 fill_value=min_value,
             )
             # Compute distance of each grid point to the nearest known point
-            if mask_relative_distance is not None:
+            if mask_distance is not None:
                 tree = cKDTree(np.array((coord[:, 1], coord[:, 0])).T)
                 distances, _ = tree.query(
                     np.c_[grid_x.ravel(), grid_y.ravel()],
                     p=2,  # for plotting squares and not sphere around centroids use p=np.inf
                 )
                 threshold = (
-                    max(extent[1] - extent[0], extent[3] - extent[2])
-                    * mask_relative_distance
+                    max(extent[1] - extent[0], extent[3] - extent[2]) * mask_distance
                 )
                 grid_im[(distances.reshape(grid_im.shape) > threshold)] = min_value
         else:
@@ -1105,7 +1104,7 @@ def plot_from_gdf(
     axis=None,
     figsize=(9, 13),
     adapt_fontsize=True,
-    mask_relative_distance=None,
+    mask_distance=None,
     **kwargs,
 ):
     """Plot several subplots from different columns of a GeoDataFrame, e.g., for
@@ -1128,10 +1127,10 @@ def plot_from_gdf(
     adapt_fontsize: bool, optional
         If set to true, the size of the fonts will be adapted to the size of the figure.
         Otherwise the default matplotlib font size is used. Default is True.
-    mask_relative_distance: float, optional
+    mask_distance: float, optional
         Relative distance (with respect to maximal map extent in longitude or latitude) to data
         points above which plot should not display values. For instance, to only plot values
-        at the centroids, use mask_relative_distance=0.01. If None, the plot is not masked.
+        at the centroids, use mask_distance=0.01. If None, the plot is not masked.
         Default is None.
     kwargs: optional
         Arguments for pcolormesh matplotlib function used in event plots.
@@ -1193,7 +1192,7 @@ def plot_from_gdf(
         axes=axis,
         figsize=figsize,
         adapt_fontsize=adapt_fontsize,
-        mask_relative_distance=mask_relative_distance,
+        mask_distance=mask_distance,
         **kwargs,
     )
 

--- a/climada/util/plot.py
+++ b/climada/util/plot.py
@@ -370,6 +370,11 @@ def geo_im_from_array(
     adapt_fontsize : bool, optional
         If set to true, the size of the fonts will be adapted to the size of the figure. Otherwise
         the default matplotlib font size is used. Default is True.
+    mask_rel_distance: float, optional
+        Relative distance (with respect to maximal map extent in longitude or latitude) to data
+        points above which plot should not display values. For instance, to only plot values
+        at the centroids, use mask_rel_distance=0.01. If None, the plot is not masked.
+        Default is None.
     **kwargs
         arbitrary keyword arguments for pcolormesh matplotlib function
 
@@ -1123,6 +1128,11 @@ def plot_from_gdf(
     adapt_fontsize: bool, optional
         If set to true, the size of the fonts will be adapted to the size of the figure.
         Otherwise the default matplotlib font size is used. Default is True.
+    mask_rel_distance: float, optional
+        Relative distance (with respect to maximal map extent in longitude or latitude) to data
+        points above which plot should not display values. For instance, to only plot values
+        at the centroids, use mask_rel_distance=0.01. If None, the plot is not masked.
+        Default is None.
     kwargs: optional
         Arguments for pcolormesh matplotlib function used in event plots.
 

--- a/climada/util/plot.py
+++ b/climada/util/plot.py
@@ -338,7 +338,7 @@ def geo_im_from_array(
     axes=None,
     figsize=(9, 13),
     adapt_fontsize=True,
-    mask_rel_distance=None,
+    mask_relative_distance=None,
     **kwargs,
 ):
     """Image(s) plot defined in array(s) over input coordinates.
@@ -370,10 +370,10 @@ def geo_im_from_array(
     adapt_fontsize : bool, optional
         If set to true, the size of the fonts will be adapted to the size of the figure. Otherwise
         the default matplotlib font size is used. Default is True.
-    mask_rel_distance: float, optional
+    mask_relative_distance: float, optional
         Relative distance (with respect to maximal map extent in longitude or latitude) to data
         points above which plot should not display values. For instance, to only plot values
-        at the centroids, use mask_rel_distance=0.01. If None, the plot is not masked.
+        at the centroids, use mask_relative_distance=0.01. If None, the plot is not masked.
         Default is None.
     **kwargs
         arbitrary keyword arguments for pcolormesh matplotlib function
@@ -456,7 +456,7 @@ def geo_im_from_array(
                 fill_value=min_value,
             )
             # Compute distance of each grid point to the nearest known point
-            if mask_rel_distance is not None:
+            if mask_relative_distance is not None:
                 tree = cKDTree(np.array((coord[:, 1], coord[:, 0])).T)
                 distances, _ = tree.query(
                     np.c_[grid_x.ravel(), grid_y.ravel()],
@@ -464,7 +464,7 @@ def geo_im_from_array(
                 )
                 threshold = (
                     max(extent[1] - extent[0], extent[3] - extent[2])
-                    * mask_rel_distance
+                    * mask_relative_distance
                 )
                 grid_im[(distances.reshape(grid_im.shape) > threshold)] = min_value
         else:
@@ -1105,7 +1105,7 @@ def plot_from_gdf(
     axis=None,
     figsize=(9, 13),
     adapt_fontsize=True,
-    mask_rel_distance=None,
+    mask_relative_distance=None,
     **kwargs,
 ):
     """Plot several subplots from different columns of a GeoDataFrame, e.g., for
@@ -1128,10 +1128,10 @@ def plot_from_gdf(
     adapt_fontsize: bool, optional
         If set to true, the size of the fonts will be adapted to the size of the figure.
         Otherwise the default matplotlib font size is used. Default is True.
-    mask_rel_distance: float, optional
+    mask_relative_distance: float, optional
         Relative distance (with respect to maximal map extent in longitude or latitude) to data
         points above which plot should not display values. For instance, to only plot values
-        at the centroids, use mask_rel_distance=0.01. If None, the plot is not masked.
+        at the centroids, use mask_relative_distance=0.01. If None, the plot is not masked.
         Default is None.
     kwargs: optional
         Arguments for pcolormesh matplotlib function used in event plots.
@@ -1193,7 +1193,7 @@ def plot_from_gdf(
         axes=axis,
         figsize=figsize,
         adapt_fontsize=adapt_fontsize,
-        mask_rel_distance=mask_rel_distance,
+        mask_relative_distance=mask_relative_distance,
         **kwargs,
     )
 


### PR DESCRIPTION
Changes proposed in this PR:
- Add an optional parameter to `geo_im_from_array` such that the user can input a (relative) distance above which plot locations that are further away than this distance from any centroids are masked (ie, no values plotted). This option is then available in all function that call `geo_im_from_array`, i.e., `_event_plot`, `hazard.plot_intensity`, `hazard.plot_fraction`, `plot_from_gdf`, `hazard.plot_rp_intensity`, `impact.plot_rp_imp`
- removed bug about the NaN legend in `geo_im_from_array`

### PR Author Checklist

- [x] Read the [Contribution Guide][contrib]
- [x] Correct target branch selected (if unsure, select `develop`)
- [x] Descriptive pull request title added
- [x] Source branch up-to-date with target branch
- [ ] [Documentation](https://climada-python.readthedocs.io/en/latest/guide/Guide_PythonDos-n-Donts.html#2.--Commenting-&-Documenting) updated
- [ ] [Tests][testing] updated
- [ ] [Tests][testing] passing
- [ ] No new [linter issues][linter]
- [ ] [Changelog](https://github.com/CLIMADA-project/climada_python/blob/main/CHANGELOG.md) updated

### PR Reviewer Checklist

- [ ] Read the [Contribution Guide][contrib]
- [ ] [CLIMADA Reviewer Checklist](https://climada-python.readthedocs.io/en/latest/guide/Guide_Reviewer_Checklist.html) passed
- [ ] [Tests][testing] passing
- [ ] No new [linter issues][linter]

[contrib]: https://github.com/CLIMADA-project/climada_python/blob/main/CONTRIBUTING.md
[testing]: https://climada-python.readthedocs.io/en/latest/guide/Guide_Continuous_Integration_and_Testing.html
[linter]: https://climada-python.readthedocs.io/en/stable/guide/Guide_Continuous_Integration_and_Testing.html#3.C.--Static-Code-Analysis
