### PR TITLE
Hotfix: assign centroids in cost benefit impact calculation if in new exposure no centroids were assigned

### DIFF
--- a/climada/engine/cost_benefit.py
+++ b/climada/engine/cost_benefit.py
@@ -1079,9 +1079,7 @@ class CostBenefit:
         # compute impact for each measure
         for measure in meas_set.get_measure(hazard.haz_type):
             LOGGER.debug("%s impact of measure %s.", when, measure.name)
-            imp_tmp, risk_transf = measure.calc_impact(
-                exposures, imp_fun_set, hazard, assign_centroids=False
-            )
+            imp_tmp, risk_transf = measure.calc_impact(exposures, imp_fun_set, hazard)
             impact_meas[measure.name] = dict()
             impact_meas[measure.name]["cost"] = (
                 measure.cost,

--- a/climada/engine/test/test_cost_benefit.py
+++ b/climada/engine/test/test_cost_benefit.py
@@ -1140,14 +1140,13 @@ class TestSteps(unittest.TestCase):
                     imp_time_depen=None,
                     save_imp=True,
                 )
-                if logs.output:
-                    for log in logs.output:
-                        self.assertNotIn(
-                            "No assigned hazard centroids in exposure object after",
-                            log,
-                            "Centroids are already assinged in Measure Exposure object"
-                            "and should not be reassigned.",
-                        )
+                for log in logs.output:
+                    self.assertNotIn(
+                        "No assigned hazard centroids in exposure object after",
+                        log,
+                        "Centroids are already assinged in Measure Exposure object"
+                        "and should not be reassigned.",
+                    )
         except AssertionError as e:
             if "no logs" in str(e).lower():
                 pass

--- a/climada/engine/test/test_cost_benefit.py
+++ b/climada/engine/test/test_cost_benefit.py
@@ -1129,21 +1129,30 @@ class TestSteps(unittest.TestCase):
         entity.exposures.ref_year = 2018
 
         # test that warning is not raised when centroid are assigned
-        with self.assertLogs(ILOG, level="WARNING") as logs:
-            cost_ben = CostBenefit()
-            cost_ben.calc(
-                hazard,
-                entity,
-                future_year=2040,
-                risk_func=risk_aai_agg,
-                imp_time_depen=None,
-                save_imp=True,
-            )
-            ILOG.warning("Dummy warning")
-        self.assertEqual(
-            ["WARNING:climada.entity.measures.base:Dummy warning"],
-            logs.output,
-        )
+        try:
+            with self.assertLogs(ILOG, level="WARNING") as logs:
+                cost_ben = CostBenefit()
+                cost_ben.calc(
+                    hazard,
+                    entity,
+                    future_year=2040,
+                    risk_func=risk_aai_agg,
+                    imp_time_depen=None,
+                    save_imp=True,
+                )
+                if logs.output:
+                    for log in logs.output:
+                        self.assertNotIn(
+                            "No assigned hazard centroids in exposure object after",
+                            log,
+                            "Centroids are already assinged in Measure Exposure object"
+                            "and should not be reassigned.",
+                        )
+        except AssertionError as e:
+            if "no logs" in str(e).lower():
+                pass
+            else:
+                raise
 
         # add measure with exposure without assigned centroids
         exp_no_assigned_centroids = entity.exposures.copy()

--- a/climada/entity/measures/base.py
+++ b/climada/entity/measures/base.py
@@ -204,7 +204,9 @@ class Measure:
         if new_haz.centr_exp_col not in new_exp.gdf.columns:
             LOGGER.warning(
                 "No assigned hazard centroids in exposure object after the "
-                "application of the measure. The centroids were assigned in impact calcualtion."
+                "application of the measure. The centroids will be assigned during impact "
+                "calculation. This is potentiall costly. To silence this warning, make sure "
+                "that centroids are assigned to all exposures."
             )
             new_exp.assign_centroids(new_haz)
 


### PR DESCRIPTION
Changes proposed in this PR:
- If a Measure included a new exposure object with no hazard centroids assigned, this led to an error message that was not clear how to resolve, see #1056. Now the method checks if there are assigned centroids and assigns them if not.

This PR fixes #1056

### PR Author Checklist

- [ ] Read the [Contribution Guide][contrib]
- [ ] Correct target branch selected (if unsure, select `develop`)
- [ ] Descriptive pull request title added
- [ ] Source branch up-to-date with target branch
- [ ] [Documentation](https://climada-python.readthedocs.io/en/latest/guide/Guide_PythonDos-n-Donts.html#2.--Commenting-&-Documenting) updated
- [ ] [Tests][testing] updated
- [ ] [Tests][testing] passing
- [ ] No new [linter issues][linter]
- [ ] [Changelog](https://github.com/CLIMADA-project/climada_python/blob/main/CHANGELOG.md) updated

### PR Reviewer Checklist

- [ ] Read the [Contribution Guide][contrib]
- [ ] [CLIMADA Reviewer Checklist](https://climada-python.readthedocs.io/en/latest/guide/Guide_Reviewer_Checklist.html) passed
- [ ] [Tests][testing] passing
- [ ] No new [linter issues][linter]

[contrib]: https://github.com/CLIMADA-project/climada_python/blob/main/CONTRIBUTING.md
[testing]: https://climada-python.readthedocs.io/en/latest/guide/Guide_Continuous_Integration_and_Testing.html
[linter]: https://climada-python.readthedocs.io/en/stable/guide/Guide_Continuous_Integration_and_Testing.html#3.C.--Static-Code-Analysis
