### PR TITLE
Fix/number check

### DIFF
--- a/climada/entity/exposures/litpop/litpop.py
+++ b/climada/entity/exposures/litpop/litpop.py
@@ -19,6 +19,7 @@ Define LitPop class.
 """
 
 import logging
+import numbers
 from pathlib import Path
 
 import geopandas
@@ -820,12 +821,12 @@ class LitPop(Exposures):
             total_value = _get_total_value_per_country(iso3a, fin_mode, reference_year)
 
         # disaggregate total value proportional to LitPop values:
-        if isinstance(total_value, (float, int)):
+        if isinstance(total_value, numbers.Number):
             litpop_gdf["value"] = (
                 np.divide(litpop_gdf["value"], litpop_gdf["value"].sum()) * total_value
             )
         elif total_value is not None:
-            raise TypeError("total_value must be int or float.")
+            raise TypeError(f"total_value ({total_value}) must be a number.")
 
         exp = LitPop()
         exp.set_gdf(litpop_gdf)

--- a/climada/util/test/test_files.py
+++ b/climada/util/test/test_files.py
@@ -22,7 +22,12 @@ Test files_handler module.
 import unittest
 from pathlib import Path
 
-from climada.util.constants import DEMO_DIR, ENT_TEMPLATE_XLS, GLB_CENTROIDS_MAT
+from climada.util.constants import (
+    DEMO_DIR,
+    ENT_TEMPLATE_XLS,
+    GLB_CENTROIDS_MAT,
+    SYSTEM_DIR,
+)
 from climada.util.files_handler import (
     download_file,
     get_extension,
@@ -107,7 +112,8 @@ class TestGetFileNames(unittest.TestCase):
     def test_wrong_argument(self):
         """If the input contains a non-existing file, an empyt directory or a pattern that is not
         matched, the method should raise a ValueError."""
-        empty_dir = DEMO_DIR.parent
+        empty_dir = SYSTEM_DIR / "exposures"
+        self.assertTrue(empty_dir.is_dir)
         with self.assertRaises(ValueError) as ve:
             get_file_names(str(empty_dir))
         self.assertIn("no files", str(ve.exception))


### PR DESCRIPTION
Changes proposed in this PR:

- after upgrading geopandas and pandas two integration tests failed due to incomparable types, float and numpy.float32

This PR fixes this

### PR Author Checklist

- [ ] Read the [Contribution Guide][contrib]
- [x] Correct target branch selected (if unsure, select `develop`)
- [x] Descriptive pull request title added
- [x] Source branch up-to-date with target branch
- [ ] [Documentation](https://climada-python.readthedocs.io/en/latest/guide/Guide_PythonDos-n-Donts.html#2.--Commenting-&-Documenting) updated
- [ ] [Tests][testing] updated
- [ ] [Tests][testing] passing
- [ ] No new [linter issues][linter]
- [ ] [Changelog](https://github.com/CLIMADA-project/climada_python/blob/main/CHANGELOG.md) updated

### PR Reviewer Checklist

- [ ] Read the [Contribution Guide][contrib]
- [ ] [CLIMADA Reviewer Checklist](https://climada-python.readthedocs.io/en/latest/guide/Guide_Reviewer_Checklist.html) passed
- [ ] [Tests][testing] passing
- [ ] No new [linter issues][linter]

[contrib]: https://github.com/CLIMADA-project/climada_python/blob/main/CONTRIBUTING.md
[testing]: https://climada-python.readthedocs.io/en/latest/guide/Guide_Continuous_Integration_and_Testing.html
[linter]: https://climada-python.readthedocs.io/en/stable/guide/Guide_Continuous_Integration_and_Testing.html#3.C.--Static-Code-Analysis
