### PR TITLE
Fix logging of asset count in impact calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ Code freeze date: YYYY-MM-DD
 
 ### Fixed
 
+- Fixed asset count in impact logging message [#1195](https://github.com/CLIMADA-project/climada_python/pull/1195).
+
 ### Deprecated
 
 ### Removed

--- a/climada/engine/impact_calc.py
+++ b/climada/engine/impact_calc.py
@@ -186,7 +186,7 @@ class ImpactCalc:
             return self._return_empty(save_mat)
         LOGGER.info(
             "Calculating impact for %s assets (>0) and %s events.",
-            exp_gdf.size,
+            len(exp_gdf),
             self.n_events,
         )
         imp_mat_gen = self.imp_mat_gen(exp_gdf, impf_col)

--- a/climada/engine/test/test_impact_calc.py
+++ b/climada/engine/test/test_impact_calc.py
@@ -441,7 +441,7 @@ class TestImpactCalc(unittest.TestCase):
         self.assertEqual(
             logs.output,
             [
-                "INFO:climada.engine.impact_calc:Calculating impact for 150 assets (>0) and 14450 events."
+                "INFO:climada.engine.impact_calc:Calculating impact for 50 assets (>0) and 14450 events."
             ],
         )
         self.assertEqual(icalc.n_events, len(impact.at_event))


### PR DESCRIPTION
In the following:

```
LOGGER.info(
            "Calculating impact for %s assets (>0) and %s events.",
            exp_gdf.size,
            self.n_events,
        )
```

`gdf.size` return the number of cells, not the number of rows, so the logging message is wrong.

This is easily fixed by switching to `len(exp_gdf)`

### PR Author Checklist

- [x] Read the [Contribution Guide][contrib]
- [x] Correct target branch selected (if unsure, select `develop`)
- [x] Descriptive pull request title added
- [x] Source branch up-to-date with target branch
- [x] [Documentation](https://climada-python.readthedocs.io/en/latest/guide/Guide_PythonDos-n-Donts.html#2.--Commenting-&-Documenting) updated
- [x] [Tests][testing] updated
- [x] [Tests][testing] passing
- [x] No new [linter issues][linter]
- [ ] [Changelog](https://github.com/CLIMADA-project/climada_python/blob/main/CHANGELOG.md) updated

### PR Reviewer Checklist

- [ ] Read the [Contribution Guide][contrib]
- [ ] [CLIMADA Reviewer Checklist](https://climada-python.readthedocs.io/en/latest/development/Guide_Review.html) passed
- [ ] [Tests][testing] passing
- [ ] No new [linter issues][linter]

[contrib]: https://github.com/CLIMADA-project/climada_python/blob/main/CONTRIBUTING.md
[testing]: https://climada-python.readthedocs.io/en/latest/development/Guide_continuous_integration_GitHub_actions.html
[linter]: https://climada-python.readthedocs.io/en/latest/development/Guide_continuous_integration_GitHub_actions.html#static-code-analysis
