### PR TITLE
Change leadtime from datetime to timedelta

### DIFF
--- a/climada/engine/impact_forecast.py
+++ b/climada/engine/impact_forecast.py
@@ -45,9 +45,9 @@ class ImpactForecast(Forecast, Impact):
         Parameters
         ----------
         lead_time : np.ndarray, optional
-            The lead time associated with each event entry
+            The lead time associated with each event entry, given as timedelta64 type
         member : np.ndarray, optional
-            The ensemble member associated with each event entry
+            The ensemble member associated with each event entry, given as integers
         impact_kwargs
             Keyword-arguments passed to ~:py:class`climada.engine.impact.Impact`.
         """
@@ -65,9 +65,9 @@ class ImpactForecast(Forecast, Impact):
         impact : climada.engine.impact.Impact
             The impact object whose data to use in the forecast object
         lead_time : np.ndarray, optional
-            The lead time associated with each event entry
+            The lead time associated with each event entry, given as timedelta64 type
         member : np.ndarray, optional
-            The ensemble member associated with each event entry
+            The ensemble member associated with each event entry, given as integers
         """
         with log_level("WARNING", "climada.engine.impact"):
             return cls(

--- a/climada/engine/test/test_impact_forecast.py
+++ b/climada/engine/test/test_impact_forecast.py
@@ -52,7 +52,7 @@ def assert_impact_kwargs(impact: Impact, **kwargs):
 
 
 class TestImpactForecastInit:
-    lead_time = pd.date_range("2000-01-01", "2000-01-02", periods=6).to_numpy()
+    lead_time = pd.timedelta_range(start="1 day", periods=6).to_numpy()
     member = np.arange(6)
 
     def test_impact_forecast_init(self, impact_kwargs):

--- a/climada/hazard/test/test_forecast.py
+++ b/climada/hazard/test/test_forecast.py
@@ -29,8 +29,6 @@ from climada.hazard.base import Hazard
 from climada.hazard.forecast import HazardForecast
 from climada.hazard.test.test_base import hazard_kwargs
 
-# --- Examples for fixtures and test organization --- #
-
 
 @pytest.fixture
 def haz_kwargs():

--- a/climada/util/forecast.py
+++ b/climada/util/forecast.py
@@ -28,8 +28,8 @@ class Forecast:
     Attributes
     ----------
     lead_time : np.ndarray
-        Array of forecast lead times, given as datetime64 objects.
-        Represents the time points for which forecasts are made.
+        Array of forecast lead times, given as timedelta64 objects.
+        Represents the lead times of the forecasts.
     member : np.ndarray
         Array of ensemble member identifiers, given as integers.
         Represents different forecast ensemble members.

--- a/climada/util/test/test_forecast.py
+++ b/climada/util/test/test_forecast.py
@@ -21,6 +21,7 @@ Tests for Forecast base class.
 
 import numpy as np
 import numpy.testing as npt
+import pandas as pd
 
 from climada.util.forecast import Forecast
 
@@ -34,8 +35,10 @@ def test_forecast_init():
     forecast = Forecast(member=np.array([1, 2]))
     npt.assert_array_equal(forecast.member, np.array([1, 2]), strict=True)
 
-    forecast = Forecast(lead_time=np.array([1, 2]))
-    npt.assert_array_equal(forecast.lead_time, np.array([1, 2]), strict=True)
+    forecast = Forecast(lead_time=np.array([6, 12], dtype="timedelta64[h]"))
+    npt.assert_array_equal(
+        forecast.lead_time, np.array([6, 12], dtype="timedelta64[h]"), strict=True
+    )
 
     forecast = Forecast(lead_time=np.array([1, 2]), member=[3, 4])
     npt.assert_array_equal(forecast.lead_time, np.array([1, 2]), strict=True)
@@ -43,10 +46,7 @@ def test_forecast_init():
     assert isinstance(forecast.member, np.ndarray)
 
     # Test with datetime64 including seconds
-    lead_times_seconds = np.array(
-        ["2024-01-01T00:00:00", "2024-01-01T00:01:00", "2024-01-01"],
-        dtype="datetime64[s]",
-    )
+    lead_times_seconds = pd.timedelta_range(start="1 day", periods=4).to_numpy()
     forecast = Forecast(lead_time=lead_times_seconds, member=[1, 2, 3])
     npt.assert_array_equal(forecast.lead_time, lead_times_seconds, strict=True)
-    assert forecast.lead_time.dtype == np.dtype("datetime64[s]")
+    assert forecast.lead_time.dtype == np.dtype("timedelta64[ns]")


### PR DESCRIPTION
Changes proposed in this PR:
- Changed docstring in forecast class
- Changed tests to timedelta
- same for ImpactForecasts

Fixes [#1173](https://github.com/CLIMADA-project/climada_python/issues/1173)