### PR TITLE
Raise ValueError in download_world_bank_indicator

### DIFF
--- a/climada/test/test_litpop_integr.py
+++ b/climada/test/test_litpop_integr.py
@@ -53,7 +53,9 @@ class TestLitPopExposure(unittest.TestCase):
         self.assertEqual(ent.gdf.shape[0], 2829)
 
     def test_BLM150_pass(self):
-        """Test from_countries for BLM at 150 arcsec, 2 data points"""
+        """Test from_countries for BLM at 150 arcsec, 2 data points
+        The world bank doesn't provide data for Saint Barthélemy, fall back to natearth
+        """
         ent = lp.LitPop.from_countries("BLM", res_arcsec=150, reference_year=2016)
         self.assertEqual(ent.gdf.shape[0], 2)
 

--- a/climada/util/finance.py
+++ b/climada/util/finance.py
@@ -216,7 +216,7 @@ def download_world_bank_indicator(
         # Check if we received an error message
         try:
             if json_data[0]["message"][0]["id"] == "120":
-                raise RuntimeError(
+                raise ValueError(
                     "Error requesting data from the World Bank API. Did you use the "
                     "correct country code and indicator ID?"
                 )

--- a/climada/util/test/test_finance.py
+++ b/climada/util/test/test_finance.py
@@ -151,12 +151,12 @@ class TestWBData(unittest.TestCase):
 
         # Check errors raised
         with self.assertRaisesRegex(
-            RuntimeError,
+            ValueError,
             "Did you use the correct country code",
         ):
             download_world_bank_indicator("Spain", "NY.GDP.MKTP.CD")
         with self.assertRaisesRegex(
-            RuntimeError,
+            ValueError,
             "Did you use the correct country code",
         ):
             download_world_bank_indicator("ESP", "BogusIndicator")


### PR DESCRIPTION
Changes proposed in this PR:
- Raise a `ValueError` in `download_world_bank_indicator` instead of a `RuntimeError`
  as this is caught in `gdp` to then use `nat_earth_adm0` instead

This PR fixes #1049

### PR Author Checklist

- [ ] Read the [Contribution Guide][contrib]
- [x] Correct target branch selected (if unsure, select `develop`)
- [x] Descriptive pull request title added
- [x] Source branch up-to-date with target branch
- [ ] [Documentation](https://climada-python.readthedocs.io/en/latest/guide/Guide_PythonDos-n-Donts.html#2.--Commenting-&-Documenting) updated
- [x] [Tests][testing] updated
- [ ] [Tests][testing] passing
- [ ] No new [linter issues][linter]
- [ ] [Changelog](https://github.com/CLIMADA-project/climada_python/blob/main/CHANGELOG.md) updated

### PR Reviewer Checklist

- [ ] Read the [Contribution Guide][contrib]
- [ ] [CLIMADA Reviewer Checklist](https://climada-python.readthedocs.io/en/latest/guide/Guide_Reviewer_Checklist.html) passed
- [ ] [Tests][testing] passing
- [ ] No new [linter issues][linter]

[contrib]: https://github.com/CLIMADA-project/climada_python/blob/main/CONTRIBUTING.md
[testing]: https://climada-python.readthedocs.io/en/latest/guide/Guide_Continuous_Integration_and_Testing.html
[linter]: https://climada-python.readthedocs.io/en/stable/guide/Guide_Continuous_Integration_and_Testing.html#3.C.--Static-Code-Analysis
