### PR TITLE
Allow Exposures.from_raster to set Exposure metadata

### DIFF
--- a/climada/entity/exposures/base.py
+++ b/climada/entity/exposures/base.py
@@ -707,6 +707,7 @@ class Exposures:
         width=None,
         height=None,
         resampling=Resampling.nearest,
+        attrs=None
     ):
         """Read raster data and set latitude, longitude, value and meta
 
@@ -734,11 +735,19 @@ class Exposures:
         resampling : rasterio.warp,.Resampling optional
             resampling
             function used for reprojection to dst_crs
+        attrs : dict
+            dictionary giving kwargs passed to the Exposures class. Keys must 
+            be in the Exposures._metadata list, i.e. "description", "ref_year",
+            "value_unit"
 
         returns
         --------
         Exposures
         """
+        if not attrs:
+            attrs = {}
+        attrs = {key: attrs[key] for key in set(attrs) & set(cls._metadata)}
+
         meta, value = u_coord.read_raster(
             file_name,
             [band],
@@ -765,6 +774,7 @@ class Exposures:
             },
             meta=meta,
             crs=meta["crs"],
+            **attrs
         )
 
     def plot_scatter(

--- a/climada/entity/exposures/test/test_base.py
+++ b/climada/entity/exposures/test/test_base.py
@@ -128,7 +128,10 @@ class TestFuncs(unittest.TestCase):
 
     def test_read_raster_pass(self):
         """from_raster"""
-        exp = Exposures.from_raster(HAZ_DEMO_FL, window=Window(10, 20, 50, 60))
+        exp = Exposures.from_raster(
+            HAZ_DEMO_FL,
+            window=Window(10, 20, 50, 60),
+            attrs={'value_unit': 'USD'})
         exp.check()
         self.assertTrue(u_coord.equal_crs(exp.crs, DEF_CRS))
         self.assertAlmostEqual(
@@ -149,6 +152,7 @@ class TestFuncs(unittest.TestCase):
         self.assertAlmostEqual(
             exp.gdf["value"].values.reshape((60, 50))[25, 12], 0.056825936
         )
+        self.assertEqual(exp.value_unit, 'USD')
 
     def test_assign_raster_pass(self):
         """Test assign_centroids with raster hazard"""


### PR DESCRIPTION
Changes proposed in this PR:
- Add an `attrs` parameter to the `Exposures.from_raster` class method, analogous to the `Hazard.from_raster` method. In this method the `attrs` parameter is a dictionary that is used as additional keyword arguments in the subsequent call of the `__init__`.
- However, to limit unexpected behaviour, I've limited the input dictionary to keys contained in the `Exposures._metadata` list `["description", "ref_year", "value_unit"]`. Other arguments taken by `Exposures.__init__` method are either already provided by the `from_raster` method, or could make a mess (e.g. `lat`, `lon`, `value`). In the current implementation, they are dropped quietly – should there be a warning too?
- While the `Hazard.from_raster` method takes `attrs` as one of its first parameters, here I've added `attrs` as an additional, final parameter. I think it i's less likely to break stuff and the end is usually where a `**kwargs` goes anyway.

### PR Author Checklist

- [x] Read the [Contribution Guide][contrib]
- [x] Correct target branch selected (if unsure, select `develop`)
- [x] Descriptive pull request title added
- [x] Source branch up-to-date with target branch
- [ ] [Documentation](https://climada-python.readthedocs.io/en/latest/guide/Guide_PythonDos-n-Donts.html#2.--Commenting-&-Documenting) updated
- [x] [Tests][testing] updated
- [x] [Tests][testing] passing
- [ ] No new [linter issues][linter]
- [ ] [Changelog](https://github.com/CLIMADA-project/climada_python/blob/main/CHANGELOG.md) updated

### PR Reviewer Checklist

- [ ] Read the [Contribution Guide][contrib]
- [ ] [CLIMADA Reviewer Checklist](https://climada-python.readthedocs.io/en/latest/guide/Guide_Reviewer_Checklist.html) passed
- [ ] [Tests][testing] passing
- [ ] No new [linter issues][linter]

[contrib]: https://github.com/CLIMADA-project/climada_python/blob/main/CONTRIBUTING.md
[testing]: https://climada-python.readthedocs.io/en/latest/guide/Guide_Continuous_Integration_and_Testing.html
[linter]: https://climada-python.readthedocs.io/en/stable/guide/Guide_Continuous_Integration_and_Testing.html#3.C.--Static-Code-Analysis
