### PR TITLE
Risk Trajectory Split 3 : Impact Computation Strategies

### DIFF
--- a/climada/trajectories/impact_calc_strat.py
+++ b/climada/trajectories/impact_calc_strat.py
@@ -95,7 +95,7 @@ class ImpactCalcComputation(ImpactComputationStrategy):
         vul: ImpactFuncSet,
     ) -> Impact:
         """
-        Calculates the impact and applies the "global" risk transfer mechanism.
+        Calculates the impact.
 
         Parameters
         ----------
@@ -110,31 +110,5 @@ class ImpactCalcComputation(ImpactComputationStrategy):
         -------
         Impact
             The final impact object.
-        """
-        impact = self.compute_impacts_pre_transfer(exp, haz, vul)
-        return impact
-
-    def compute_impacts_pre_transfer(
-        self,
-        exp: Exposures,
-        haz: Hazard,
-        vul: ImpactFuncSet,
-    ) -> Impact:
-        """
-        Calculates the raw impact matrix before any risk transfer is applied.
-
-        Parameters
-        ----------
-        exp : Exposures
-            The exposure data.
-        haz : Hazard
-            The hazard data.
-        vul : ImpactFuncSet
-            The set of vulnerability functions.
-
-        Returns
-        -------
-        Impact
-            An Impact object containing the raw, pre-transfer impact matrix.
         """
         return ImpactCalc(exposures=exp, impfset=vul, hazard=haz).impact()

--- a/climada/trajectories/impact_calc_strat.py
+++ b/climada/trajectories/impact_calc_strat.py
@@ -32,6 +32,10 @@ from climada.hazard.base import Hazard
 __all__ = ["ImpactCalcComputation"]
 
 
+# The following is acceptable.
+# We design a pattern, and currently it requires only to
+# define the compute_impacts method.
+# pylint: disable=too-few-public-methods
 class ImpactComputationStrategy(ABC):
     """
     Interface for impact computation strategies.
@@ -73,7 +77,6 @@ class ImpactComputationStrategy(ABC):
         --------
         ImpactCalcComputation : The default implementation of this interface.
         """
-        ...
 
 
 class ImpactCalcComputation(ImpactComputationStrategy):

--- a/climada/trajectories/impact_calc_strat.py
+++ b/climada/trajectories/impact_calc_strat.py
@@ -1,0 +1,137 @@
+"""
+This file is part of CLIMADA.
+
+Copyright (C) 2017 ETH Zurich, CLIMADA contributors listed in AUTHORS.
+
+CLIMADA is free software: you can redistribute it and/or modify it under the
+terms of the GNU General Public License as published by the Free
+Software Foundation, version 3.
+
+CLIMADA is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along
+with CLIMADA. If not, see <https://www.gnu.org/licenses/>.
+
+---
+
+This modules implements the impact computation strategy objects for risk
+trajectories.
+
+"""
+
+from abc import ABC, abstractmethod
+
+from climada.engine.impact import Impact
+from climada.engine.impact_calc import ImpactCalc
+from climada.entity.exposures.base import Exposures
+from climada.entity.impact_funcs.impact_func_set import ImpactFuncSet
+from climada.hazard.base import Hazard
+
+__all__ = ["ImpactCalcComputation"]
+
+
+class ImpactComputationStrategy(ABC):
+    """
+    Interface for impact computation strategies.
+
+    This abstract class defines the contract for all concrete strategies
+    responsible for calculating and optionally modifying with a risk transfer,
+    the impact computation, based on a set of inputs (exposure, hazard, vulnerability).
+
+    It revolves around a `compute_impacts()` method that takes as arguments
+    the three dimensions of risk (exposure, hazard, vulnerability) and return an
+    Impact object.
+    """
+
+    @abstractmethod
+    def compute_impacts(
+        self,
+        exp: Exposures,
+        haz: Hazard,
+        vul: ImpactFuncSet,
+    ) -> Impact:
+        """
+        Calculates the total impact, including optional risk transfer application.
+
+        Parameters
+        ----------
+        exp : Exposures
+            The exposure data.
+        haz : Hazard
+            The hazard data (e.g., event intensity).
+        vul : ImpactFuncSet
+            The set of vulnerability functions.
+
+        Returns
+        -------
+        Impact
+            An object containing the computed total impact matrix and metrics.
+
+        See Also
+        --------
+        ImpactCalcComputation : The default implementation of this interface.
+        """
+        ...
+
+
+class ImpactCalcComputation(ImpactComputationStrategy):
+    r"""
+    Default impact computation strategy using the core engine of climada.
+
+    This strategy first calculates the raw impact using the standard
+    :class:`ImpactCalc` logic.
+
+    """
+
+    def compute_impacts(
+        self,
+        exp: Exposures,
+        haz: Hazard,
+        vul: ImpactFuncSet,
+    ) -> Impact:
+        """
+        Calculates the impact and applies the "global" risk transfer mechanism.
+
+        Parameters
+        ----------
+        exp : Exposures
+            The exposure data.
+        haz : Hazard
+            The hazard data.
+        vul : ImpactFuncSet
+            The set of vulnerability functions.
+
+        Returns
+        -------
+        Impact
+            The final impact object.
+        """
+        impact = self.compute_impacts_pre_transfer(exp, haz, vul)
+        return impact
+
+    def compute_impacts_pre_transfer(
+        self,
+        exp: Exposures,
+        haz: Hazard,
+        vul: ImpactFuncSet,
+    ) -> Impact:
+        """
+        Calculates the raw impact matrix before any risk transfer is applied.
+
+        Parameters
+        ----------
+        exp : Exposures
+            The exposure data.
+        haz : Hazard
+            The hazard data.
+        vul : ImpactFuncSet
+            The set of vulnerability functions.
+
+        Returns
+        -------
+        Impact
+            An Impact object containing the raw, pre-transfer impact matrix.
+        """
+        return ImpactCalc(exposures=exp, impfset=vul, hazard=haz).impact()

--- a/climada/trajectories/test/test_impact_calc_strat.py
+++ b/climada/trajectories/test/test_impact_calc_strat.py
@@ -1,0 +1,84 @@
+"""
+This file is part of CLIMADA.
+
+Copyright (C) 2017 ETH Zurich, CLIMADA contributors listed in AUTHORS.
+
+CLIMADA is free software: you can redistribute it and/or modify it under the
+terms of the GNU General Public License as published by the Free
+Software Foundation, version 3.
+
+CLIMADA is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along
+with CLIMADA. If not, see <https://www.gnu.org/licenses/>.
+
+---
+
+Tests for impact_calc_strat
+
+"""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from climada.engine import Impact
+from climada.entity import ImpactFuncSet
+from climada.entity.exposures import Exposures
+from climada.hazard import Hazard
+from climada.trajectories import Snapshot
+from climada.trajectories.impact_calc_strat import ImpactCalcComputation
+
+
+class TestImpactCalcComputation(unittest.TestCase):
+    def setUp(self):
+        self.mock_snapshot0 = MagicMock(spec=Snapshot)
+        self.mock_snapshot0.exposure = MagicMock(spec=Exposures)
+        self.mock_snapshot0.hazard = MagicMock(spec=Hazard)
+        self.mock_snapshot0.impfset = MagicMock(spec=ImpactFuncSet)
+        self.mock_snapshot1 = MagicMock(spec=Snapshot)
+        self.mock_snapshot1.exposure = MagicMock(spec=Exposures)
+        self.mock_snapshot1.hazard = MagicMock(spec=Hazard)
+        self.mock_snapshot1.impfset = MagicMock(spec=ImpactFuncSet)
+
+        self.impact_calc_computation = ImpactCalcComputation()
+
+    @patch.object(ImpactCalcComputation, "compute_impacts_pre_transfer")
+    def test_compute_impacts(self, mock_calculate_impacts_for_snapshots):
+        mock_impacts = MagicMock(spec=Impact)
+        mock_calculate_impacts_for_snapshots.return_value = mock_impacts
+
+        result = self.impact_calc_computation.compute_impacts(
+            exp=self.mock_snapshot0.exposure,
+            haz=self.mock_snapshot0.hazard,
+            vul=self.mock_snapshot0.impfset,
+        )
+
+        self.assertEqual(result, mock_impacts)
+        mock_calculate_impacts_for_snapshots.assert_called_once_with(
+            self.mock_snapshot0.exposure,
+            self.mock_snapshot0.hazard,
+            self.mock_snapshot0.impfset,
+        )
+
+    def test_calculate_impacts_for_snapshots(self):
+        mock_imp_E0H0 = MagicMock(spec=Impact)
+
+        with patch(
+            "climada.trajectories.impact_calc_strat.ImpactCalc"
+        ) as mock_impact_calc:
+            mock_impact_calc.return_value.impact.side_effect = [mock_imp_E0H0]
+
+            result = self.impact_calc_computation.compute_impacts_pre_transfer(
+                exp=self.mock_snapshot0.exposure,
+                haz=self.mock_snapshot0.hazard,
+                vul=self.mock_snapshot0.impfset,
+            )
+
+            self.assertEqual(result, mock_imp_E0H0)
+
+
+if __name__ == "__main__":
+    TESTS = unittest.TestLoader().loadTestsFromTestCase(TestImpactCalcComputation)
+    unittest.TextTestRunner(verbosity=2).run(TESTS)

--- a/climada/trajectories/test/test_impact_calc_strat.py
+++ b/climada/trajectories/test/test_impact_calc_strat.py
@@ -20,65 +20,78 @@ Tests for impact_calc_strat
 
 """
 
-import unittest
 from unittest.mock import MagicMock, patch
+
+import pytest
 
 from climada.engine import Impact
 from climada.entity import ImpactFuncSet
 from climada.entity.exposures import Exposures
 from climada.hazard import Hazard
 from climada.trajectories import Snapshot
-from climada.trajectories.impact_calc_strat import ImpactCalcComputation
+from climada.trajectories.impact_calc_strat import (
+    ImpactCalcComputation,
+    ImpactComputationStrategy,
+)
+
+# --- Fixtures ---
 
 
-class TestImpactCalcComputation(unittest.TestCase):
-    def setUp(self):
-        self.mock_snapshot0 = MagicMock(spec=Snapshot)
-        self.mock_snapshot0.exposure = MagicMock(spec=Exposures)
-        self.mock_snapshot0.hazard = MagicMock(spec=Hazard)
-        self.mock_snapshot0.impfset = MagicMock(spec=ImpactFuncSet)
-        self.mock_snapshot1 = MagicMock(spec=Snapshot)
-        self.mock_snapshot1.exposure = MagicMock(spec=Exposures)
-        self.mock_snapshot1.hazard = MagicMock(spec=Hazard)
-        self.mock_snapshot1.impfset = MagicMock(spec=ImpactFuncSet)
+@pytest.fixture
+def mock_snapshot():
+    """Provides a snapshot with mocked exposure, hazard, and impact functions."""
+    snap = MagicMock(spec=Snapshot)
+    snap.exposure = MagicMock(spec=Exposures)
+    snap.hazard = MagicMock(spec=Hazard)
+    snap.impfset = MagicMock(spec=ImpactFuncSet)
+    return snap
 
-        self.impact_calc_computation = ImpactCalcComputation()
 
-    @patch.object(ImpactCalcComputation, "compute_impacts_pre_transfer")
-    def test_compute_impacts(self, mock_calculate_impacts_for_snapshots):
-        mock_impacts = MagicMock(spec=Impact)
-        mock_calculate_impacts_for_snapshots.return_value = mock_impacts
+@pytest.fixture
+def strategy():
+    """Provides an instance of the ImpactCalcComputation strategy."""
+    return ImpactCalcComputation()
 
-        result = self.impact_calc_computation.compute_impacts(
-            exp=self.mock_snapshot0.exposure,
-            haz=self.mock_snapshot0.hazard,
-            vul=self.mock_snapshot0.impfset,
+
+# --- Tests ---
+def test_interface_compliance(strategy):
+    """Ensure the class correctly inherits from the Abstract Base Class."""
+    assert isinstance(strategy, ImpactComputationStrategy)
+    assert isinstance(strategy, ImpactCalcComputation)
+
+
+def test_compute_impacts(strategy, mock_snapshot):
+    """Test that compute_impacts calls the pre-transfer method correctly."""
+    mock_impacts = MagicMock(spec=Impact)
+
+    # We patch the ImpactCalc within trajectories
+    with patch("climada.trajectories.impact_calc_strat.ImpactCalc") as mock_ImpactCalc:
+        mock_ImpactCalc.return_value.impact.return_value = mock_impacts
+        result = strategy.compute_impacts(
+            exp=mock_snapshot.exposure,
+            haz=mock_snapshot.hazard,
+            vul=mock_snapshot.impfset,
         )
-
-        self.assertEqual(result, mock_impacts)
-        mock_calculate_impacts_for_snapshots.assert_called_once_with(
-            self.mock_snapshot0.exposure,
-            self.mock_snapshot0.hazard,
-            self.mock_snapshot0.impfset,
+        mock_ImpactCalc.assert_called_once_with(
+            exposures=mock_snapshot.exposure,
+            impfset=mock_snapshot.impfset,
+            hazard=mock_snapshot.hazard,
         )
-
-    def test_calculate_impacts_for_snapshots(self):
-        mock_imp_E0H0 = MagicMock(spec=Impact)
-
-        with patch(
-            "climada.trajectories.impact_calc_strat.ImpactCalc"
-        ) as mock_impact_calc:
-            mock_impact_calc.return_value.impact.side_effect = [mock_imp_E0H0]
-
-            result = self.impact_calc_computation.compute_impacts_pre_transfer(
-                exp=self.mock_snapshot0.exposure,
-                haz=self.mock_snapshot0.hazard,
-                vul=self.mock_snapshot0.impfset,
-            )
-
-            self.assertEqual(result, mock_imp_E0H0)
+        mock_ImpactCalc.return_value.impact.assert_called_once()
+        assert result == mock_impacts
 
 
-if __name__ == "__main__":
-    TESTS = unittest.TestLoader().loadTestsFromTestCase(TestImpactCalcComputation)
-    unittest.TextTestRunner(verbosity=2).run(TESTS)
+def test_cannot_instantiate_abstract_base_class():
+    """Ensure ImpactComputationStrategy cannot be instantiated directly."""
+    with pytest.raises(TypeError, match="Can't instantiate abstract class"):
+        ImpactComputationStrategy()  # type: ignore
+
+
+@pytest.mark.parametrize("invalid_input", [None, 123, "string"])
+def test_compute_impacts_type_errors(strategy, invalid_input):
+    """
+    Smoke test: Ensure that if ImpactCalc raises errors due to bad input,
+    the strategy correctly propagates them.
+    """
+    with pytest.raises(AttributeError):
+        strategy.compute_impacts(invalid_input, invalid_input, invalid_input)

--- a/doc/api/climada/climada.trajectories.impact_calc_strat.rst
+++ b/doc/api/climada/climada.trajectories.impact_calc_strat.rst
@@ -1,0 +1,7 @@
+climada\.trajectories\.impact_calc_strat module
+----------------------------------------
+
+.. automodule:: climada.trajectories.impact_calc_strat
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/doc/api/climada/climada.trajectories.rst
+++ b/doc/api/climada/climada.trajectories.rst
@@ -5,3 +5,4 @@ climada\.trajectories module
 .. toctree::
 
     climada.trajectories.snapshot
+    climada.trajectories.impact_calc_strat


### PR DESCRIPTION
As the Risk trajectory PR is too substantial, this is a third split.

This PR implements the concept of impact computation strategies.
An impact computation strategy defines what underlying process to follow to get from (exp,haz,vul) triplet to an impact.

The idea is to ease the extension of the trajectories to also allow non `ImpactCalc` based impacts (think network, unsequa, etc.)

Currently, it really is just a wrapper around ImpactCalc().

It has proved helpful in tests/prototypes of risk trajectory / option appraisal to, for instance:
- "custom" compute impacts on polygons / lines 
- pre-assign centroid or not

### PR Author Checklist

- [ ] Read the [Contribution Guide][contrib]
- [ ] Correct target branch selected (if unsure, select `develop`)
- [ ] Descriptive pull request title added
- [ ] Source branch up-to-date with target branch
- [ ] [Documentation](https://climada-python.readthedocs.io/en/latest/guide/Guide_PythonDos-n-Donts.html#2.--Commenting-&-Documenting) updated
- [ ] [Tests][testing] updated
- [ ] [Tests][testing] passing
- [ ] No new [linter issues][linter]
- [ ] [Changelog](https://github.com/CLIMADA-project/climada_python/blob/main/CHANGELOG.md) updated

### PR Reviewer Checklist

- [ ] Read the [Contribution Guide][contrib]
- [ ] [CLIMADA Reviewer Checklist](https://climada-python.readthedocs.io/en/latest/development/Guide_Review.html) passed
- [ ] [Tests][testing] passing
- [ ] No new [linter issues][linter]

[contrib]: https://github.com/CLIMADA-project/climada_python/blob/main/CONTRIBUTING.md
[testing]: https://climada-python.readthedocs.io/en/latest/development/Guide_continuous_integration_GitHub_actions.html
[linter]: https://climada-python.readthedocs.io/en/latest/development/Guide_continuous_integration_GitHub_actions.html#static-code-analysis
