### PR TITLE
Impact calc return impact forecast

### DIFF
--- a/climada/engine/impact_calc.py
+++ b/climada/engine/impact_calc.py
@@ -259,7 +259,7 @@ class ImpactCalc:
 
         Returns
         -------
-        Impact
+        Impact or ImpactForecast
             Empty impact object with correct array sizes.
         """
         at_event = np.zeros(self.n_events)
@@ -271,9 +271,17 @@ class ImpactCalc:
             )
         else:
             imp_mat = None
-        return Impact.from_eih(
+        impact = Impact.from_eih(
             self.exposures, self.hazard, at_event, eai_exp, aai_agg, imp_mat
         )
+        if isinstance(self.hazard, HazardForecast):
+            return ImpactForecast().from_impact(
+                impact, self.hazard.ensemble_member, self.hazard.lead_time
+            )  # return ImpactForecast object
+        else:
+            return (
+                impact  # return normal impact object if hazard is not a HazardForecast
+            )
 
     def minimal_exp_gdf(
         self, impf_col, assign_centroids, ignore_cover, ignore_deductible

--- a/climada/engine/impact_calc.py
+++ b/climada/engine/impact_calc.py
@@ -29,6 +29,8 @@ from scipy import sparse
 
 from climada import CONFIG
 from climada.engine.impact import Impact
+from climada.engine.impact_forecast import ImpactForecast
+from climada.hazard.forecast import HazardForecast
 
 LOGGER = logging.getLogger(__name__)
 
@@ -217,7 +219,7 @@ class ImpactCalc:
 
         Returns
         -------
-        Impact
+        Impact or ImpactForecast
             Impact Object initialize from the impact matrix
 
         See Also
@@ -233,9 +235,18 @@ class ImpactCalc:
         else:
             imp_mat = None
             at_event, eai_exp, aai_agg = self.stitch_risk_metrics(imp_mat_gen)
-        return Impact.from_eih(
+
+        impact = Impact.from_eih(
             self.exposures, self.hazard, at_event, eai_exp, aai_agg, imp_mat
         )
+        if isinstance(self.hazard, HazardForecast):
+            return ImpactForecast().from_impact(
+                impact, self.hazard.ensemble_member, self.hazard.lead_time
+            )  # return ImpactForecast object
+        else:
+            return (
+                impact  # return normal impact object if hazard is not a HazardForecast
+            )
 
     def _return_empty(self, save_mat):
         """

--- a/climada/engine/impact_calc.py
+++ b/climada/engine/impact_calc.py
@@ -233,11 +233,11 @@ class ImpactCalc:
                 imp_mat, self.hazard.frequency
             )
             if isinstance(self.hazard, HazardForecast):
-                eai_exp = np.nan * np.ones(eai_exp.shape, dtype=eai_exp.dtype)
-                aai_agg = np.nan * np.ones(aai_agg.shape, dtype=aai_agg.dtype)
+                eai_exp = np.full_like(eai_exp, np.nan, dtype=eai_exp.dtype)
+                aai_agg = np.full_like(aai_agg, np.nan, dtype=aai_agg.dtype)
                 LOGGER.warning(
                     "eai_exp and aai_agg are undefined with forecasts. "
-                    "Setting them to empty arrays."
+                    "Setting them to NaN arrays."
                 )
 
         else:
@@ -256,8 +256,7 @@ class ImpactCalc:
             return ImpactForecast.from_impact(
                 impact, self.hazard.lead_time, self.hazard.member
             )
-        else:
-            return impact
+        return impact
 
     def _return_empty(self, save_mat):
         """
@@ -273,13 +272,14 @@ class ImpactCalc:
         Impact or ImpactForecast
             Empty impact object with correct array sizes.
         """
+        at_event = np.zeros(self.n_events)
         if isinstance(self.hazard, HazardForecast):
-            eai_exp = np.nan * np.ones(self.n_exp_pnt)
+            eai_exp = np.full(self.n_exp_pnt, np.nan)
             aai_agg = np.nan
         else:
             eai_exp = np.zeros(self.n_exp_pnt)
             aai_agg = 0.0
-        at_event = np.zeros(self.n_events)
+
         if save_mat:
             imp_mat = sparse.csr_matrix(
                 (self.n_events, self.n_exp_pnt), dtype=np.float64
@@ -287,10 +287,11 @@ class ImpactCalc:
         else:
             if isinstance(self.hazard, HazardForecast):
                 raise ValueError(
-                    "Saving impact matrix is required when using HazardForecast."
+                    "Saving impact matrix is required when using HazardForecast. "
                     "Please set save_mat=True."
                 )
             imp_mat = None
+
         impact = Impact.from_eih(
             self.exposures, self.hazard, at_event, eai_exp, aai_agg, imp_mat
         )
@@ -298,8 +299,7 @@ class ImpactCalc:
             return ImpactForecast.from_impact(
                 impact, self.hazard.lead_time, self.hazard.member
             )
-        else:
-            return impact
+        return impact
 
     def minimal_exp_gdf(
         self, impf_col, assign_centroids, ignore_cover, ignore_deductible

--- a/climada/engine/impact_calc.py
+++ b/climada/engine/impact_calc.py
@@ -233,6 +233,10 @@ class ImpactCalc:
                 imp_mat, self.hazard.frequency
             )
         else:
+            if isinstance(self.hazard, HazardForecast):
+                raise ValueError(
+                    "Saving impact matrix is required when using HazardForecast."
+                )
             imp_mat = None
             at_event, eai_exp, aai_agg = self.stitch_risk_metrics(imp_mat_gen)
 
@@ -270,6 +274,10 @@ class ImpactCalc:
                 (self.n_events, self.n_exp_pnt), dtype=np.float64
             )
         else:
+            if isinstance(self.hazard, HazardForecast):
+                raise ValueError(
+                    "Saving impact matrix is required when using HazardForecast."
+                )
             imp_mat = None
         impact = Impact.from_eih(
             self.exposures, self.hazard, at_event, eai_exp, aai_agg, imp_mat

--- a/climada/engine/impact_calc.py
+++ b/climada/engine/impact_calc.py
@@ -240,8 +240,8 @@ class ImpactCalc:
             self.exposures, self.hazard, at_event, eai_exp, aai_agg, imp_mat
         )
         if isinstance(self.hazard, HazardForecast):
-            return ImpactForecast().from_impact(
-                impact, self.hazard.ensemble_member, self.hazard.lead_time
+            return ImpactForecast.from_impact(
+                impact, self.hazard.lead_time, self.hazard.member
             )  # return ImpactForecast object
         else:
             return (
@@ -275,8 +275,8 @@ class ImpactCalc:
             self.exposures, self.hazard, at_event, eai_exp, aai_agg, imp_mat
         )
         if isinstance(self.hazard, HazardForecast):
-            return ImpactForecast().from_impact(
-                impact, self.hazard.ensemble_member, self.hazard.lead_time
+            return ImpactForecast.from_impact(
+                impact, self.hazard.lead_time, self.hazard.member
             )  # return ImpactForecast object
         else:
             return (

--- a/climada/engine/impact_calc.py
+++ b/climada/engine/impact_calc.py
@@ -232,6 +232,14 @@ class ImpactCalc:
             at_event, eai_exp, aai_agg = self.risk_metrics(
                 imp_mat, self.hazard.frequency
             )
+            if isinstance(self.hazard, HazardForecast):
+                eai_exp = np.nan * np.ones(eai_exp.shape, dtype=eai_exp.dtype)
+                aai_agg = np.nan * np.ones(aai_agg.shape, dtype=aai_agg.dtype)
+                LOGGER.warning(
+                    "eai_exp and aai_agg are undefined with forecasts. "
+                    "Setting them to empty arrays."
+                )
+
         else:
             if isinstance(self.hazard, HazardForecast):
                 raise ValueError(

--- a/climada/engine/impact_calc.py
+++ b/climada/engine/impact_calc.py
@@ -273,9 +273,13 @@ class ImpactCalc:
         Impact or ImpactForecast
             Empty impact object with correct array sizes.
         """
+        if isinstance(self.hazard, HazardForecast):
+            eai_exp = np.nan * np.ones(self.n_exp_pnt)
+            aai_agg = np.nan
+        else:
+            eai_exp = np.zeros(self.n_exp_pnt)
+            aai_agg = 0.0
         at_event = np.zeros(self.n_events)
-        eai_exp = np.zeros(self.n_exp_pnt)
-        aai_agg = 0.0
         if save_mat:
             imp_mat = sparse.csr_matrix(
                 (self.n_events, self.n_exp_pnt), dtype=np.float64

--- a/climada/engine/impact_calc.py
+++ b/climada/engine/impact_calc.py
@@ -236,6 +236,7 @@ class ImpactCalc:
             if isinstance(self.hazard, HazardForecast):
                 raise ValueError(
                     "Saving impact matrix is required when using HazardForecast."
+                    "Please set save_mat=True."
                 )
             imp_mat = None
             at_event, eai_exp, aai_agg = self.stitch_risk_metrics(imp_mat_gen)
@@ -246,11 +247,9 @@ class ImpactCalc:
         if isinstance(self.hazard, HazardForecast):
             return ImpactForecast.from_impact(
                 impact, self.hazard.lead_time, self.hazard.member
-            )  # return ImpactForecast object
-        else:
-            return (
-                impact  # return normal impact object if hazard is not a HazardForecast
             )
+        else:
+            return impact
 
     def _return_empty(self, save_mat):
         """
@@ -277,6 +276,7 @@ class ImpactCalc:
             if isinstance(self.hazard, HazardForecast):
                 raise ValueError(
                     "Saving impact matrix is required when using HazardForecast."
+                    "Please set save_mat=True."
                 )
             imp_mat = None
         impact = Impact.from_eih(
@@ -285,11 +285,9 @@ class ImpactCalc:
         if isinstance(self.hazard, HazardForecast):
             return ImpactForecast.from_impact(
                 impact, self.hazard.lead_time, self.hazard.member
-            )  # return ImpactForecast object
-        else:
-            return (
-                impact  # return normal impact object if hazard is not a HazardForecast
             )
+        else:
+            return impact
 
     def minimal_exp_gdf(
         self, impf_col, assign_centroids, ignore_cover, ignore_deductible

--- a/climada/engine/impact_forecast.py
+++ b/climada/engine/impact_forecast.py
@@ -91,6 +91,7 @@ class ImpactForecast(Forecast, Impact):
 
     @property
     def at_event(self):
+        LOGGER.warning("at_event for forecasts is not yet implemented.")
         return self._at_event
 
     @at_event.setter

--- a/climada/engine/impact_forecast.py
+++ b/climada/engine/impact_forecast.py
@@ -91,13 +91,16 @@ class ImpactForecast(Forecast, Impact):
 
     @property
     def at_event(self):
-        LOGGER.warning("at_event for forecasts is not yet implemented.")
+        """Get the total impact for each member/lead_time combination."""
+        LOGGER.warning(
+            "at_event gives the total impact for one specific combination of member and "
+            "lead_time."
+        )
         return self._at_event
 
     @at_event.setter
     def at_event(self, value):
-        """Set the total exposure value close to a hazard"""
-        LOGGER.warning("at_event for forecasts is not yet implemented.")
+        """Set the total impact for each member/lead_time combination."""
         self._at_event = value
 
     def local_exceedance_impact(
@@ -110,9 +113,14 @@ class ImpactForecast(Forecast, Impact):
         bin_decimals=None,
     ):
         """Compution of local exceedance impact for given return periods is not
-        implemented for ImpactForecast. See climada.engine.impact.Impact for details.
-        Returns
-        -------
+        implemented for ImpactForecast.
+
+        See Also
+        --------
+        See :py:meth:`~climada.engine.impact.Impact.local_exceedance_impact`
+
+        Raises
+        ------
         NotImplementedError
         """
 
@@ -131,8 +139,13 @@ class ImpactForecast(Forecast, Impact):
         bin_decimals=None,
     ):
         """Compution of local return period for given impact thresholds is not
-        implemented for ImpactForecast. See climada.engine.impact.Impact for details.
-        Returns
+        implemented for ImpactForecast.
+
+        See Also
+        --------
+        See :py:meth:`~climada.engine.impact.Impact.local_return_period`
+
+        Raises
         -------
         NotImplementedError
         """
@@ -144,9 +157,14 @@ class ImpactForecast(Forecast, Impact):
 
     def calc_freq_curve(self, return_per=None):
         """Computation of the impact exceedance frequency curve is not
-        implemented for ImpactForecast. See climada.engine.impact.Impact for details.
-        Returns
-        -------
+        implemented for ImpactForecast.
+
+        See Also
+        --------
+        See :py:meth:`~climada.engine.impact.Impact.calc_freq_curve`
+
+        Raises
+        ------
         NotImplementedError
         """
 

--- a/climada/engine/impact_forecast.py
+++ b/climada/engine/impact_forecast.py
@@ -88,3 +88,13 @@ class ImpactForecast(Forecast, Impact):
                 imp_mat=impact.imp_mat,
                 haz_type=impact.haz_type,
             )
+
+    @property
+    def at_event(self):
+        return self._at_event
+
+    @at_event.setter
+    def at_event(self, value):
+        """Set the total exposure value close to a hazard"""
+        LOGGER.warning("at_event for forecasts is not yet implemented.")
+        self._at_event = value

--- a/climada/engine/impact_forecast.py
+++ b/climada/engine/impact_forecast.py
@@ -119,3 +119,35 @@ class ImpactForecast(Forecast, Impact):
         raise NotImplementedError(
             "local_exceedance_impact is not defined for ImpactForecast"
         )
+
+    def local_return_period(
+        self,
+        threshold_impact=(1000.0, 10000.0),
+        method="interpolate",
+        min_impact=0,
+        log_frequency=True,
+        log_impact=True,
+        bin_decimals=None,
+    ):
+        """Compution of local return period for given impact thresholds is not
+        implemented for ImpactForecast. See climada.engine.impact.Impact for details.
+        Returns
+        -------
+        NotImplementedError
+        """
+
+        LOGGER.error("local_return_period is not defined for ImpactForecast")
+        raise NotImplementedError(
+            "local_return_period is not defined for ImpactForecast"
+        )
+
+    def calc_freq_curve(self, return_per=None):
+        """Computation of the impact exceedance frequency curve is not
+        implemented for ImpactForecast. See climada.engine.impact.Impact for details.
+        Returns
+        -------
+        NotImplementedError
+        """
+
+        LOGGER.error("calc_freq_curve is not defined for ImpactForecast")
+        raise NotImplementedError("calc_freq_curve is not defined for ImpactForecast")

--- a/climada/engine/impact_forecast.py
+++ b/climada/engine/impact_forecast.py
@@ -98,3 +98,24 @@ class ImpactForecast(Forecast, Impact):
         """Set the total exposure value close to a hazard"""
         LOGGER.warning("at_event for forecasts is not yet implemented.")
         self._at_event = value
+
+    def local_exceedance_impact(
+        self,
+        return_periods=(25, 50, 100, 250),
+        method="interpolate",
+        min_impact=0,
+        log_frequency=True,
+        log_impact=True,
+        bin_decimals=None,
+    ):
+        """Compution of local exceedance impact for given return periods is not
+        implemented for ImpactForecast. See climada.engine.impact.Impact for details.
+        Returns
+        -------
+        NotImplementedError
+        """
+
+        LOGGER.error("local_exceedance_impact is not defined for ImpactForecast")
+        raise NotImplementedError(
+            "local_exceedance_impact is not defined for ImpactForecast"
+        )

--- a/climada/engine/test/test_impact_calc.py
+++ b/climada/engine/test/test_impact_calc.py
@@ -26,14 +26,17 @@ from unittest.mock import MagicMock, call, create_autospec, patch
 
 import geopandas as gpd
 import numpy as np
+import pandas as pd
 from scipy import sparse
 
 from climada import CONFIG
 from climada.engine import Impact, ImpactCalc
 from climada.engine.impact_calc import LOGGER as ILOG
+from climada.engine.impact_forecast import ImpactForecast
 from climada.entity import Exposures, ImpactFunc, ImpactFuncSet, ImpfTropCyclone
 from climada.entity.entity_def import Entity
 from climada.hazard.base import Centroids, Hazard
+from climada.hazard.forecast import HazardForecast
 from climada.test import get_test_file
 from climada.util.api_client import Client
 from climada.util.config import Config
@@ -47,7 +50,7 @@ DATA_FOLDER.mkdir(exist_ok=True)
 
 
 def check_impact(self, imp, haz, exp, aai_agg, eai_exp, at_event, imp_mat_array=None):
-    """Test properties of imapcts"""
+    """Test properties of impacts"""
     self.assertEqual(len(haz.event_id), len(imp.at_event))
     self.assertIsInstance(imp, Impact)
     np.testing.assert_allclose(imp.coord_exp[:, 0], exp.latitude)
@@ -301,6 +304,89 @@ class TestImpactCalc(unittest.TestCase):
         )
         # fmt: on
         check_impact(self, impact, haz, exp, aai_agg, eai_exp, at_event, imp_mat_array)
+
+    def test_impactForecast(self):
+        """Test that ImpactForecast is returned correctly"""
+        lead_time = pd.timedelta_range("1h", periods=6).to_numpy()
+        member = np.arange(6)
+        _haz = Hazard.from_hdf5(get_test_file("test_hazard_US_flood_random_locations"))
+        haz_fc = HazardForecast.from_hazard(_haz, lead_time=lead_time, member=member)
+
+        exp = Exposures.from_hdf5(
+            get_test_file("test_exposure_US_flood_random_locations")
+        )
+        impf_set = ImpactFuncSet.from_excel(
+            Path(__file__).parent / "data" / "flood_imp_func_set.xls"
+        )
+        icalc = ImpactCalc(exp, impf_set, haz_fc)
+        impact = icalc.impact(assign_centroids=False)
+        aai_agg = 161436.05112960344
+        eai_exp = np.array(
+            [
+                1.61159701e05,
+                1.33742847e02,
+                0.00000000e00,
+                4.21352988e-01,
+                1.42185609e02,
+                0.00000000e00,
+                0.00000000e00,
+                0.00000000e00,
+            ]
+        )
+        at_event = np.array(
+            [
+                0.00000000e00,
+                0.00000000e00,
+                9.85233619e04,
+                3.41245461e04,
+                7.73566566e07,
+                0.00000000e00,
+                0.00000000e00,
+            ]
+        )
+        # fmt: off
+        imp_mat_array = np.array(
+            [
+                [
+                    0.00000000e00, 0.00000000e00, 0.00000000e00, 0.00000000e00,
+                    0.00000000e00, 0.00000000e00, 0.00000000e00, 0.00000000e00,
+                ],
+                [
+                    0.00000000e00, 0.00000000e00, 0.00000000e00, 0.00000000e00,
+                    0.00000000e00, 0.00000000e00, 0.00000000e00, 0.00000000e00,
+                ],
+                [
+                    0.00000000e00, 6.41965663e04, 0.00000000e00, 2.02249434e02,
+                    3.41245461e04, 0.00000000e00, 0.00000000e00, 0.00000000e00,
+                ],
+                [
+                    0.00000000e00, 0.00000000e00, 0.00000000e00, 0.00000000e00,
+                    3.41245461e04, 0.00000000e00, 0.00000000e00, 0.00000000e00,
+                ],
+                [
+                    7.73566566e07, 0.00000000e00, 0.00000000e00, 0.00000000e00,
+                    0.00000000e00, 0.00000000e00, 0.00000000e00, 0.00000000e00,
+                ],
+                [
+                    0.00000000e00, 0.00000000e00, 0.00000000e00, 0.00000000e00,
+                    0.00000000e00, 0.00000000e00, 0.00000000e00, 0.00000000e00,
+                ],
+                [
+                    0.00000000e00, 0.00000000e00, 0.00000000e00, 0.00000000e00,
+                    0.00000000e00, 0.00000000e00, 0.00000000e00, 0.00000000e00,
+                ],
+            ]
+        )
+        # fmt: on
+        check_impact(
+            self, impact, haz_fc, exp, aai_agg, eai_exp, at_event, imp_mat_array
+        )
+
+        # additional test to check that impact is indeed ImpactForecast
+        self.assertIsInstance(impact, ImpactForecast)
+        np.testing.assert_array_equal(impact.lead_time, lead_time)
+        self.assertIs(impact.lead_time.dtype, lead_time.dtype)
+        np.testing.assert_array_equal(impact.member, member)
 
     def test_empty_impact(self):
         """Check that empty impact is returned if no centroids match the exposures"""

--- a/climada/engine/test/test_impact_calc.py
+++ b/climada/engine/test/test_impact_calc.py
@@ -50,8 +50,9 @@ DATA_FOLDER = DEMO_DIR / "test-results"
 DATA_FOLDER.mkdir(exist_ok=True)
 
 
-@pytest.fixture(autouse=True)
-def exposure_fixture(n_exp=50):
+@pytest.fixture(params=[50, 1, 0])
+def exposure(request):
+    n_exp = request.param
     lats = np.linspace(-10, 10, n_exp)
     lons = np.linspace(-10, 10, n_exp)
     data = gpd.GeoDataFrame(
@@ -67,19 +68,19 @@ def exposure_fixture(n_exp=50):
     return exposures
 
 
-@pytest.fixture(autouse=True)
-def hazard_fixture(exposure_fixture):
+@pytest.fixture
+def hazard(exposure):
     n_events = 10
     centroids = Centroids(
-        lat=exposure_fixture.gdf.geometry.x,
-        lon=exposure_fixture.gdf.geometry.y,
+        lat=exposure.gdf.geometry.x,
+        lon=exposure.gdf.geometry.y,
     )
     intensity = sparse.csr_matrix(
-        np.ones((n_events, exposure_fixture.gdf.shape[0])) * 50
+        np.ones((n_events, exposure.gdf.shape[0])) * 50
     )  # uniform intensity
     haz = Hazard()
     haz.event_id = np.arange(n_events)
-    haz.event_name = haz.event_id
+    haz.event_name = haz.event_id.tolist()
     haz.haz_type = "TC"
     haz.date = haz.event_id
     haz.frequency_unit = "m/s"
@@ -89,24 +90,28 @@ def hazard_fixture(exposure_fixture):
     return haz
 
 
-@pytest.fixture(autouse=True)
-def hazard_forecast_fixture(hazard_fixture):
-    n_events = hazard_fixture.size
+@pytest.fixture
+def hazard_forecast(hazard):
+    n_events = hazard.size
     lead_time = pd.timedelta_range("1h", periods=n_events).to_numpy()
-    member = np.arange(10)
+    member = np.arange(n_events)
     haz_fc = HazardForecast.from_hazard(
-        hazard=hazard_fixture,
+        hazard=hazard,
         lead_time=lead_time,
         member=member,
     )
     return haz_fc
 
 
-@pytest.fixture(autouse=True)
-def impact_func_set_fixture(exposure_fixture, hazard_fixture):
+@pytest.fixture
+def impact_func_set(exposure, hazard):
     step_impf = ImpactFunc()
-    step_impf.id = exposure_fixture.data[f"impf_{hazard_fixture.haz_type}"].unique()[0]
-    step_impf.haz_type = hazard_fixture.haz_type
+    step_impf.id = 1
+    try:
+        step_impf.id = exposure.data[f"impf_{hazard.haz_type}"].unique()[0]
+    except IndexError:
+        pass
+    step_impf.haz_type = hazard.haz_type
     step_impf.name = "fixture step function"
     step_impf.intensity_unit = ""
     step_impf.intensity = np.array([0, 0.495, 0.4955, 0.5, 1, 10])
@@ -115,18 +120,12 @@ def impact_func_set_fixture(exposure_fixture, hazard_fixture):
     return ImpactFuncSet([step_impf])
 
 
-@pytest.fixture(autouse=True)
-def impact_calc_fixture(exposure_fixture, hazard_fixture, impact_func_set_fixture):
-    imp_mat = np.ones(
-        (
-            len(hazard_fixture.event_id),
-            exposure_fixture.gdf.shape[0],
-            exposure_fixture.gdf.shape[0],
-        )
-    )
-    aai_agg = np.sum(exposure_fixture.gdf["value"]) * hazard_fixture.frequency[0]
-    eai_exp = np.ones(exposure_fixture.gdf.shape[0]) * hazard_fixture.frequency[0]
-    at_event = np.ones(hazard_fixture.size) * np.sum(exposure_fixture.gdf["value"])
+@pytest.fixture
+def impact_calc(exposure, hazard):
+    imp_mat = np.ones((len(hazard.event_id), exposure.gdf.shape[0]))
+    aai_agg = np.sum(exposure.gdf["value"]) * hazard.frequency[0]
+    eai_exp = np.ones(exposure.gdf.shape[0]) * hazard.frequency[0]
+    at_event = np.ones(hazard.size) * np.sum(exposure.gdf["value"])
     return {
         "imp_mat": imp_mat,
         "aai_agg": aai_agg,
@@ -135,17 +134,18 @@ def impact_calc_fixture(exposure_fixture, hazard_fixture, impact_func_set_fixtur
     }
 
 
-def check_impact(self, imp, haz, exp, aai_agg, eai_exp, at_event, imp_mat_array=None):
+def check_impact(imp, haz, exp, aai_agg, eai_exp, at_event, imp_mat_array=None):
     """Test properties of impacts"""
-    self.assertEqual(len(haz.event_id), len(imp.at_event))
-    self.assertIsInstance(imp, Impact)
+    # NOTE: Correctly compares NaNs!
+    assert len(haz.event_id) == len(imp.at_event)
+    assert isinstance(imp, Impact)
     np.testing.assert_allclose(imp.coord_exp[:, 0], exp.latitude)
     np.testing.assert_allclose(imp.coord_exp[:, 1], exp.longitude)
-    self.assertAlmostEqual(imp.aai_agg, aai_agg, 3)
+    np.testing.assert_allclose(imp.aai_agg, aai_agg, rtol=1e-3)
     np.testing.assert_allclose(imp.eai_exp, eai_exp, rtol=1e-5)
     np.testing.assert_allclose(imp.at_event, at_event, rtol=1e-5)
     if imp_mat_array is not None:
-        np.testing.assert_allclose(imp.imp_mat.toarray().ravel(), imp_mat_array.ravel())
+        np.testing.assert_allclose(imp.imp_mat.todense(), imp_mat_array)
 
 
 class TestImpactCalc(unittest.TestCase):
@@ -389,7 +389,7 @@ class TestImpactCalc(unittest.TestCase):
             ]
         )
         # fmt: on
-        check_impact(self, impact, haz, exp, aai_agg, eai_exp, at_event, imp_mat_array)
+        check_impact(impact, haz, exp, aai_agg, eai_exp, at_event, imp_mat_array)
 
     def test_empty_impact(self):
         """Check that empty impact is returned if no centroids match the exposures"""
@@ -400,11 +400,11 @@ class TestImpactCalc(unittest.TestCase):
         aai_agg = 0.0
         eai_exp = np.zeros(len(exp.gdf))
         at_event = np.zeros(HAZ.size)
-        check_impact(self, impact, HAZ, exp, aai_agg, eai_exp, at_event, None)
+        check_impact(impact, HAZ, exp, aai_agg, eai_exp, at_event, None)
 
         impact = icalc.impact(save_mat=True, assign_centroids=False)
         imp_mat_array = sparse.csr_matrix((HAZ.size, len(exp.gdf))).toarray()
-        check_impact(self, impact, HAZ, exp, aai_agg, eai_exp, at_event, imp_mat_array)
+        check_impact(impact, HAZ, exp, aai_agg, eai_exp, at_event, imp_mat_array)
 
     def test_single_event_impact(self):
         """Check impact for single event"""
@@ -414,11 +414,11 @@ class TestImpactCalc(unittest.TestCase):
         aai_agg = 0.0
         eai_exp = np.zeros(len(ENT.exposures.gdf))
         at_event = np.array([0])
-        check_impact(self, impact, haz, ENT.exposures, aai_agg, eai_exp, at_event, None)
+        check_impact(impact, haz, ENT.exposures, aai_agg, eai_exp, at_event, None)
         impact = icalc.impact(save_mat=True, assign_centroids=False)
         imp_mat_array = sparse.csr_matrix((haz.size, len(ENT.exposures.gdf))).toarray()
         check_impact(
-            self, impact, haz, ENT.exposures, aai_agg, eai_exp, at_event, imp_mat_array
+            impact, haz, ENT.exposures, aai_agg, eai_exp, at_event, imp_mat_array
         )
 
     def test_calc_impact_save_mat_pass(self):
@@ -692,70 +692,47 @@ class TestImpactCalc(unittest.TestCase):
         imp = ImpactCalc(exp, impf_set, haz).impact(
             assign_centroids=False, save_mat=True
         )
-        check_impact(self, imp, haz, exp, aai_agg, eai_exp, at_event, at_event)
+        check_impact(imp, haz, exp, aai_agg, eai_exp, at_event, at_event)
 
 
 class TestImpactCalcForecast:
     """Test impact calc for forecast hazard"""
 
-    def test_impactForecast_type(
+    @pytest.fixture
+    def impact_calc_forecast(self, impact_calc):
+        """Write NaNs to attributes that are not used"""
+        impact_calc["aai_agg"] = np.full_like(impact_calc["aai_agg"], np.nan)
+        impact_calc["eai_exp"] = np.full_like(impact_calc["eai_exp"], np.nan)
+
+    def test_impact_forecast(
         self,
-        exposure_fixture,
-        hazard_forecast_fixture,
-        impact_func_set_fixture,
-        impact_calc_fixture,
+        exposure,
+        hazard_forecast,
+        impact_func_set,
+        impact_calc,
+        impact_calc_forecast,
     ):
         """Test that ImpactForecast is returned correctly"""
-        impact = ImpactCalc(
-            exposure_fixture, impact_func_set_fixture, hazard_forecast_fixture
-        ).impact(assign_centroids=True, save_mat=True)
-        # check that impact is indeed ImpactForecast
-        assert isinstance(impact, ImpactForecast)
-        np.testing.assert_array_equal(
-            impact.lead_time, hazard_forecast_fixture.lead_time
+        impact = ImpactCalc(exposure, impact_func_set, hazard_forecast).impact(
+            assign_centroids=True, save_mat=True
         )
-        assert impact.lead_time.dtype == hazard_forecast_fixture.lead_time.dtype
-        np.testing.assert_array_equal(impact.member, hazard_forecast_fixture.member)
+        # check that impact is indeed ImpactForecast
+        impact_calc["imp_mat_array"] = impact_calc.pop("imp_mat")
+        check_impact(imp=impact, haz=hazard_forecast, exp=exposure, **impact_calc)
+        assert isinstance(impact, ImpactForecast)
+        np.testing.assert_array_equal(impact.lead_time, hazard_forecast.lead_time)
+        assert impact.lead_time.dtype == hazard_forecast.lead_time.dtype
+        np.testing.assert_array_equal(impact.member, hazard_forecast.member)
 
     def test_impact_forecast_empty_impmat_error(
-        self, hazard_forecast_fixture, exposure_fixture, impact_func_set_fixture
+        self, hazard_forecast, exposure, impact_func_set
     ):
         """Test that error is raised when trying to compute impact forecast
         without saving impact matrix
         """
-        icalc = ImpactCalc(
-            exposure_fixture, impact_func_set_fixture, hazard_forecast_fixture
-        )
-        no_impmat_exception = (
-            "Saving impact matrix is required when using HazardForecast."
-            "Please set save_mat=True."
-        )
-        with pytest.raises(ValueError) as cm:
+        icalc = ImpactCalc(exposure, impact_func_set, hazard_forecast)
+        with pytest.raises(ValueError, match="Saving impact matrix is required"):
             icalc.impact(assign_centroids=True, save_mat=False)
-        assert no_impmat_exception == str(cm.value)
-
-    def test_impact_forecast_blocked_nonsense_attrs(
-        self, hazard_forecast_fixture, exposure_fixture, impact_func_set_fixture
-    ):
-        """Test that nonsense attributes are blocked when computing impact forecast"""
-        lead_time = hazard_forecast_fixture.lead_time
-        member = hazard_forecast_fixture.member
-
-        impact = ImpactCalc(
-            exposure_fixture, impact_func_set_fixture, hazard_forecast_fixture
-        ).impact(assign_centroids=True, save_mat=True)
-        assert np.isnan(impact.aai_agg)
-        assert np.all(np.isnan(impact.eai_exp))
-        assert impact.eai_exp.shape == (len(exposure_fixture.gdf),)
-
-        # test that aai_agg and eai_exp are also nan when 0-size exp
-        empty_exp = exposure_fixture(n_exp=0)
-        impact_empty = ImpactCalc(
-            exposure_fixture, impact_func_set_fixture, hazard_forecast_fixture
-        ).impact(assign_centroids=True, save_mat=True)
-        assert np.isnan(impact_empty.aai_agg)
-        assert np.all(np.isnan(impact_empty.eai_exp))
-        assert impact_empty.eai_exp.shape == (len(empty_exp.gdf),)
 
 
 class TestImpactMatrixCalc(unittest.TestCase):

--- a/climada/engine/test/test_impact_calc.py
+++ b/climada/engine/test/test_impact_calc.py
@@ -51,8 +51,7 @@ DATA_FOLDER.mkdir(exist_ok=True)
 
 
 @pytest.fixture(autouse=True)
-def exposure_fixture():
-    n_exp = 50
+def exposure_fixture(n_exp=50):
     lats = np.linspace(-10, 10, n_exp)
     lons = np.linspace(-10, 10, n_exp)
     data = gpd.GeoDataFrame(
@@ -748,6 +747,15 @@ class TestImpactCalcForecast:
         assert np.isnan(impact.aai_agg)
         assert np.all(np.isnan(impact.eai_exp))
         assert impact.eai_exp.shape == (len(exposure_fixture.gdf),)
+
+        # test that aai_agg and eai_exp are also nan when 0-size exp
+        empty_exp = exposure_fixture(n_exp=0)
+        impact_empty = ImpactCalc(
+            exposure_fixture, impact_func_set_fixture, hazard_forecast_fixture
+        ).impact(assign_centroids=True, save_mat=True)
+        assert np.isnan(impact_empty.aai_agg)
+        assert np.all(np.isnan(impact_empty.eai_exp))
+        assert impact_empty.eai_exp.shape == (len(empty_exp.gdf),)
 
 
 class TestImpactMatrixCalc(unittest.TestCase):

--- a/climada/engine/test/test_impact_calc.py
+++ b/climada/engine/test/test_impact_calc.py
@@ -305,113 +305,6 @@ class TestImpactCalc(unittest.TestCase):
         # fmt: on
         check_impact(self, impact, haz, exp, aai_agg, eai_exp, at_event, imp_mat_array)
 
-    def test_impactForecast(self):
-        """Test that ImpactForecast is returned correctly"""
-        lead_time = pd.timedelta_range("1h", periods=6).to_numpy()
-        member = np.arange(6)
-        _haz = Hazard.from_hdf5(get_test_file("test_hazard_US_flood_random_locations"))
-        haz_fc = HazardForecast.from_hazard(_haz, lead_time=lead_time, member=member)
-
-        exp = Exposures.from_hdf5(
-            get_test_file("test_exposure_US_flood_random_locations")
-        )
-        impf_set = ImpactFuncSet.from_excel(
-            Path(__file__).parent / "data" / "flood_imp_func_set.xls"
-        )
-        icalc = ImpactCalc(exp, impf_set, haz_fc)
-        impact = icalc.impact(assign_centroids=False)
-        aai_agg = 161436.05112960344
-        eai_exp = np.array(
-            [
-                1.61159701e05,
-                1.33742847e02,
-                0.00000000e00,
-                4.21352988e-01,
-                1.42185609e02,
-                0.00000000e00,
-                0.00000000e00,
-                0.00000000e00,
-            ]
-        )
-        at_event = np.array(
-            [
-                0.00000000e00,
-                0.00000000e00,
-                9.85233619e04,
-                3.41245461e04,
-                7.73566566e07,
-                0.00000000e00,
-                0.00000000e00,
-            ]
-        )
-        # fmt: off
-        imp_mat_array = np.array(
-            [
-                [
-                    0.00000000e00, 0.00000000e00, 0.00000000e00, 0.00000000e00,
-                    0.00000000e00, 0.00000000e00, 0.00000000e00, 0.00000000e00,
-                ],
-                [
-                    0.00000000e00, 0.00000000e00, 0.00000000e00, 0.00000000e00,
-                    0.00000000e00, 0.00000000e00, 0.00000000e00, 0.00000000e00,
-                ],
-                [
-                    0.00000000e00, 6.41965663e04, 0.00000000e00, 2.02249434e02,
-                    3.41245461e04, 0.00000000e00, 0.00000000e00, 0.00000000e00,
-                ],
-                [
-                    0.00000000e00, 0.00000000e00, 0.00000000e00, 0.00000000e00,
-                    3.41245461e04, 0.00000000e00, 0.00000000e00, 0.00000000e00,
-                ],
-                [
-                    7.73566566e07, 0.00000000e00, 0.00000000e00, 0.00000000e00,
-                    0.00000000e00, 0.00000000e00, 0.00000000e00, 0.00000000e00,
-                ],
-                [
-                    0.00000000e00, 0.00000000e00, 0.00000000e00, 0.00000000e00,
-                    0.00000000e00, 0.00000000e00, 0.00000000e00, 0.00000000e00,
-                ],
-                [
-                    0.00000000e00, 0.00000000e00, 0.00000000e00, 0.00000000e00,
-                    0.00000000e00, 0.00000000e00, 0.00000000e00, 0.00000000e00,
-                ],
-            ]
-        )
-        # fmt: on
-        check_impact(
-            self, impact, haz_fc, exp, aai_agg, eai_exp, at_event, imp_mat_array
-        )
-
-        # additional test to check that impact is indeed ImpactForecast
-        self.assertIsInstance(impact, ImpactForecast)
-        np.testing.assert_array_equal(impact.lead_time, lead_time)
-        self.assertIs(impact.lead_time.dtype, lead_time.dtype)
-        np.testing.assert_array_equal(impact.member, member)
-
-    def test_impact_forecast_empty_impmat_error(self):
-        """Test that error is raised when trying to compute impact forecast
-        without saving impact matrix
-        """
-        lead_time = pd.timedelta_range("1h", periods=6).to_numpy()
-        member = np.arange(6)
-        _haz = Hazard.from_hdf5(get_test_file("test_hazard_US_flood_random_locations"))
-        haz_fc = HazardForecast.from_hazard(_haz, lead_time=lead_time, member=member)
-
-        exp = Exposures.from_hdf5(
-            get_test_file("test_exposure_US_flood_random_locations")
-        )
-        impf_set = ImpactFuncSet.from_excel(
-            Path(__file__).parent / "data" / "flood_imp_func_set.xls"
-        )
-        icalc = ImpactCalc(exp, impf_set, haz_fc)
-        with self.assertRaises(ValueError) as cm:
-            icalc.impact(assign_centroids=False, save_mat=False)
-        the_exception = cm.exception
-        self.assertEqual(
-            the_exception.args[0],
-            "Saving impact matrix is required when using HazardForecast.",
-        )
-
     def test_empty_impact(self):
         """Check that empty impact is returned if no centroids match the exposures"""
         exp = ENT.exposures.copy()
@@ -716,6 +609,118 @@ class TestImpactCalc(unittest.TestCase):
         check_impact(self, imp, haz, exp, aai_agg, eai_exp, at_event, at_event)
 
 
+class TestImpactCalcForecast(unittest.TestCase):
+    """Test impact calc for forecast hazard"""
+
+    def test_impactForecast(self):
+        """Test that ImpactForecast is returned correctly"""
+        lead_time = pd.timedelta_range("1h", periods=6).to_numpy()
+        member = np.arange(6)
+        _haz = Hazard.from_hdf5(get_test_file("test_hazard_US_flood_random_locations"))
+        haz_fc = HazardForecast.from_hazard(_haz, lead_time=lead_time, member=member)
+
+        exp = Exposures.from_hdf5(
+            get_test_file("test_exposure_US_flood_random_locations")
+        )
+        impf_set = ImpactFuncSet.from_excel(
+            Path(__file__).parent / "data" / "flood_imp_func_set.xls"
+        )
+        icalc = ImpactCalc(exp, impf_set, haz_fc)
+        impact = icalc.impact(assign_centroids=False)
+        aai_agg = 161436.05112960344
+        eai_exp = np.array(
+            [
+                1.61159701e05,
+                1.33742847e02,
+                0.00000000e00,
+                4.21352988e-01,
+                1.42185609e02,
+                0.00000000e00,
+                0.00000000e00,
+                0.00000000e00,
+            ]
+        )
+        at_event = np.array(
+            [
+                0.00000000e00,
+                0.00000000e00,
+                9.85233619e04,
+                3.41245461e04,
+                7.73566566e07,
+                0.00000000e00,
+                0.00000000e00,
+            ]
+        )
+        # fmt: off
+        imp_mat_array = np.array(
+            [
+                [
+                    0.00000000e00, 0.00000000e00, 0.00000000e00, 0.00000000e00,
+                    0.00000000e00, 0.00000000e00, 0.00000000e00, 0.00000000e00,
+                ],
+                [
+                    0.00000000e00, 0.00000000e00, 0.00000000e00, 0.00000000e00,
+                    0.00000000e00, 0.00000000e00, 0.00000000e00, 0.00000000e00,
+                ],
+                [
+                    0.00000000e00, 6.41965663e04, 0.00000000e00, 2.02249434e02,
+                    3.41245461e04, 0.00000000e00, 0.00000000e00, 0.00000000e00,
+                ],
+                [
+                    0.00000000e00, 0.00000000e00, 0.00000000e00, 0.00000000e00,
+                    3.41245461e04, 0.00000000e00, 0.00000000e00, 0.00000000e00,
+                ],
+                [
+                    7.73566566e07, 0.00000000e00, 0.00000000e00, 0.00000000e00,
+                    0.00000000e00, 0.00000000e00, 0.00000000e00, 0.00000000e00,
+                ],
+                [
+                    0.00000000e00, 0.00000000e00, 0.00000000e00, 0.00000000e00,
+                    0.00000000e00, 0.00000000e00, 0.00000000e00, 0.00000000e00,
+                ],
+                [
+                    0.00000000e00, 0.00000000e00, 0.00000000e00, 0.00000000e00,
+                    0.00000000e00, 0.00000000e00, 0.00000000e00, 0.00000000e00,
+                ],
+            ]
+        )
+        # fmt: on
+        check_impact(
+            self, impact, haz_fc, exp, aai_agg, eai_exp, at_event, imp_mat_array
+        )
+
+        # additional test to check that impact is indeed ImpactForecast
+        self.assertIsInstance(impact, ImpactForecast)
+        np.testing.assert_array_equal(impact.lead_time, lead_time)
+        self.assertIs(impact.lead_time.dtype, lead_time.dtype)
+        np.testing.assert_array_equal(impact.member, member)
+
+    def test_impact_forecast_empty_impmat_error(self):
+        """Test that error is raised when trying to compute impact forecast
+        without saving impact matrix
+        """
+        lead_time = pd.timedelta_range("1h", periods=6).to_numpy()
+        member = np.arange(6)
+        _haz = Hazard.from_hdf5(get_test_file("test_hazard_US_flood_random_locations"))
+        haz_fc = HazardForecast.from_hazard(_haz, lead_time=lead_time, member=member)
+
+        exp = Exposures.from_hdf5(
+            get_test_file("test_exposure_US_flood_random_locations")
+        )
+        impf_set = ImpactFuncSet.from_excel(
+            Path(__file__).parent / "data" / "flood_imp_func_set.xls"
+        )
+        icalc = ImpactCalc(exp, impf_set, haz_fc)
+        with self.assertRaises(ValueError) as cm:
+            icalc.impact(assign_centroids=False, save_mat=False)
+        no_impmat_exception = cm.exception
+        self.assertEqual(
+            no_impmat_exception.args[0],
+            "Saving impact matrix is required when using HazardForecast."
+            "Please set save_mat=True.",
+        )
+
+
 class TestImpactMatrixCalc(unittest.TestCase):
     """Verify the computation of the impact matrix"""
 
@@ -1011,6 +1016,7 @@ class TestReturnImpact(unittest.TestCase):
 # Execute Tests
 if __name__ == "__main__":
     TESTS = unittest.TestLoader().loadTestsFromTestCase(TestImpactCalc)
+    TESTS.addTests(unittest.TestLoader().loadTestsFromTestCase(TestImpactCalcForecast))
     TESTS.addTests(unittest.TestLoader().loadTestsFromTestCase(TestReturnImpact))
     TESTS.addTests(unittest.TestLoader().loadTestsFromTestCase(TestImpactMatrix))
     TESTS.addTests(unittest.TestLoader().loadTestsFromTestCase(TestImpactMatrixCalc))

--- a/climada/engine/test/test_impact_calc.py
+++ b/climada/engine/test/test_impact_calc.py
@@ -720,6 +720,26 @@ class TestImpactCalcForecast(unittest.TestCase):
             "Please set save_mat=True.",
         )
 
+    def test_impact_forecast_blocked_nonsense_attrs(self):
+        """Test that nonsense attributes are blocked when computing impact forecast"""
+        lead_time = pd.timedelta_range("1h", periods=6).to_numpy()
+        member = np.arange(6)
+        haz = Hazard.from_hdf5(get_test_file("test_hazard_US_flood_random_locations"))
+        haz_fc = HazardForecast.from_hazard(haz, lead_time=lead_time, member=member)
+
+        exp = Exposures.from_hdf5(
+            get_test_file("test_exposure_US_flood_random_locations")
+        )
+        impf_set = ImpactFuncSet.from_excel(
+            Path(__file__).parent / "data" / "flood_imp_func_set.xls"
+        )
+        impact = ImpactCalc(exp, impf_set, haz_fc).impact(
+            assign_centroids=False, save_mat=True
+        )
+        assert np.isnan(impact.aai_agg)
+        assert np.all(np.isnan(impact.eai_exp))
+        assert impact.eai_exp.shape == (len(exp.gdf),)
+
 
 class TestImpactMatrixCalc(unittest.TestCase):
     """Verify the computation of the impact matrix"""

--- a/climada/engine/test/test_impact_calc.py
+++ b/climada/engine/test/test_impact_calc.py
@@ -75,11 +75,15 @@ def hazard_fixture(exposure_fixture):
         lat=exposure_fixture.gdf.geometry.x,
         lon=exposure_fixture.gdf.geometry.y,
     )
-    intensity = (
+    intensity = sparse.csr_matrix(
         np.ones((n_events, exposure_fixture.gdf.shape[0])) * 50
     )  # uniform intensity
     haz = Hazard()
+    haz.event_id = np.arange(n_events)
+    haz.event_name = haz.event_id
     haz.haz_type = "TC"
+    haz.date = haz.event_id
+    haz.frequency_unit = "m/s"
     haz.centroids = centroids
     haz.intensity = intensity
     haz.frequency = 1 / 10 * np.ones(n_events)  # uniform frequency (10 n_events)
@@ -696,13 +700,16 @@ class TestImpactCalcForecast:
     """Test impact calc for forecast hazard"""
 
     def test_impactForecast_type(
+        self,
         exposure_fixture,
         hazard_forecast_fixture,
         impact_func_set_fixture,
         impact_calc_fixture,
     ):
         """Test that ImpactForecast is returned correctly"""
-
+        impact = ImpactCalc(
+            exposure_fixture, impact_func_set_fixture, hazard_forecast_fixture
+        ).impact(assign_centroids=True, save_mat=True)
         # check that impact is indeed ImpactForecast
         assert isinstance(impact, ImpactForecast)
         np.testing.assert_array_equal(
@@ -712,7 +719,7 @@ class TestImpactCalcForecast:
         np.testing.assert_array_equal(impact.member, hazard_forecast_fixture.member)
 
     def test_impact_forecast_empty_impmat_error(
-        hazard_forecast_fixture, exposure_fixture, impact_func_set_fixture
+        self, hazard_forecast_fixture, exposure_fixture, impact_func_set_fixture
     ):
         """Test that error is raised when trying to compute impact forecast
         without saving impact matrix
@@ -720,21 +727,20 @@ class TestImpactCalcForecast:
         icalc = ImpactCalc(
             exposure_fixture, impact_func_set_fixture, hazard_forecast_fixture
         )
-        with self.assertRaises(ValueError) as cm:
-            icalc.impact(assign_centroids=False, save_mat=False)
-        no_impmat_exception = cm.exception
-        self.assertEqual(
-            no_impmat_exception.args[0],
+        no_impmat_exception = (
             "Saving impact matrix is required when using HazardForecast."
-            "Please set save_mat=True.",
+            "Please set save_mat=True."
         )
+        with pytest.raises(ValueError) as cm:
+            icalc.impact(assign_centroids=True, save_mat=False)
+        assert no_impmat_exception == str(cm.value)
 
     def test_impact_forecast_blocked_nonsense_attrs(
-        hazard_forecast_fixture, exposure_fixture, impact_func_set_fixture
+        self, hazard_forecast_fixture, exposure_fixture, impact_func_set_fixture
     ):
         """Test that nonsense attributes are blocked when computing impact forecast"""
-        lead_time = hazard_fixture.lead_time
-        member = hazard_fixture.member
+        lead_time = hazard_forecast_fixture.lead_time
+        member = hazard_forecast_fixture.member
 
         impact = ImpactCalc(
             exposure_fixture, impact_func_set_fixture, hazard_forecast_fixture

--- a/climada/engine/test/test_impact_calc.py
+++ b/climada/engine/test/test_impact_calc.py
@@ -27,6 +27,7 @@ from unittest.mock import MagicMock, call, create_autospec, patch
 import geopandas as gpd
 import numpy as np
 import pandas as pd
+import pytest
 from scipy import sparse
 
 from climada import CONFIG
@@ -47,6 +48,88 @@ HAZ = Hazard.from_hdf5(get_test_file("test_tc_florida"))
 
 DATA_FOLDER = DEMO_DIR / "test-results"
 DATA_FOLDER.mkdir(exist_ok=True)
+
+
+@pytest.fixture(autouse=True)
+def exposure_fixture():
+    n_exp = 50
+    lats = np.linspace(-10, 10, n_exp)
+    lons = np.linspace(-10, 10, n_exp)
+    data = gpd.GeoDataFrame(
+        {
+            "impf_TC": 1,
+            "value": 1,
+        },
+        index=range(n_exp),
+        geometry=gpd.points_from_xy(lons, lats),
+        crs="EPSG:4326",
+    )
+    exposures = Exposures(data=data)
+    return exposures
+
+
+@pytest.fixture(autouse=True)
+def hazard_fixture(exposure_fixture):
+    n_events = 10
+    centroids = Centroids(
+        lat=exposure_fixture.gdf.geometry.x,
+        lon=exposure_fixture.gdf.geometry.y,
+    )
+    intensity = (
+        np.ones((n_events, exposure_fixture.gdf.shape[0])) * 50
+    )  # uniform intensity
+    haz = Hazard()
+    haz.haz_type = "TC"
+    haz.centroids = centroids
+    haz.intensity = intensity
+    haz.frequency = 1 / 10 * np.ones(n_events)  # uniform frequency (10 n_events)
+    return haz
+
+
+@pytest.fixture(autouse=True)
+def hazard_forecast_fixture(hazard_fixture):
+    n_events = hazard_fixture.size
+    lead_time = pd.timedelta_range("1h", periods=n_events).to_numpy()
+    member = np.arange(10)
+    haz_fc = HazardForecast.from_hazard(
+        hazard=hazard_fixture,
+        lead_time=lead_time,
+        member=member,
+    )
+    return haz_fc
+
+
+@pytest.fixture(autouse=True)
+def impact_func_set_fixture(exposure_fixture, hazard_fixture):
+    step_impf = ImpactFunc()
+    step_impf.id = exposure_fixture.data[f"impf_{hazard_fixture.haz_type}"].unique()[0]
+    step_impf.haz_type = hazard_fixture.haz_type
+    step_impf.name = "fixture step function"
+    step_impf.intensity_unit = ""
+    step_impf.intensity = np.array([0, 0.495, 0.4955, 0.5, 1, 10])
+    step_impf.mdd = np.array([0, 0, 0, 1, 1, 1])
+    step_impf.paa = np.sort(np.linspace(1, 1, num=6))
+    return ImpactFuncSet([step_impf])
+
+
+@pytest.fixture(autouse=True)
+def impact_calc_fixture(exposure_fixture, hazard_fixture, impact_func_set_fixture):
+    imp_mat = np.ones(
+        (
+            len(hazard_fixture.event_id),
+            exposure_fixture.gdf.shape[0],
+            exposure_fixture.gdf.shape[0],
+        )
+    )
+    aai_agg = np.sum(exposure_fixture.gdf["value"]) * hazard_fixture.frequency[0]
+    eai_exp = np.ones(exposure_fixture.gdf.shape[0]) * hazard_fixture.frequency[0]
+    at_event = np.ones(hazard_fixture.size) * np.sum(exposure_fixture.gdf["value"])
+    return {
+        "imp_mat": imp_mat,
+        "aai_agg": aai_agg,
+        "eai_exp": eai_exp,
+        "at_event": at_event,
+    }
 
 
 def check_impact(self, imp, haz, exp, aai_agg, eai_exp, at_event, imp_mat_array=None):
@@ -609,108 +692,34 @@ class TestImpactCalc(unittest.TestCase):
         check_impact(self, imp, haz, exp, aai_agg, eai_exp, at_event, at_event)
 
 
-class TestImpactCalcForecast(unittest.TestCase):
+class TestImpactCalcForecast:
     """Test impact calc for forecast hazard"""
 
-    def test_impactForecast(self):
+    def test_impactForecast_type(
+        exposure_fixture,
+        hazard_forecast_fixture,
+        impact_func_set_fixture,
+        impact_calc_fixture,
+    ):
         """Test that ImpactForecast is returned correctly"""
-        lead_time = pd.timedelta_range("1h", periods=6).to_numpy()
-        member = np.arange(6)
-        _haz = Hazard.from_hdf5(get_test_file("test_hazard_US_flood_random_locations"))
-        haz_fc = HazardForecast.from_hazard(_haz, lead_time=lead_time, member=member)
 
-        exp = Exposures.from_hdf5(
-            get_test_file("test_exposure_US_flood_random_locations")
+        # check that impact is indeed ImpactForecast
+        assert isinstance(impact, ImpactForecast)
+        np.testing.assert_array_equal(
+            impact.lead_time, hazard_forecast_fixture.lead_time
         )
-        impf_set = ImpactFuncSet.from_excel(
-            Path(__file__).parent / "data" / "flood_imp_func_set.xls"
-        )
-        icalc = ImpactCalc(exp, impf_set, haz_fc)
-        impact = icalc.impact(assign_centroids=False)
-        aai_agg = 161436.05112960344
-        eai_exp = np.array(
-            [
-                1.61159701e05,
-                1.33742847e02,
-                0.00000000e00,
-                4.21352988e-01,
-                1.42185609e02,
-                0.00000000e00,
-                0.00000000e00,
-                0.00000000e00,
-            ]
-        )
-        at_event = np.array(
-            [
-                0.00000000e00,
-                0.00000000e00,
-                9.85233619e04,
-                3.41245461e04,
-                7.73566566e07,
-                0.00000000e00,
-                0.00000000e00,
-            ]
-        )
-        # fmt: off
-        imp_mat_array = np.array(
-            [
-                [
-                    0.00000000e00, 0.00000000e00, 0.00000000e00, 0.00000000e00,
-                    0.00000000e00, 0.00000000e00, 0.00000000e00, 0.00000000e00,
-                ],
-                [
-                    0.00000000e00, 0.00000000e00, 0.00000000e00, 0.00000000e00,
-                    0.00000000e00, 0.00000000e00, 0.00000000e00, 0.00000000e00,
-                ],
-                [
-                    0.00000000e00, 6.41965663e04, 0.00000000e00, 2.02249434e02,
-                    3.41245461e04, 0.00000000e00, 0.00000000e00, 0.00000000e00,
-                ],
-                [
-                    0.00000000e00, 0.00000000e00, 0.00000000e00, 0.00000000e00,
-                    3.41245461e04, 0.00000000e00, 0.00000000e00, 0.00000000e00,
-                ],
-                [
-                    7.73566566e07, 0.00000000e00, 0.00000000e00, 0.00000000e00,
-                    0.00000000e00, 0.00000000e00, 0.00000000e00, 0.00000000e00,
-                ],
-                [
-                    0.00000000e00, 0.00000000e00, 0.00000000e00, 0.00000000e00,
-                    0.00000000e00, 0.00000000e00, 0.00000000e00, 0.00000000e00,
-                ],
-                [
-                    0.00000000e00, 0.00000000e00, 0.00000000e00, 0.00000000e00,
-                    0.00000000e00, 0.00000000e00, 0.00000000e00, 0.00000000e00,
-                ],
-            ]
-        )
-        # fmt: on
-        check_impact(
-            self, impact, haz_fc, exp, aai_agg, eai_exp, at_event, imp_mat_array
-        )
+        assert impact.lead_time.dtype == hazard_forecast_fixture.lead_time.dtype
+        np.testing.assert_array_equal(impact.member, hazard_forecast_fixture.member)
 
-        # additional test to check that impact is indeed ImpactForecast
-        self.assertIsInstance(impact, ImpactForecast)
-        np.testing.assert_array_equal(impact.lead_time, lead_time)
-        self.assertIs(impact.lead_time.dtype, lead_time.dtype)
-        np.testing.assert_array_equal(impact.member, member)
-
-    def test_impact_forecast_empty_impmat_error(self):
+    def test_impact_forecast_empty_impmat_error(
+        hazard_forecast_fixture, exposure_fixture, impact_func_set_fixture
+    ):
         """Test that error is raised when trying to compute impact forecast
         without saving impact matrix
         """
-        lead_time = pd.timedelta_range("1h", periods=6).to_numpy()
-        member = np.arange(6)
-        _haz = Hazard.from_hdf5(get_test_file("test_hazard_US_flood_random_locations"))
-        haz_fc = HazardForecast.from_hazard(_haz, lead_time=lead_time, member=member)
-
-        exp = Exposures.from_hdf5(
-            get_test_file("test_exposure_US_flood_random_locations")
+        icalc = ImpactCalc(
+            exposure_fixture, impact_func_set_fixture, hazard_forecast_fixture
         )
-        impf_set = ImpactFuncSet.from_excel(
-            Path(__file__).parent / "data" / "flood_imp_func_set.xls"
-        )
-        icalc = ImpactCalc(exp, impf_set, haz_fc)
         with self.assertRaises(ValueError) as cm:
             icalc.impact(assign_centroids=False, save_mat=False)
         no_impmat_exception = cm.exception
@@ -720,25 +729,19 @@ class TestImpactCalcForecast(unittest.TestCase):
             "Please set save_mat=True.",
         )
 
-    def test_impact_forecast_blocked_nonsense_attrs(self):
+    def test_impact_forecast_blocked_nonsense_attrs(
+        hazard_forecast_fixture, exposure_fixture, impact_func_set_fixture
+    ):
         """Test that nonsense attributes are blocked when computing impact forecast"""
-        lead_time = pd.timedelta_range("1h", periods=6).to_numpy()
-        member = np.arange(6)
-        haz = Hazard.from_hdf5(get_test_file("test_hazard_US_flood_random_locations"))
-        haz_fc = HazardForecast.from_hazard(haz, lead_time=lead_time, member=member)
+        lead_time = hazard_fixture.lead_time
+        member = hazard_fixture.member
 
-        exp = Exposures.from_hdf5(
-            get_test_file("test_exposure_US_flood_random_locations")
-        )
-        impf_set = ImpactFuncSet.from_excel(
-            Path(__file__).parent / "data" / "flood_imp_func_set.xls"
-        )
-        impact = ImpactCalc(exp, impf_set, haz_fc).impact(
-            assign_centroids=False, save_mat=True
-        )
+        impact = ImpactCalc(
+            exposure_fixture, impact_func_set_fixture, hazard_forecast_fixture
+        ).impact(assign_centroids=True, save_mat=True)
         assert np.isnan(impact.aai_agg)
         assert np.all(np.isnan(impact.eai_exp))
-        assert impact.eai_exp.shape == (len(exp.gdf),)
+        assert impact.eai_exp.shape == (len(exposure_fixture.gdf),)
 
 
 class TestImpactMatrixCalc(unittest.TestCase):

--- a/climada/engine/test/test_impact_calc.py
+++ b/climada/engine/test/test_impact_calc.py
@@ -692,7 +692,7 @@ class TestImpactCalc(unittest.TestCase):
         imp = ImpactCalc(exp, impf_set, haz).impact(
             assign_centroids=False, save_mat=True
         )
-        check_impact(imp, haz, exp, aai_agg, eai_exp, at_event, at_event)
+        check_impact(imp, haz, exp, aai_agg, eai_exp, at_event, np.array([at_event]).T)
 
 
 class TestImpactCalcForecast:

--- a/climada/engine/test/test_impact_calc.py
+++ b/climada/engine/test/test_impact_calc.py
@@ -388,6 +388,30 @@ class TestImpactCalc(unittest.TestCase):
         self.assertIs(impact.lead_time.dtype, lead_time.dtype)
         np.testing.assert_array_equal(impact.member, member)
 
+    def test_impact_forecast_empty_impmat_error(self):
+        """Test that error is raised when trying to compute impact forecast
+        without saving impact matrix
+        """
+        lead_time = pd.timedelta_range("1h", periods=6).to_numpy()
+        member = np.arange(6)
+        _haz = Hazard.from_hdf5(get_test_file("test_hazard_US_flood_random_locations"))
+        haz_fc = HazardForecast.from_hazard(_haz, lead_time=lead_time, member=member)
+
+        exp = Exposures.from_hdf5(
+            get_test_file("test_exposure_US_flood_random_locations")
+        )
+        impf_set = ImpactFuncSet.from_excel(
+            Path(__file__).parent / "data" / "flood_imp_func_set.xls"
+        )
+        icalc = ImpactCalc(exp, impf_set, haz_fc)
+        with self.assertRaises(ValueError) as cm:
+            icalc.impact(assign_centroids=False, save_mat=False)
+        the_exception = cm.exception
+        self.assertEqual(
+            the_exception.args[0],
+            "Saving impact matrix is required when using HazardForecast.",
+        )
+
     def test_empty_impact(self):
         """Check that empty impact is returned if no centroids match the exposures"""
         exp = ENT.exposures.copy()

--- a/climada/engine/test/test_impact_forecast.py
+++ b/climada/engine/test/test_impact_forecast.py
@@ -105,7 +105,13 @@ def test_impact_forecast_concat(impact_forecast, member):
     npt.assert_array_equal(impact_fc.member, np.concatenate([member, member]))
 
 
-def test_impact_forecast_exceedance_freq_curve_error(impact_forecast):
+def test_impact_forecast_blocked_methods(impact_forecast):
     """Check if ImpactForecast.exceedance_freq_curve raises NotImplementedError"""
     with pytest.raises(NotImplementedError):
         impact_forecast.local_exceedance_impact(np.array([10, 50, 100]))
+
+    with pytest.raises(NotImplementedError):
+        impact_forecast.local_return_period(np.array([10, 50, 100]))
+
+    with pytest.raises(NotImplementedError):
+        impact_forecast.calc_freq_curve(np.array([10, 50, 100]))

--- a/climada/engine/test/test_impact_forecast.py
+++ b/climada/engine/test/test_impact_forecast.py
@@ -106,7 +106,7 @@ def test_impact_forecast_concat(impact_forecast, member):
 
 
 def test_impact_forecast_blocked_methods(impact_forecast):
-    """Check if ImpactForecast.exceedance_freq_curve raises NotImplementedError"""
+    """Check if blocked methods raise NotImplementedError"""
     with pytest.raises(NotImplementedError):
         impact_forecast.local_exceedance_impact(np.array([10, 50, 100]))
 

--- a/climada/engine/test/test_impact_forecast.py
+++ b/climada/engine/test/test_impact_forecast.py
@@ -103,3 +103,9 @@ def test_impact_forecast_concat(impact_forecast, member):
         [impact_forecast, impact_forecast], reset_event_ids=True
     )
     npt.assert_array_equal(impact_fc.member, np.concatenate([member, member]))
+
+
+def test_impact_forecast_exceedance_freq_curve_error(impact_forecast):
+    """Check if ImpactForecast.exceedance_freq_curve raises NotImplementedError"""
+    with pytest.raises(NotImplementedError):
+        impact_forecast.local_exceedance_impact(np.array([10, 50, 100]))


### PR DESCRIPTION
Changes proposed in this PR:
- Make ImapctCalc return ImpactForecast object when hazardForecast object is passed

This PR fixes #1138 #1135 

### PR Author Checklist

- [ ] Read the [Contribution Guide][contrib]
- [ ] Correct target branch selected (if unsure, select `develop`)
- [ ] Descriptive pull request title added
- [ ] Source branch up-to-date with target branch
- [ ] [Documentation](https://climada-python.readthedocs.io/en/latest/guide/Guide_PythonDos-n-Donts.html#2.--Commenting-&-Documenting) updated
- [x] [Tests][testing] updated
- [x] [Tests][testing] passing
- [ ] No new [linter issues][linter]
- [ ] [Changelog](https://github.com/CLIMADA-project/climada_python/blob/main/CHANGELOG.md) updated

### PR Reviewer Checklist

- [ ] Read the [Contribution Guide][contrib]
- [ ] [CLIMADA Reviewer Checklist](https://climada-python.readthedocs.io/en/latest/development/Guide_Review.html) passed
- [ ] [Tests][testing] passing
- [ ] No new [linter issues][linter]

[contrib]: https://github.com/CLIMADA-project/climada_python/blob/main/CONTRIBUTING.md
[testing]: https://climada-python.readthedocs.io/en/latest/development/Guide_continuous_integration_GitHub_actions.html
[linter]: https://climada-python.readthedocs.io/en/latest/development/Guide_continuous_integration_GitHub_actions.html#static-code-analysis
