### PR TITLE
add idx boolean selection for member and leadtime

### DIFF
--- a/climada/util/forecast.py
+++ b/climada/util/forecast.py
@@ -63,7 +63,7 @@ class Forecast:
         Parameters
         ----------
         member : np.ndarray
-            Forecast ensemble members, given as integers.
+            Array of ensemble members (ints) for which to return an indexer
 
         Returns
         -------
@@ -79,7 +79,7 @@ class Forecast:
         Parameters
         ----------
         lead_time : np.ndarray
-            Forecast lead times, given as timedelta64 objects.
+            Array of lead times (numpy.timedelta64) for which to return an indexer
 
         Returns
         -------

--- a/climada/util/forecast.py
+++ b/climada/util/forecast.py
@@ -56,3 +56,13 @@ class Forecast:
         )
         self.member = np.asarray(member) if member is not None else np.array([])
         super().__init__(**kwargs)
+
+    def idx_member(self, member: np.ndarray) -> np.ndarray:
+        """Return boolean array where self.member == member using numpy.isin()"""
+
+        return np.isin(self.member, member)
+
+    def idx_lead_time(self, lead_time: np.ndarray) -> np.ndarray:
+        """Return boolean array where self.lead_time == lead_time using numpy.isin()"""
+
+        return np.isin(self.lead_time, lead_time)

--- a/climada/util/forecast.py
+++ b/climada/util/forecast.py
@@ -58,11 +58,33 @@ class Forecast:
         super().__init__(**kwargs)
 
     def idx_member(self, member: np.ndarray) -> np.ndarray:
-        """Return boolean array where self.member == member using numpy.isin()"""
+        """Return boolean array where self.member == member using numpy.isin()
+
+        Parameters
+        ----------
+        member : np.ndarray
+            Forecast ensemble members, given as integers.
+
+        Returns
+        -------
+        np.ndarray
+            Boolean array where self.member is in member.
+        """
 
         return np.isin(self.member, member)
 
     def idx_lead_time(self, lead_time: np.ndarray) -> np.ndarray:
-        """Return boolean array where self.lead_time == lead_time using numpy.isin()"""
+        """Return boolean array where self.lead_time == lead_time using numpy.isin()
+
+        Parameters
+        ----------
+        lead_time : np.ndarray
+            Forecast lead times, given as timedelta64 objects.
+
+        Returns
+        -------
+        np.ndarray
+            Boolean array where self.lead_time is in lead_time.
+        """
 
         return np.isin(self.lead_time, lead_time)

--- a/climada/util/test/test_forecast.py
+++ b/climada/util/test/test_forecast.py
@@ -50,3 +50,40 @@ def test_forecast_init():
     forecast = Forecast(lead_time=lead_times_seconds, member=[1, 2, 3])
     npt.assert_array_equal(forecast.lead_time, lead_times_seconds, strict=True)
     assert forecast.lead_time.dtype == np.dtype("timedelta64[ns]")
+
+
+def test_idx_member():
+    """Test idx_member method of Forecast class."""
+    forecast = Forecast(member=np.array([1, 2, 3, 4]))
+
+    idx = forecast.idx_member(1)
+    npt.assert_array_equal(idx, np.array([True, False, False, False]), strict=True)
+
+    idx = forecast.idx_member(np.array([2, 4]))
+    npt.assert_array_equal(idx, np.array([False, True, False, True]), strict=True)
+
+    idx = forecast.idx_member([2, 4])
+    npt.assert_array_equal(idx, np.array([False, True, False, True]), strict=True)
+
+    idx = forecast.idx_member(None)
+    npt.assert_array_equal(idx, np.array([False, False, False, False]), strict=True)
+
+
+def test_idx_lead_time():
+    """Test idx_lead_time method of Forecast class."""
+    forecast = Forecast(
+        lead_time=pd.timedelta_range(start="1 day", periods=4).to_numpy()
+    )
+
+    idx = forecast.idx_lead_time(
+        pd.timedelta_range(start="1 day", periods=4).to_numpy()[::2]
+    )
+    npt.assert_array_equal(idx, np.array([True, False, True, False]), strict=True)
+
+    idx = forecast.idx_lead_time(
+        pd.timedelta_range(start="1 day", periods=4).to_numpy()[0]
+    )
+    npt.assert_array_equal(idx, np.array([True, False, False, False]), strict=True)
+
+    idx = forecast.idx_lead_time(None)
+    npt.assert_array_equal(idx, np.array([False, False, False, False]), strict=True)

--- a/climada/util/test/test_forecast.py
+++ b/climada/util/test/test_forecast.py
@@ -68,6 +68,12 @@ def test_idx_member():
     idx = forecast.idx_member(None)
     npt.assert_array_equal(idx, np.array([False, False, False, False]), strict=True)
 
+    # Try once with inconsitent types
+    forecast = Forecast(member=np.array(["1", -2, np.nan]))
+    npt.assert_array_equal(
+        forecast.idx_member([np.nan, "1"]), np.array([True, False, True]), strict=True
+    )
+
 
 def test_idx_lead_time():
     """Test idx_lead_time method of Forecast class."""


### PR DESCRIPTION
Changes proposed in this PR:
- two methods in forecast base class to select member and lead time with boolean indexing
- two tests

This PR fixes #1159 

### PR Author Checklist

- [ ] Read the [Contribution Guide][contrib]
- [ ] Correct target branch selected (if unsure, select `develop`)
- [ ] Descriptive pull request title added
- [ ] Source branch up-to-date with target branch
- [ ] [Documentation](https://climada-python.readthedocs.io/en/latest/guide/Guide_PythonDos-n-Donts.html#2.--Commenting-&-Documenting) updated
- [ ] [Tests][testing] updated
- [ ] [Tests][testing] passing
- [ ] No new [linter issues][linter]
- [ ] [Changelog](https://github.com/CLIMADA-project/climada_python/blob/main/CHANGELOG.md) updated

### PR Reviewer Checklist

- [ ] Read the [Contribution Guide][contrib]
- [ ] [CLIMADA Reviewer Checklist](https://climada-python.readthedocs.io/en/latest/development/Guide_Review.html) passed
- [ ] [Tests][testing] passing
- [ ] No new [linter issues][linter]

[contrib]: https://github.com/CLIMADA-project/climada_python/blob/main/CONTRIBUTING.md
[testing]: https://climada-python.readthedocs.io/en/latest/development/Guide_continuous_integration_GitHub_actions.html
[linter]: https://climada-python.readthedocs.io/en/latest/development/Guide_continuous_integration_GitHub_actions.html#static-code-analysis
