### PR TITLE
ci: Add job for Mamba installation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,9 +13,6 @@ jobs:
     name: 'Core / Unit Test Pipeline'
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    permissions:
-      # For publishing results
-      checks: write
 
     # Run this test for different Python versions
     strategy:
@@ -53,20 +50,43 @@ jobs:
         run: |
           make unit_test
       -
-        name: Publish Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
-        if: always()
+        name: Upload Test Reports
+        if: (!cancelled())
+        uses: actions/upload-artifact@v6
         with:
-          junit_files: tests_xml/tests.xml
-          check_name: "Core / Unit Test Results (${{ matrix.python-version }})"
-          comment_mode: "off"
+          name: test-results-python-${{ matrix.python-version }}
+          path: tests_xml/tests.xml
       -
         name: Upload Coverage Reports
-        if: always()
-        uses: actions/upload-artifact@v4
+        if: (!cancelled())
+        uses: actions/upload-artifact@v6
         with:
           name: coverage-report-core-unittests-py${{ matrix.python-version }}
           path: coverage/
+
+  publish-test-results:
+    name: "Tests Results"
+    needs: build-and-test
+    runs-on: ubuntu-latest
+    permissions:
+      # For publishing results
+      checks: write
+
+    if: (!cancelled())
+    steps:
+      -
+        name: Download Artifacts
+        uses: actions/download-artifact@v7
+        with:
+          path: artifacts
+          pattern: test-results-python-*
+      -
+        name: Publish Test Results
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        with:
+          junit_files: artifacts/**/*.xml
+          check_name: "Core / Unit Test"
+          comment_mode: "off"
 
   test-petals:
     name: Petals Compatibility

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,9 @@ jobs:
     name: 'Core / Unit Test Pipeline'
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    permissions:
+      # For publishing results
+      checks: write
 
     # Run this test for different Python versions
     strategy:
@@ -50,43 +53,20 @@ jobs:
         run: |
           make unit_test
       -
-        name: Upload Test Reports
-        if: (!cancelled())
-        uses: actions/upload-artifact@v6
+        name: Publish Test Results
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        if: always()
         with:
-          name: test-results-python-${{ matrix.python-version }}
-          path: tests_xml/tests.xml
+          junit_files: tests_xml/tests.xml
+          check_name: "Core / Unit Test Results (${{ matrix.python-version }})"
+          comment_mode: "off"
       -
         name: Upload Coverage Reports
-        if: (!cancelled())
-        uses: actions/upload-artifact@v6
+        if: always()
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-report-core-unittests-py${{ matrix.python-version }}
           path: coverage/
-
-  publish-test-results:
-    name: "Tests Results"
-    needs: build-and-test
-    runs-on: ubuntu-latest
-    permissions:
-      # For publishing results
-      checks: write
-
-    if: (!cancelled())
-    steps:
-      -
-        name: Download Artifacts
-        uses: actions/download-artifact@v7
-        with:
-          path: artifacts
-          pattern: test-results-python-*
-      -
-        name: Publish Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
-        with:
-          junit_files: artifacts/**/*.xml
-          check_name: "Core / Unit Test"
-          comment_mode: "off"
 
   test-petals:
     name: Petals Compatibility

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -35,13 +35,16 @@ jobs:
           cache-environment: false
           cache-downloads: true
           cache-downloads-key: downloads-${{ matrix.os }}-py${{ matrix.python-version }}
-
       -
-        name: Import CLIMADA (bash)
-        run: python -c "import climada"
+        name: Test CLIMADA (bash)
         shell: bash -el {0}
+        run: |
+          python -c "import climada"
+          python -m unittest climada.engine.test.test_impact
       -
-        name: Import CLIMADA (powershell)
-        run: python -c "import climada"
+        name: Test CLIMADA (powershell)
         shell: pwsh
         if: ${{ matrix.os == 'windows-latest' }}
+        run: |
+          python -c "import climada"
+          python -m unittest climada.engine.test.test_impact

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -6,7 +6,6 @@ on:
   schedule:
      - cron: "0 6 * * *"
   workflow_dispatch:
-  push:  # TODO: Remove before merge!
 
 jobs:
   install-conda:

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -30,5 +30,12 @@ jobs:
           create-args: >-
             python=${{ matrix.python-version }}
             climada
-          cache-environment: false  # Recompute environment for each run
+          init-shell: bash powershell
+          # Recompute environment for each run, but possibly use cached downloads
+          cache-environment: false
           cache-downloads: true
+          cache-downloads-key: downloads-${{ matrix.os }}-py${{ matrix.python-version }}
+
+      -
+        name: Import CLIMADA
+        run: python -c "import climada"

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -14,8 +14,8 @@ jobs:
     timeout-minutes: 10
 
     strategy:
+      fail-fast: false
       matrix:
-        fail-fast: false
         python-version: ["3.10", "3.11", "3.12"]
         os: [ubuntu-latest, windows-latest, macos-latest]
 

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -37,5 +37,11 @@ jobs:
           cache-downloads-key: downloads-${{ matrix.os }}-py${{ matrix.python-version }}
 
       -
-        name: Import CLIMADA
+        name: Import CLIMADA (bash)
         run: python -c "import climada"
+        shell: bash -el {0}
+      -
+        name: Import CLIMADA (powershell)
+        run: python -c "import climada"
+        shell: pwsh
+        if: ${{ matrix.os == 'windows-latest' }}

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -1,0 +1,34 @@
+# Check if installation with conda/mamba works
+
+name: Install Test
+
+on:
+  schedule:
+     - cron: "0 6 * * *"
+  workflow_dispatch:
+  push:  # TODO: Remove before merge!
+
+jobs:
+  install-conda:
+    name: Install from Conda
+    timeout-minutes: 10
+
+    strategy:
+      matrix:
+        fail-fast: false
+        python-version: ["3.10", "3.11", "3.12"]
+        os: [ubuntu-latest, windows-latest, macos-latest]
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      -
+        name: Install with Mamba
+        uses: mamba-org/setup-micromamba@v2
+        with:
+          environment-name: climada_env_${{ matrix.python-version }}
+          create-args: >-
+            python=${{ matrix.python-version }}
+            climada
+          cache-environment: false  # Recompute environment for each run
+          cache-downloads: true


### PR DESCRIPTION
Changes proposed in this PR:
- Add a CI job script for a regular installation test of CLIMADA via Mamba
   - Install CLIMADA, and import it in Python. No tests are executed
- Execute this job every day at 6 am or manually upon user request (`workflow_dispatch`)

Notes:
- ~~**Remove `on: push` before merging!**~~ *done*
- Unit test results can get published to the wrong test suite (`Test Install / Core / Unit Test Results` instead of `GitHub CI / Core / Unit Test Results`). This is a known issue that currently cannot be fixed: https://github.com/EnricoMi/publish-unit-test-result-action/issues/12

This PR fixes #

### PR Author Checklist

- [x] Read the [Contribution Guide][contrib]
- [x] Correct target branch selected: **`main` because scheduled/triggered jobs only work from default branch**
- [x] Descriptive pull request title added
- [x] Source branch up-to-date with target branch
- [ ] [Documentation](https://climada-python.readthedocs.io/en/latest/guide/Guide_PythonDos-n-Donts.html#2.--Commenting-&-Documenting) updated
- [ ] [Tests][testing] updated
- [ ] [Tests][testing] passing
- [ ] No new [linter issues][linter]
- [ ] [Changelog](https://github.com/CLIMADA-project/climada_python/blob/main/CHANGELOG.md) updated

### PR Reviewer Checklist

- [ ] Read the [Contribution Guide][contrib]
- [ ] [CLIMADA Reviewer Checklist](https://climada-python.readthedocs.io/en/latest/development/Guide_Review.html) passed
- [ ] [Tests][testing] passing
- [ ] No new [linter issues][linter]

[contrib]: https://github.com/CLIMADA-project/climada_python/blob/main/CONTRIBUTING.md
[testing]: https://climada-python.readthedocs.io/en/latest/development/Guide_continuous_integration_GitHub_actions.html
[linter]: https://climada-python.readthedocs.io/en/latest/development/Guide_continuous_integration_GitHub_actions.html#static-code-analysis
