### PR TITLE
Fixes TypeError when casting arrays to scalar with Numpy>=2.4

### DIFF
--- a/climada/hazard/tc_tracks_synth.py
+++ b/climada/hazard/tc_tracks_synth.py
@@ -1049,7 +1049,7 @@ def _apply_decay_coeffs(track, v_rel, p_rel, land_geom, s_rel):
                 # if there is no further landfall, correct until the end of
                 # the track
                 end_cor = track["time"].size
-            rndn = 0.1 * float(np.abs(np.random.normal(size=1) * 5) + 6)
+            rndn = 0.1 * float(np.abs(np.random.default_rng().normal() * 5) + 6)
             r_diff = (
                 track["central_pressure"][land_sea].values
                 - track["central_pressure"][land_sea - 1].values

--- a/climada/util/hdf5_handler.py
+++ b/climada/util/hdf5_handler.py
@@ -89,7 +89,7 @@ def get_string(array):
     -------
     string
     """
-    return "".join(chr(int(c[0])) for c in array)
+    return "".join(chr(int(c.item())) for c in array)
 
 
 def get_str_from_ref(file_name, var):

--- a/climada/util/hdf5_handler.py
+++ b/climada/util/hdf5_handler.py
@@ -89,7 +89,7 @@ def get_string(array):
     -------
     string
     """
-    return "".join(chr(int(c)) for c in array)
+    return "".join(chr(int(c[0])) for c in array)
 
 
 def get_str_from_ref(file_name, var):

--- a/climada/util/hdf5_handler.py
+++ b/climada/util/hdf5_handler.py
@@ -89,7 +89,7 @@ def get_string(array):
     -------
     string
     """
-    return "".join(chr(int(c.item())) for c in array)
+    return "".join(chr(c.item()) for c in array)
 
 
 def get_str_from_ref(file_name, var):


### PR DESCRIPTION
Changes proposed in this PR:
Proper item access (or 0-dim array) before casting to float/int.

This PR fixes #1263 and partly #1204

### PR Author Checklist

- [ ] Read the [Contribution Guide][contrib]
- [ ] Correct target branch selected (if unsure, select `develop`)
- [ ] Descriptive pull request title added
- [ ] Source branch up-to-date with target branch
- [ ] [Documentation](https://climada-python.readthedocs.io/en/latest/guide/Guide_PythonDos-n-Donts.html#2.--Commenting-&-Documenting) updated
- [ ] [Tests][testing] updated
- [ ] [Tests][testing] passing
- [ ] No new [linter issues][linter]
- [ ] [Changelog](https://github.com/CLIMADA-project/climada_python/blob/main/CHANGELOG.md) updated

### PR Reviewer Checklist

- [ ] Read the [Contribution Guide][contrib]
- [ ] [CLIMADA Reviewer Checklist](https://climada-python.readthedocs.io/en/latest/development/Guide_Review.html) passed
- [ ] [Tests][testing] passing
- [ ] No new [linter issues][linter]

[contrib]: https://github.com/CLIMADA-project/climada_python/blob/main/CONTRIBUTING.md
[testing]: https://climada-python.readthedocs.io/en/latest/development/Guide_continuous_integration_GitHub_actions.html
[linter]: https://climada-python.readthedocs.io/en/latest/development/Guide_continuous_integration_GitHub_actions.html#static-code-analysis
