### PR TITLE
speed-up the function to add country borders and coastlines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,8 @@ Removed:
 - `ImpactFunc` and `ImpactFuncSet` now support equality comparisons via `==` [#1027](https://github.com/CLIMADA-project/climada_python/pull/1027)
 
 ### Changed
-
+- Changed the default mask_distance in `util.plot.geo_im_from_array` to 0.03 to avoid white gaps in gridded hazard data with comparably low resolution (>80 centroids per axis) [#1073](https://github.com/CLIMADA-project/climada_python/pull/1073)
+- Increased speed of `util.plot.add_shapes` by avoiding for loops, substantially speeding up `Hazard.plot_intensity` and other functions. [#1073](https://github.com/CLIMADA-project/climada_python/pull/1073)
 - `Hazard.local_exceedance_intensity`, `Hazard.local_return_period` and `Impact.local_exceedance_impact`, `Impact.local_return_period`, using the `climada.util.interpolation` module: New default (no binning), binning on decimals, and faster implementation [#1012](https://github.com/CLIMADA-project/climada_python/pull/1012)
 - World Bank indicator data is now downloaded directly from their API via the function `download_world_bank_indicator`, instead of relying on the `pandas-datareader` package [#1033](https://github.com/CLIMADA-project/climada_python/pull/1033)
 - `Exposures.write_hdf5` pickles geometry data in WKB format, which is faster and more sustainable. [#1051](https://github.com/CLIMADA-project/climada_python/pull/1051)

--- a/climada/engine/impact.py
+++ b/climada/engine/impact.py
@@ -1178,7 +1178,7 @@ class Impact:
         return_periods=(25, 50, 100, 250),
         log10_scale=True,
         axis=None,
-        mask_distance=0.01,
+        mask_distance=0.03,
         kwargs_local_exceedance_impact=None,
         **kwargs,
     ):
@@ -1198,8 +1198,8 @@ class Impact:
         mask_distance: float, optional
             Only regions are plotted that are closer to any of the data points than this distance,
             relative to overall plot size. For instance, to only plot values
-            at the centroids, use mask_distance=0.01. If None, the plot is not masked.
-            Default is 0.01.
+            at the centroids, use mask_distance=0.03. If None, the plot is not masked.
+            Default is 0.03.
         kwargs_local_exceedance_impact: dict
             Dictionary of keyword arguments for the method impact.local_exceedance_impact.
         kwargs : dict, optional

--- a/climada/hazard/plot.py
+++ b/climada/hazard/plot.py
@@ -40,7 +40,7 @@ class HazardPlot:
         self,
         return_periods=(25, 50, 100, 250),
         axis=None,
-        mask_distance=0.01,
+        mask_distance=0.03,
         kwargs_local_exceedance_intensity=None,
         **kwargs,
     ):
@@ -60,8 +60,8 @@ class HazardPlot:
         mask_distance: float, optional
             Only regions are plotted that are closer to any of the data points than this distance,
             relative to overall plot size. For instance, to only plot values
-            at the centroids, use mask_distance=0.01. If None, the plot is not masked.
-            Default is 0.01.
+            at the centroids, use mask_distance=0.03. If None, the plot is not masked.
+            Default is 0.03.
         kwargs: optional
             arguments for pcolormesh matplotlib function used in event plots
 
@@ -111,7 +111,7 @@ class HazardPlot:
         smooth=True,
         axis=None,
         adapt_fontsize=True,
-        mask_distance=0.01,
+        mask_distance=0.03,
         **kwargs,
     ):
         """Plot intensity values for a selected event or centroid.
@@ -138,8 +138,8 @@ class HazardPlot:
         mask_distance: float, optional
             Only regions are plotted that are closer to any of the data points than this distance,
             relative to overall plot size. For instance, to only plot values
-            at the centroids, use mask_distance=0.01. If None, the plot is not masked.
-            Default is 0.01.
+            at the centroids, use mask_distance=0.03. If None, the plot is not masked.
+            Default is 0.03.
         kwargs: optional
             arguments for pcolormesh matplotlib function
             used in event plots or for plot function used in centroids plots
@@ -181,7 +181,7 @@ class HazardPlot:
         centr=None,
         smooth=True,
         axis=None,
-        mask_distance=0.01,
+        mask_distance=0.03,
         **kwargs,
     ):
         """Plot fraction values for a selected event or centroid.
@@ -208,8 +208,8 @@ class HazardPlot:
         mask_distance: float, optional
             Relative distance (with respect to maximal map extent in longitude or latitude) to data
             points above which plot should not display values. For instance, to only plot values
-            at the centroids, use mask_distance=0.01. If None, the plot is not masked.
-            Default is None.
+            at the centroids, use mask_distance=0.03. If None, the plot is not masked.
+            Default is 0.03.
         kwargs: optional
             arguments for pcolormesh matplotlib function
             used in event plots or for plot function used in centroids plots
@@ -252,7 +252,7 @@ class HazardPlot:
         axis=None,
         figsize=(9, 13),
         adapt_fontsize=True,
-        mask_distance=0.01,
+        mask_distance=0.03,
         **kwargs,
     ):
         """Plot an event of the input matrix.
@@ -277,8 +277,8 @@ class HazardPlot:
         mask_distance: float, optional
             Only regions are plotted that are closer to any of the data points than this distance,
             relative to overall plot size. For instance, to only plot values
-            at the centroids, use mask_distance=0.01. If None, the plot is not masked.
-            Default is None.
+            at the centroids, use mask_distance=0.03. If None, the plot is not masked.
+            Default is 0.03.
         kwargs: optional
             arguments for pcolormesh matplotlib function
 

--- a/climada/util/plot.py
+++ b/climada/util/plot.py
@@ -733,8 +733,8 @@ def add_shapes(axis):
     axis : cartopy.mpl.geoaxes.GeoAxesSubplot
         Cartopy axis
     """
-    axis.add_feature(cfeature.BORDERS.with_scale('10m'), edgecolor='dimgrey')
-    axis.add_feature(cfeature.COASTLINE.with_scale('10m'), edgecolor='dimgrey')
+    axis.add_feature(cfeature.BORDERS.with_scale("10m"), edgecolor="dimgrey")
+    axis.add_feature(cfeature.COASTLINE.with_scale("10m"), edgecolor="dimgrey")
 
 def _ensure_utf8(val):
     # Without the `*.cpg` file present, the shape reader wrongly assumes latin-1 encoding:

--- a/climada/util/plot.py
+++ b/climada/util/plot.py
@@ -35,6 +35,7 @@ import warnings
 from textwrap import wrap
 
 import cartopy.crs as ccrs
+import cartopy.feature as cfeature
 import geopandas as gpd
 import matplotlib as mpl
 import matplotlib.patches as mpatches
@@ -338,7 +339,7 @@ def geo_im_from_array(
     axes=None,
     figsize=(9, 13),
     adapt_fontsize=True,
-    mask_distance=0.01,
+    mask_distance=0.03,
     **kwargs,
 ):
     """Image(s) plot defined in array(s) over input coordinates.
@@ -373,8 +374,8 @@ def geo_im_from_array(
     mask_distance: float, optional
         Only regions are plotted that are closer to any of the data points than this distance,
         relative to overall plot size. For instance, to only plot values
-        at the centroids, use mask_distance=0.01. If None, the plot is not masked.
-        Default is 0.01.
+        at the centroids, use mask_distance=0.03. If None, the plot is not masked.
+        Default is 0.03.
     **kwargs
         arbitrary keyword arguments for pcolormesh matplotlib function
 
@@ -725,25 +726,15 @@ def make_map(num_sub=1, figsize=(9, 13), proj=ccrs.PlateCarree(), adapt_fontsize
 
 def add_shapes(axis):
     """
-    Overlay Earth's countries coastlines to matplotlib.pyplot axis.
+    Overlay Earth's countries and coastlines to matplotlib.pyplot axis.
 
     Parameters
     ----------
     axis : cartopy.mpl.geoaxes.GeoAxesSubplot
         Cartopy axis
-    projection : cartopy.crs projection, optional
-        Geographical projection.
-        The default is PlateCarree.
     """
-    shp_file = shapereader.natural_earth(
-        resolution="10m", category="cultural", name="admin_0_countries"
-    )
-    shp = shapereader.Reader(shp_file)
-    for geometry in shp.geometries():
-        axis.add_geometries(
-            [geometry], crs=ccrs.PlateCarree(), facecolor="none", edgecolor="dimgray"
-        )
-
+    axis.add_feature(cfeature.BORDERS.with_scale('10m'), edgecolor='dimgrey')
+    axis.add_feature(cfeature.COASTLINE.with_scale('10m'), edgecolor='dimgrey')
 
 def _ensure_utf8(val):
     # Without the `*.cpg` file present, the shape reader wrongly assumes latin-1 encoding:
@@ -1104,7 +1095,7 @@ def plot_from_gdf(
     axis=None,
     figsize=(9, 13),
     adapt_fontsize=True,
-    mask_distance=0.01,
+    mask_distance=0.03,
     **kwargs,
 ):
     """Plot several subplots from different columns of a GeoDataFrame, e.g., for
@@ -1130,8 +1121,8 @@ def plot_from_gdf(
     mask_distance: float, optional
         Relative distance (with respect to maximal map extent in longitude or latitude) to data
         points above which plot should not display values. For instance, to only plot values
-        at the centroids, use mask_distance=0.01. If None, the plot is not masked.
-        Default is 0.01.
+        at the centroids, use mask_distance=0.03. If None, the plot is not masked.
+        Default is 0.03.
     kwargs: optional
         Arguments for pcolormesh matplotlib function used in event plots.
 

--- a/climada/util/plot.py
+++ b/climada/util/plot.py
@@ -736,6 +736,7 @@ def add_shapes(axis):
     axis.add_feature(cfeature.BORDERS.with_scale("10m"), edgecolor="dimgrey")
     axis.add_feature(cfeature.COASTLINE.with_scale("10m"), edgecolor="dimgrey")
 
+
 def _ensure_utf8(val):
     # Without the `*.cpg` file present, the shape reader wrongly assumes latin-1 encoding:
     # https://github.com/SciTools/cartopy/issues/1282


### PR DESCRIPTION
Changes proposed in this PR:
- Substantially speeding up plots by directly adding all borders with one call, rather than loop through each geometry object, when adding countries and coastlines in the `u_plot.add_shapes` function. I've tested the new function in multiple tutorials and my own data (both with standard and projected coordinates) and the plots look equivalent. 
- Set the default value of the recently implemented mask_distance in hazard plots from 0.01 to 0.03.

This PR fixes #1071 
Substantially speeds up hazard.plot_intensity (and other functions that use `u_plot.add_shapes`). Before the update, adding the country borders took up to 75% of the overall time, which is reduced to <1%, significantly speeding up the overall function. 

The change of the default mask_distance is somewhat independent. While testing many plots in the tutorial, we noticed in multiple instances the haz.plot_intensity() with the recently updated raster plotting functionality (PR #1047) showed small white gaps within gridded data, if there are fewer than ~80 regularly spaced gridpoints in one direction. Changing the default from 0.01 to 0.03 allows smooth plots for data with fewer (down to ~30) gridpoints per side, while keeping the default interpolation distance for data with gaps reasonably small. 
Of course, users can always adjust the parameter depending on their data, but increasing the default will lead to fewer user seeing gaps in their gridded hazard data plot and needing to dig into the keyword arguments of the haz.plot_intensity() function.

### PR Author Checklist

- [x] Read the [Contribution Guide][contrib]
- [x] Correct target branch selected (if unsure, select `develop`)
- [x] Descriptive pull request title added
- [x] Source branch up-to-date with target branch
- [x] [Documentation](https://climada-python.readthedocs.io/en/latest/guide/Guide_PythonDos-n-Donts.html#2.--Commenting-&-Documenting) updated
- [x] [Tests][testing] updated
- [x] [Tests][testing] passing
- [x] No new [linter issues][linter]
- [x] [Changelog](https://github.com/CLIMADA-project/climada_python/blob/main/CHANGELOG.md) updated

### PR Reviewer Checklist

- [ ] Read the [Contribution Guide][contrib]
- [ ] [CLIMADA Reviewer Checklist](https://climada-python.readthedocs.io/en/latest/guide/Guide_Reviewer_Checklist.html) passed
- [ ] [Tests][testing] passing
- [ ] No new [linter issues][linter]

[contrib]: https://github.com/CLIMADA-project/climada_python/blob/main/CONTRIBUTING.md
[testing]: https://climada-python.readthedocs.io/en/latest/guide/Guide_Continuous_Integration_and_Testing.html
[linter]: https://climada-python.readthedocs.io/en/stable/guide/Guide_Continuous_Integration_and_Testing.html#3.C.--Static-Code-Analysis
