### PR TITLE
Feature/exposures hdf5 io

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,18 +15,23 @@ Removed:
 - `pandas-datareader`
 
 ### Added
+
 - Added instructions to install Climada petals on Euler cluster in `doc.guide.Guide_Euler.ipynb` [#1029](https://github.com/CLIMADA-project/climada_python/pull/1029)
 
 ### Changed
+
 - `Hazard.local_exceedance_intensity`, `Hazard.local_return_period` and `Impact.local_exceedance_impact`, `Impact.local_return_period`, using the `climada.util.interpolation` module: New default (no binning), binning on decimals, and faster implementation [#1012](https://github.com/CLIMADA-project/climada_python/pull/1012)
 - World Bank indicator data is now downloaded directly from their API via the function `download_world_bank_indicator`, instead of relying on the `pandas-datareader` package [#1033](https://github.com/CLIMADA-project/climada_python/pull/1033)
+- `Exposures.write_hdf5` pickles geometry data in WKB format by default, and not as `shapely` objects anymore. There is now a flag to keep the previous behavior.
 
 ### Fixed
+
 - NaN plotting issues in `geo_im_from_array`[#1038](https://github.com/CLIMADA-project/climada_python/pull/1038)
 
 ### Deprecated
 
 ### Removed
+
 - `climada.util.interpolation.round_to_sig_digits` [#1012](https://github.com/CLIMADA-project/climada_python/pull/1012)
 
 ## 6.0.1

--- a/climada/entity/exposures/base.py
+++ b/climada/entity/exposures/base.py
@@ -1145,7 +1145,7 @@ class Exposures:
                     pandas_df[col] = np.asarray(self.data[col])
                 else:
                     wkb_data[col] = to_wkb_store(self.geometry)
-                    pandas_df.drop(columns=["geometry"])
+                    pandas_df.drop(columns=[col], inplace=True)
 
         # Avoid pandas PerformanceWarning when writing HDF5 data
         with warnings.catch_warnings():

--- a/climada/entity/exposures/test/test_base.py
+++ b/climada/entity/exposures/test/test_base.py
@@ -378,11 +378,11 @@ class TestIO(unittest.TestCase):
 
     def test_io_hdf5_pass(self):
         """write and read hdf5"""
-        exp_df = Exposures(pd.read_excel(ENT_TEMPLATE_XLS), crs="epsg:32632")
-        exp_df.check()
+        exp = Exposures(pd.read_excel(ENT_TEMPLATE_XLS), crs="epsg:32632")
+
         # set metadata
-        exp_df.ref_year = 2020
-        exp_df.value_unit = "XSD"
+        exp.ref_year = 2020
+        exp.value_unit = "XSD"
 
         file_name = DATA_DIR.joinpath("test_hdf5_exp.h5")
 
@@ -390,48 +390,51 @@ class TestIO(unittest.TestCase):
         # PerformanceWarning would result in test failure here
         import warnings
 
-        with warnings.catch_warnings():
-            warnings.simplefilter("error", category=pd.errors.PerformanceWarning)
-            exp_df.write_hdf5(file_name)
+        for pickle_geometry_as_shapely in [False, True]:
+            with warnings.catch_warnings():
+                warnings.simplefilter("error", category=pd.errors.PerformanceWarning)
+                exp.write_hdf5(
+                    file_name, pickle_geometry_as_shapely=pickle_geometry_as_shapely
+                )
 
-        exp_read = Exposures.from_hdf5(file_name)
+            exp_read = Exposures.from_hdf5(file_name)
 
-        self.assertEqual(exp_df.ref_year, exp_read.ref_year)
-        self.assertEqual(exp_df.value_unit, exp_read.value_unit)
-        self.assertEqual(exp_df.description, exp_read.description)
-        np.testing.assert_array_equal(exp_df.latitude, exp_read.latitude)
-        np.testing.assert_array_equal(exp_df.longitude, exp_read.longitude)
-        np.testing.assert_array_equal(exp_df.value, exp_read.value)
-        np.testing.assert_array_equal(
-            exp_df.data["deductible"].values, exp_read.data["deductible"].values
-        )
-        np.testing.assert_array_equal(
-            exp_df.data["cover"].values, exp_read.data["cover"].values
-        )
-        np.testing.assert_array_equal(
-            exp_df.data["region_id"].values, exp_read.data["region_id"].values
-        )
-        np.testing.assert_array_equal(
-            exp_df.data["category_id"].values, exp_read.data["category_id"].values
-        )
-        np.testing.assert_array_equal(
-            exp_df.data["impf_TC"].values, exp_read.data["impf_TC"].values
-        )
-        np.testing.assert_array_equal(
-            exp_df.data["centr_TC"].values, exp_read.data["centr_TC"].values
-        )
-        np.testing.assert_array_equal(
-            exp_df.data["impf_FL"].values, exp_read.data["impf_FL"].values
-        )
-        np.testing.assert_array_equal(
-            exp_df.data["centr_FL"].values, exp_read.data["centr_FL"].values
-        )
+            self.assertEqual(exp.ref_year, exp_read.ref_year)
+            self.assertEqual(exp.value_unit, exp_read.value_unit)
+            self.assertEqual(exp.description, exp_read.description)
+            np.testing.assert_array_equal(exp.latitude, exp_read.latitude)
+            np.testing.assert_array_equal(exp.longitude, exp_read.longitude)
+            np.testing.assert_array_equal(exp.value, exp_read.value)
+            np.testing.assert_array_equal(
+                exp.data["deductible"].values, exp_read.data["deductible"].values
+            )
+            np.testing.assert_array_equal(
+                exp.data["cover"].values, exp_read.data["cover"].values
+            )
+            np.testing.assert_array_equal(
+                exp.data["region_id"].values, exp_read.data["region_id"].values
+            )
+            np.testing.assert_array_equal(
+                exp.data["category_id"].values, exp_read.data["category_id"].values
+            )
+            np.testing.assert_array_equal(
+                exp.data["impf_TC"].values, exp_read.data["impf_TC"].values
+            )
+            np.testing.assert_array_equal(
+                exp.data["centr_TC"].values, exp_read.data["centr_TC"].values
+            )
+            np.testing.assert_array_equal(
+                exp.data["impf_FL"].values, exp_read.data["impf_FL"].values
+            )
+            np.testing.assert_array_equal(
+                exp.data["centr_FL"].values, exp_read.data["centr_FL"].values
+            )
 
-        self.assertTrue(
-            u_coord.equal_crs(exp_df.crs, exp_read.crs),
-            f"{exp_df.crs} and {exp_read.crs} are different",
-        )
-        self.assertTrue(u_coord.equal_crs(exp_df.gdf.crs, exp_read.gdf.crs))
+            self.assertTrue(
+                u_coord.equal_crs(exp.crs, exp_read.crs),
+                f"{exp.crs} and {exp_read.crs} are different",
+            )
+            self.assertTrue(u_coord.equal_crs(exp.gdf.crs, exp_read.gdf.crs))
 
 
 class TestAddSea(unittest.TestCase):


### PR DESCRIPTION
Changes proposed in this PR:

- By default convert geometry data to wkb format before writing Exposures to HDF5 files.
- Add a flag to `Exposures.write_hdf5` that allows to keep the previous behavior.
- Adapt the `from_hdf5` methods accordingly.

The data is still be pickled but pickled byte arrays are unlikely to be subject to change.
This is not a performance boost. Quite likely there are faster ways to store geometry data as wkb arrays,
but they are not obvious and maybe hard to get right. In light of future plans to introduce the parquet file format as standard in climada, any more efforts to optimize have been omitted.

This PR fixes #

### PR Author Checklist

- [ ] Read the [Contribution Guide][contrib]
- [ ] Correct target branch selected (if unsure, select `develop`)
- [ ] Descriptive pull request title added
- [ ] Source branch up-to-date with target branch
- [ ] [Documentation](https://climada-python.readthedocs.io/en/latest/guide/Guide_PythonDos-n-Donts.html#2.--Commenting-&-Documenting) updated
- [ ] [Tests][testing] updated
- [ ] [Tests][testing] passing
- [ ] No new [linter issues][linter]
- [ ] [Changelog](https://github.com/CLIMADA-project/climada_python/blob/main/CHANGELOG.md) updated

### PR Reviewer Checklist

- [ ] Read the [Contribution Guide][contrib]
- [ ] [CLIMADA Reviewer Checklist](https://climada-python.readthedocs.io/en/latest/guide/Guide_Reviewer_Checklist.html) passed
- [ ] [Tests][testing] passing
- [ ] No new [linter issues][linter]

[contrib]: https://github.com/CLIMADA-project/climada_python/blob/main/CONTRIBUTING.md
[testing]: https://climada-python.readthedocs.io/en/latest/guide/Guide_Continuous_Integration_and_Testing.html
[linter]: https://climada-python.readthedocs.io/en/stable/guide/Guide_Continuous_Integration_and_Testing.html#3.C.--Static-Code-Analysis
