### PR TITLE
remove geopandas.datasets

### DIFF
--- a/climada/hazard/test/test_tc_tracks.py
+++ b/climada/hazard/test/test_tc_tracks.py
@@ -27,7 +27,8 @@ import geopandas as gpd
 import numpy as np
 import pandas as pd
 import xarray as xr
-from shapely.geometry import LineString, MultiLineString, Point
+from cartopy.io import shapereader
+from shapely.geometry import LineString, MultiLineString
 
 import climada.hazard.tc_tracks as tc
 import climada.util.coordinates as u_coord
@@ -1278,8 +1279,16 @@ class TestFuncs(unittest.TestCase):
         storms = {"in": "2000233N12316", "out": "2000160N21267"}
         tc_track = tc.TCTracks.from_ibtracs_netcdf(storm_id=list(storms.values()))
 
-        # Define exposure from geopandas
-        world = gpd.read_file(gpd.datasets.get_path("naturalearth_lowres"))
+        # Define exposure from shapefile.natural_earth
+        shape_file = shapereader.Reader(
+            shapereader.natural_earth(
+                resolution="110m", category="cultural", name="admin_0_countries"
+            )
+        )
+        world = gpd.GeoDataFrame(
+            data=[cntry.attributes for cntry in shape_file.records()],
+            geometry=[cntry.geometry for cntry in shape_file.records()],
+        )
         exp_world = Exposures(world)
         exp = Exposures(exp_world.gdf[exp_world.gdf["name"] == "Cuba"])
 

--- a/climada/hazard/test/test_tc_tracks.py
+++ b/climada/hazard/test/test_tc_tracks.py
@@ -1288,7 +1288,7 @@ class TestFuncs(unittest.TestCase):
         world = gpd.GeoDataFrame(
             data=[cntry.attributes for cntry in shape_file.records()],
             geometry=[cntry.geometry for cntry in shape_file.records()],
-        )
+        ).rename(columns=lambda col: col.lower())
         exp_world = Exposures(world)
         exp = Exposures(exp_world.gdf[exp_world.gdf["name"] == "Cuba"])
 


### PR DESCRIPTION
Changes proposed in this PR:

- `gopandas.datasets` is deprecated and has been removed from geopandas >= 1.0
- in climada, the module is used exactly once, in test_tc_tacks, to create an exposures object from 110m admin 0 cultural vectors
- The nearly very same data can be downloaded via cartopy.io.shapereader
- In particular, for Cuba, which is the only relevant country in this test, the data is exactly equal.

This PR renders upgrading geopandas to 1.0 possible.

### PR Author Checklist

- [ ] Read the [Contribution Guide][contrib]
- [x] Correct target branch selected (if unsure, select `develop`)
- [x] Descriptive pull request title added
- [x] Source branch up-to-date with target branch
- [ ] [Documentation](https://climada-python.readthedocs.io/en/latest/guide/Guide_PythonDos-n-Donts.html#2.--Commenting-&-Documenting) updated
- [ ] [Tests][testing] updated
- [ ] [Tests][testing] passing
- [ ] No new [linter issues][linter]
- [ ] [Changelog](https://github.com/CLIMADA-project/climada_python/blob/main/CHANGELOG.md) updated

### PR Reviewer Checklist

- [ ] Read the [Contribution Guide][contrib]
- [ ] [CLIMADA Reviewer Checklist](https://climada-python.readthedocs.io/en/latest/guide/Guide_Reviewer_Checklist.html) passed
- [ ] [Tests][testing] passing
- [ ] No new [linter issues][linter]

[contrib]: https://github.com/CLIMADA-project/climada_python/blob/main/CONTRIBUTING.md
[testing]: https://climada-python.readthedocs.io/en/latest/guide/Guide_Continuous_Integration_and_Testing.html
[linter]: https://climada-python.readthedocs.io/en/stable/guide/Guide_Continuous_Integration_and_Testing.html#3.C.--Static-Code-Analysis
