### PR TITLE
Better type hints and overloads signatures for ImpactFuncSet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Code freeze date: YYYY-MM-DD
 
 ### Added
 
+- Better type hints and overloads signatures for ImpactFuncSet [#1250](https://github.com/CLIMADA-project/climada_python/pull/1250)
+
 ### Changed
 - Updated Impact Calculation Tutorial (`doc.climada_engine_Impact.ipynb`) [#1095](https://github.com/CLIMADA-project/climada_python/pull/1095).
 

--- a/climada/entity/impact_funcs/base.py
+++ b/climada/entity/impact_funcs/base.py
@@ -189,7 +189,7 @@ class ImpactFunc:
         haz_type: str,
         mdd: tuple[float, float] = (0, 1),
         paa: tuple[float, float] = (1, 1),
-        impf_id: int = 1,
+        impf_id: int | str = 1,
         **kwargs,
     ):
         """Step function type impact function.
@@ -207,7 +207,7 @@ class ImpactFunc:
             (min, max) mdd values. The default is (0, 1)
         paa: tuple(float, float)
             (min, max) paa values. The default is (1, 1)
-        impf_id : int, optional, default=1
+        impf_id : int|str, optional, default=1
             impact function id
         kwargs :
             keyword arguments passed to ImpactFunc()
@@ -250,7 +250,7 @@ class ImpactFunc:
         k: float,
         x0: float,
         haz_type: str,
-        impf_id: int = 1,
+        impf_id: int | str = 1,
         **kwargs,
     ):
         r"""Sigmoid type impact function hinging on three parameter.
@@ -320,7 +320,7 @@ class ImpactFunc:
         scale: float,
         exponent: float,
         haz_type: str,
-        impf_id: int = 1,
+        impf_id: int | str = 1,
         **kwargs,
     ):
         r"""S-shape polynomial impact function hinging on four parameter.

--- a/climada/entity/impact_funcs/impact_func_set.py
+++ b/climada/entity/impact_funcs/impact_func_set.py
@@ -176,18 +176,22 @@ class ImpactFuncSet:
             self._data = dict()
 
     @overload
-    def get_func(self, haz_type: str, fun_id: int | str) -> ImpactFunc: ...
-
-    @overload
-    def get_func(self, haz_type: str, fun_id: None = None) -> list[ImpactFunc]: ...
-
-    @overload
-    def get_func(self, haz_type: None, fun_id: int | str) -> list[ImpactFunc]: ...
-
-    @overload
     def get_func(
         self, haz_type: None = None, fun_id: None = None
     ) -> Dict[str, Dict[Union[int, str], ImpactFunc]]: ...
+
+    @overload
+    def get_func(
+        self, haz_type: None = ..., fun_id: int | str = ...
+    ) -> list[ImpactFunc]: ...
+
+    @overload
+    def get_func(
+        self, haz_type: str = ..., fun_id: None = None
+    ) -> list[ImpactFunc]: ...
+
+    @overload
+    def get_func(self, haz_type: str = ..., fun_id: int | str = ...) -> ImpactFunc: ...
 
     def get_func(
         self, haz_type: Optional[str] = None, fun_id: Optional[int | str] = None

--- a/climada/entity/impact_funcs/impact_func_set.py
+++ b/climada/entity/impact_funcs/impact_func_set.py
@@ -24,7 +24,7 @@ __all__ = ["ImpactFuncSet"]
 import copy
 import logging
 from itertools import repeat
-from typing import Iterable, Optional
+from typing import Dict, Iterable, Optional, Union, overload
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -173,7 +173,23 @@ class ImpactFuncSet:
         else:
             self._data = dict()
 
-    def get_func(self, haz_type=None, fun_id=None):
+    @overload
+    def get_func(self, haz_type: str, fun_id: int) -> ImpactFunc: ...
+
+    @overload
+    def get_func(self, haz_type: str, fun_id: None = None) -> list[ImpactFunc]: ...
+
+    @overload
+    def get_func(self, haz_type: None, fun_id: int) -> list[ImpactFunc]: ...
+
+    @overload
+    def get_func(
+        self, haz_type: None = None, fun_id: None = None
+    ) -> Dict[str, Dict[int, ImpactFunc]]: ...
+
+    def get_func(
+        self, haz_type: Optional[str] = None, fun_id: Optional[int] = None
+    ) -> Union[ImpactFunc, list[ImpactFunc], Dict[str, Dict[int, ImpactFunc]]]:
         """Get ImpactFunc(s) of input hazard type and/or id.
         If no input provided, all impact functions are returned.
 

--- a/climada/entity/impact_funcs/impact_func_set.py
+++ b/climada/entity/impact_funcs/impact_func_set.py
@@ -141,7 +141,9 @@ class ImpactFuncSet:
             self._data[func.haz_type] = dict()
         self._data[func.haz_type][func.id] = func
 
-    def remove_func(self, haz_type: str = None, fun_id: str | int = None):
+    def remove_func(
+        self, haz_type: Optional[str] = None, fun_id: Optional[str | int] = None
+    ):
         """Remove impact function(s) with provided hazard type and/or id.
         If no input provided, all impact functions are removed.
 
@@ -174,13 +176,13 @@ class ImpactFuncSet:
             self._data = dict()
 
     @overload
-    def get_func(self, haz_type: str, fun_id: int) -> ImpactFunc: ...
+    def get_func(self, haz_type: str, fun_id: int | str) -> ImpactFunc: ...
 
     @overload
     def get_func(self, haz_type: str, fun_id: None = None) -> list[ImpactFunc]: ...
 
     @overload
-    def get_func(self, haz_type: None, fun_id: int) -> list[ImpactFunc]: ...
+    def get_func(self, haz_type: None, fun_id: int | str) -> list[ImpactFunc]: ...
 
     @overload
     def get_func(
@@ -188,7 +190,7 @@ class ImpactFuncSet:
     ) -> Dict[str, Dict[int, ImpactFunc]]: ...
 
     def get_func(
-        self, haz_type: Optional[str] = None, fun_id: Optional[int] = None
+        self, haz_type: Optional[str] = None, fun_id: Optional[int | str] = None
     ) -> Union[ImpactFunc, list[ImpactFunc], Dict[str, Dict[int, ImpactFunc]]]:
         """Get ImpactFunc(s) of input hazard type and/or id.
         If no input provided, all impact functions are returned.
@@ -225,7 +227,7 @@ class ImpactFuncSet:
         else:
             return self._data
 
-    def get_hazard_types(self, fun_id: str | int) -> list[str]:
+    def get_hazard_types(self, fun_id: Optional[str | int]) -> list[str]:
         """Get impact functions hazard types contained for the id provided.
         Return all hazard types if no input id.
 
@@ -247,7 +249,15 @@ class ImpactFuncSet:
                 haz_types.append(vul_haz)
         return haz_types
 
-    def get_ids(self, haz_type: str = None) -> list[int | str]:
+    @overload
+    def get_ids(self, haz_type: None = None) -> dict[str, list[str | int]]: ...
+
+    @overload
+    def get_ids(self, haz_type: str) -> list[int | str]: ...
+
+    def get_ids(
+        self, haz_type: Optional[str] = None
+    ) -> dict[str, list[str | int]] | list[int | str]:
         """Get impact functions ids contained for the hazard type provided.
         Return all ids for each hazard type if no input hazard type.
 
@@ -272,7 +282,9 @@ class ImpactFuncSet:
         except KeyError:
             return list()
 
-    def size(self, haz_type: str = None, fun_id: str | int = None) -> int:
+    def size(
+        self, haz_type: Optional[str] = None, fun_id: Optional[str | int] = None
+    ) -> int:
         """Get number of impact functions contained with input hazard type and
         /or id. If no input provided, get total number of impact functions.
 
@@ -295,6 +307,7 @@ class ImpactFuncSet:
             return 1
         if (haz_type is not None) or (fun_id is not None):
             return len(self.get_func(haz_type, fun_id))
+
         return sum(len(vul_list) for vul_list in self.get_ids().values())
 
     def check(self):
@@ -316,7 +329,7 @@ class ImpactFuncSet:
                     )
                 vul.check()
 
-    def extend(self, impact_funcs: ImpactFuncSet):
+    def extend(self, impact_funcs: "ImpactFuncSet"):
         """Append impact functions of input ImpactFuncSet to current
         ImpactFuncSet. Overwrite ImpactFunc if same id and haz_type.
 
@@ -339,7 +352,13 @@ class ImpactFuncSet:
             for _, vul in vul_dict.items():
                 self.append(vul)
 
-    def plot(self, haz_type: str = None, fun_id: str | int = None, axis=None, **kwargs):
+    def plot(
+        self,
+        haz_type: Optional[str] = None,
+        fun_id: Optional[str | int] = None,
+        axis=None,
+        **kwargs,
+    ):
         """Plot impact functions of selected hazard (all if not provided) and
         selected function id (all if not provided).
 

--- a/climada/entity/impact_funcs/impact_func_set.py
+++ b/climada/entity/impact_funcs/impact_func_set.py
@@ -24,7 +24,7 @@ __all__ = ["ImpactFuncSet"]
 import copy
 import logging
 from itertools import repeat
-from typing import Dict, Iterable, Optional, Union, overload
+from typing import Iterable, Optional, Union, overload
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -178,7 +178,7 @@ class ImpactFuncSet:
     @overload
     def get_func(
         self, haz_type: None = None, fun_id: None = None
-    ) -> Dict[str, Dict[Union[int, str], ImpactFunc]]: ...
+    ) -> dict[str, dict[Union[int, str], ImpactFunc]]: ...
 
     @overload
     def get_func(
@@ -196,7 +196,7 @@ class ImpactFuncSet:
     def get_func(
         self, haz_type: Optional[str] = None, fun_id: Optional[int | str] = None
     ) -> Union[
-        ImpactFunc, list[ImpactFunc], Dict[str, Dict[Union[int, str], ImpactFunc]]
+        ImpactFunc, list[ImpactFunc], dict[str, dict[Union[int, str], ImpactFunc]]
     ]:
         """Get ImpactFunc(s) of input hazard type and/or id.
         If no input provided, all impact functions are returned.

--- a/climada/entity/impact_funcs/impact_func_set.py
+++ b/climada/entity/impact_funcs/impact_func_set.py
@@ -119,7 +119,7 @@ class ImpactFuncSet:
         """Reinitialize attributes."""
         self._data = dict()  # {hazard_type : {id:ImpactFunc}}
 
-    def append(self, func):
+    def append(self, func: ImpactFunc):
         """Append a ImpactFunc. Overwrite existing if same id and haz_type.
 
         Parameters
@@ -141,7 +141,7 @@ class ImpactFuncSet:
             self._data[func.haz_type] = dict()
         self._data[func.haz_type][func.id] = func
 
-    def remove_func(self, haz_type=None, fun_id=None):
+    def remove_func(self, haz_type: str = None, fun_id: str | int = None):
         """Remove impact function(s) with provided hazard type and/or id.
         If no input provided, all impact functions are removed.
 
@@ -225,7 +225,7 @@ class ImpactFuncSet:
         else:
             return self._data
 
-    def get_hazard_types(self, fun_id=None):
+    def get_hazard_types(self, fun_id: str | int) -> list[str]:
         """Get impact functions hazard types contained for the id provided.
         Return all hazard types if no input id.
 
@@ -247,7 +247,7 @@ class ImpactFuncSet:
                 haz_types.append(vul_haz)
         return haz_types
 
-    def get_ids(self, haz_type=None):
+    def get_ids(self, haz_type: str = None) -> list[int | str]:
         """Get impact functions ids contained for the hazard type provided.
         Return all ids for each hazard type if no input hazard type.
 
@@ -272,7 +272,7 @@ class ImpactFuncSet:
         except KeyError:
             return list()
 
-    def size(self, haz_type=None, fun_id=None):
+    def size(self, haz_type: str = None, fun_id: str | int = None) -> int:
         """Get number of impact functions contained with input hazard type and
         /or id. If no input provided, get total number of impact functions.
 
@@ -316,7 +316,7 @@ class ImpactFuncSet:
                     )
                 vul.check()
 
-    def extend(self, impact_funcs):
+    def extend(self, impact_funcs: ImpactFuncSet):
         """Append impact functions of input ImpactFuncSet to current
         ImpactFuncSet. Overwrite ImpactFunc if same id and haz_type.
 
@@ -339,7 +339,7 @@ class ImpactFuncSet:
             for _, vul in vul_dict.items():
                 self.append(vul)
 
-    def plot(self, haz_type=None, fun_id=None, axis=None, **kwargs):
+    def plot(self, haz_type: str = None, fun_id: str | int = None, axis=None, **kwargs):
         """Plot impact functions of selected hazard (all if not provided) and
         selected function id (all if not provided).
 

--- a/climada/entity/impact_funcs/impact_func_set.py
+++ b/climada/entity/impact_funcs/impact_func_set.py
@@ -229,7 +229,7 @@ class ImpactFuncSet:
         else:
             return self._data
 
-    def get_hazard_types(self, fun_id: Optional[str | int]) -> list[str]:
+    def get_hazard_types(self, fun_id: Optional[str | int] = None) -> list[str]:
         """Get impact functions hazard types contained for the id provided.
         Return all hazard types if no input id.
 

--- a/climada/entity/impact_funcs/impact_func_set.py
+++ b/climada/entity/impact_funcs/impact_func_set.py
@@ -187,11 +187,13 @@ class ImpactFuncSet:
     @overload
     def get_func(
         self, haz_type: None = None, fun_id: None = None
-    ) -> Dict[str, Dict[int, ImpactFunc]]: ...
+    ) -> Dict[str, Dict[Union[int, str], ImpactFunc]]: ...
 
     def get_func(
         self, haz_type: Optional[str] = None, fun_id: Optional[int | str] = None
-    ) -> Union[ImpactFunc, list[ImpactFunc], Dict[str, Dict[int, ImpactFunc]]]:
+    ) -> Union[
+        ImpactFunc, list[ImpactFunc], Dict[str, Dict[Union[int, str], ImpactFunc]]
+    ]:
         """Get ImpactFunc(s) of input hazard type and/or id.
         If no input provided, all impact functions are returned.
 


### PR DESCRIPTION
Changes proposed in this PR:
- Better type hints for ImpactFuncSet
- Overloads for get_func() and get_ids()

I was annoyed by my LSP saying get_func return a dict[Unknown, Unknown]

This PR adjusts a few type hints and some overloads statement for get_func. (This tells LSP what is the return type of get_func() for different inputs).

### PR Author Checklist

- [x] Read the [Contribution Guide][contrib]
- [x] Correct target branch selected (if unsure, select `develop`)
- [x] Descriptive pull request title added
- [x] Source branch up-to-date with target branch
- [x] [Documentation](https://climada-python.readthedocs.io/en/latest/guide/Guide_PythonDos-n-Donts.html#2.--Commenting-&-Documenting) updated
- [x] [Tests][testing] updated
- [x] [Tests][testing] passing
- [x] No new [linter issues][linter]
- [x] [Changelog](https://github.com/CLIMADA-project/climada_python/blob/main/CHANGELOG.md) updated

### PR Reviewer Checklist

- [ ] Read the [Contribution Guide][contrib]
- [ ] [CLIMADA Reviewer Checklist](https://climada-python.readthedocs.io/en/latest/development/Guide_Review.html) passed
- [ ] [Tests][testing] passing
- [ ] No new [linter issues][linter]

[contrib]: https://github.com/CLIMADA-project/climada_python/blob/main/CONTRIBUTING.md
[testing]: https://climada-python.readthedocs.io/en/latest/development/Guide_continuous_integration_GitHub_actions.html
[linter]: https://climada-python.readthedocs.io/en/latest/development/Guide_continuous_integration_GitHub_actions.html#static-code-analysis
