### PR TITLE
1127 - Forecast base class init

### DIFF
--- a/climada/util/forecast.py
+++ b/climada/util/forecast.py
@@ -39,7 +39,6 @@ class Forecast:
         self,
         lead_time: np.ndarray | None = None,
         member: np.ndarray | None = None,
-        *args,
         **kwargs,
     ):
         """Initialize Forecast.
@@ -58,4 +57,4 @@ class Forecast:
 
         self.member = np.asarray(member) if member is not None else np.array([])
 
-        super().__init__(*args, **kwargs)
+        super().__init__(**kwargs)

--- a/climada/util/forecast.py
+++ b/climada/util/forecast.py
@@ -54,7 +54,5 @@ class Forecast:
         self.lead_time = (
             np.asarray(lead_time) if lead_time is not None else np.array([])
         )
-
         self.member = np.asarray(member) if member is not None else np.array([])
-
         super().__init__(**kwargs)

--- a/climada/util/forecast.py
+++ b/climada/util/forecast.py
@@ -19,6 +19,19 @@ with CLIMADA. If not, see <https://www.gnu.org/licenses/>.
 Define Forecast base class.
 """
 
+import numpy as np
+
 
 class Forecast:
-    pass
+    def __init__(self, lead_time=None, member=None, *args, **kwargs):
+        if lead_time is None:
+            self.lead_time = np.array([])
+        else:
+            self.lead_time = np.array(lead_time)
+
+        if member is None:
+            self.member = np.array([])
+        else:
+            self.member = member
+
+        super().__init__(*args, **kwargs)

--- a/climada/util/forecast.py
+++ b/climada/util/forecast.py
@@ -23,15 +23,18 @@ import numpy as np
 
 
 class Forecast:
-    def __init__(self, lead_time=None, member=None, *args, **kwargs):
-        if lead_time is None:
-            self.lead_time = np.array([])
-        else:
-            self.lead_time = np.array(lead_time)
+    def __init__(
+        self,
+        lead_time: np.ndarray | None = None,
+        member: np.ndarray | None = None,
+        *args,
+        **kwargs,
+    ):
 
-        if member is None:
-            self.member = np.array([])
-        else:
-            self.member = member
+        self.lead_time = (
+            np.asarray(lead_time) if lead_time is not None else np.array([])
+        )
+
+        self.member = np.asarray(member) if member is not None else np.array([])
 
         super().__init__(*args, **kwargs)

--- a/climada/util/forecast.py
+++ b/climada/util/forecast.py
@@ -23,6 +23,18 @@ import numpy as np
 
 
 class Forecast:
+    """Mixin class for forecast data.
+
+    Attributes
+    ----------
+    lead_time : np.ndarray
+        Array of forecast lead times, given as datetime64 objects.
+        Represents the time points for which forecasts are made.
+    member : np.ndarray
+        Array of ensemble member identifiers, given as integers.
+        Represents different forecast ensemble members.
+    """
+
     def __init__(
         self,
         lead_time: np.ndarray | None = None,
@@ -30,6 +42,15 @@ class Forecast:
         *args,
         **kwargs,
     ):
+        """Initialize Forecast.
+
+        Parameters
+        ----------
+        lead_time : np.ndarray or None, optional
+            Forecast lead times. Default is empty array.
+        member : np.ndarray or None, optional
+            Ensemble member identifiers. Default is empty array.
+        """
 
         self.lead_time = (
             np.asarray(lead_time) if lead_time is not None else np.array([])

--- a/climada/util/test/test_forecast.py
+++ b/climada/util/test/test_forecast.py
@@ -18,3 +18,27 @@ with CLIMADA. If not, see <https://www.gnu.org/licenses/>.
 
 Tests for Forecast base class.
 """
+
+import numpy as np
+import numpy.testing as npt
+import pytest
+
+from climada.util.forecast import Forecast
+
+
+def test_forecast_init():
+    """Test initialization of Forecast class."""
+    forecast = Forecast()
+    npt.assert_array_equal(forecast.lead_time, np.array([]))
+    npt.assert_array_equal(forecast.member, np.array([]))
+
+    forecast = Forecast(member=np.array([1, 2]))
+    npt.assert_array_equal(forecast.member, np.array([1, 2]), strict=True)
+
+    forecast = Forecast(lead_time=np.array([1, 2]))
+    npt.assert_array_equal(forecast.lead_time, np.array([1, 2]), strict=True)
+
+    forecast = Forecast(lead_time=np.array([1, 2]), member=[3, 4])
+    npt.assert_array_equal(forecast.lead_time, np.array([1, 2]), strict=True)
+    npt.assert_array_equal(forecast.member, np.array([3, 4]), strict=True)
+    assert isinstance(forecast.member, np.ndarray)

--- a/climada/util/test/test_forecast.py
+++ b/climada/util/test/test_forecast.py
@@ -42,3 +42,12 @@ def test_forecast_init():
     npt.assert_array_equal(forecast.lead_time, np.array([1, 2]), strict=True)
     npt.assert_array_equal(forecast.member, np.array([3, 4]), strict=True)
     assert isinstance(forecast.member, np.ndarray)
+
+    # Test with datetime64 including seconds
+    lead_times_seconds = np.array(
+        ["2024-01-01T00:00:00", "2024-01-01T00:01:00", "2024-01-01"],
+        dtype="datetime64[s]",
+    )
+    forecast = Forecast(lead_time=lead_times_seconds, member=[1, 2, 3])
+    npt.assert_array_equal(forecast.lead_time, lead_times_seconds, strict=True)
+    assert forecast.lead_time.dtype == np.dtype("datetime64[s]")

--- a/climada/util/test/test_forecast.py
+++ b/climada/util/test/test_forecast.py
@@ -21,7 +21,6 @@ Tests for Forecast base class.
 
 import numpy as np
 import numpy.testing as npt
-import pytest
 
 from climada.util.forecast import Forecast
 

--- a/climada/util/test/test_forecast.py
+++ b/climada/util/test/test_forecast.py
@@ -18,3 +18,48 @@ with CLIMADA. If not, see <https://www.gnu.org/licenses/>.
 
 Tests for Forecast base class.
 """
+
+import numpy as np
+import pytest
+
+from climada.util.forecast import Forecast
+
+
+class TestForecastInit:
+    """Test Forecast initialization"""
+
+    def test_init_with_none_values(self):
+        """Test initialization with None values for lead_time and member"""
+        forecast = Forecast(lead_time=None, member=None)
+
+        # Check that lead_time is an empty numpy array
+        assert isinstance(forecast.lead_time, np.ndarray)
+        assert forecast.lead_time.size == 0
+
+        # Check that member is an empty numpy array
+        assert isinstance(forecast.member, np.ndarray)
+        assert forecast.member.size == 0
+
+    def test_init_with_empty_objects(self):
+        """Test initialization with empty objects for lead_time and member"""
+        forecast = Forecast(lead_time=[], member=[])
+
+        # Check that lead_time is an empty numpy array
+        assert isinstance(forecast.lead_time, np.ndarray)
+        assert forecast.lead_time.size == 0
+
+        # Check that member is a list (passed directly)
+        assert isinstance(forecast.member, list)
+        assert len(forecast.member) == 0
+
+    def test_init_default(self):
+        """Test initialization with no arguments (default behavior)"""
+        forecast = Forecast()
+
+        # Check that lead_time is an empty numpy array
+        assert isinstance(forecast.lead_time, np.ndarray)
+        assert forecast.lead_time.size == 0
+
+        # Check that member is an empty numpy array
+        assert isinstance(forecast.member, np.ndarray)
+        assert forecast.member.size == 0


### PR DESCRIPTION
Changes proposed in this PR:
- Initialize a "base" (mixin) class `Forecast` with forecast-specific attributes
- Write tests

This PR fixes #1127 

### PR Author Checklist

- [ ] Read the [Contribution Guide][contrib]
- [ ] Correct target branch selected (if unsure, select `develop`)
- [ ] Descriptive pull request title added
- [ ] Source branch up-to-date with target branch
- [ ] [Documentation](https://climada-python.readthedocs.io/en/latest/guide/Guide_PythonDos-n-Donts.html#2.--Commenting-&-Documenting) updated
- [ ] [Tests][testing] updated
- [ ] [Tests][testing] passing
- [ ] No new [linter issues][linter]
- [ ] [Changelog](https://github.com/CLIMADA-project/climada_python/blob/main/CHANGELOG.md) updated

### PR Reviewer Checklist

- [ ] Read the [Contribution Guide][contrib]
- [ ] [CLIMADA Reviewer Checklist](https://climada-python.readthedocs.io/en/latest/development/Guide_Review.html) passed
- [ ] [Tests][testing] passing
- [ ] No new [linter issues][linter]

[contrib]: https://github.com/CLIMADA-project/climada_python/blob/main/CONTRIBUTING.md
[testing]: https://climada-python.readthedocs.io/en/latest/development/Guide_continuous_integration_GitHub_actions.html
[linter]: https://climada-python.readthedocs.io/en/latest/development/Guide_continuous_integration_GitHub_actions.html#static-code-analysis
