### PR TITLE
Fixes possible incorrect mapping between eai metric values and exposure points in trajectories

### DIFF
--- a/climada/trajectories/calc_risk_metrics.py
+++ b/climada/trajectories/calc_risk_metrics.py
@@ -255,7 +255,12 @@ class CalcRiskMetricsPoints:
 
         """
 
-        metric_df = pd.DataFrame(self.per_date_eai, index=self._date_idx)
+        metric_df = pd.DataFrame(
+            self.per_date_eai,
+            index=self._date_idx,
+            columns=self.snapshots[0].exposure.gdf.index,
+        )
+
         metric_df = metric_df.reset_index().melt(
             id_vars=DATE_COL_NAME, var_name=COORD_ID_COL_NAME, value_name=RISK_COL_NAME
         )
@@ -868,7 +873,11 @@ class CalcRiskMetricsPeriod:
         (notably for `value` and `group_id`).
 
         """
-        metric_df = pd.DataFrame(self.per_date_eai, index=self.date_idx)
+        metric_df = pd.DataFrame(
+            self.per_date_eai,
+            index=self._date_idx,
+            columns=self.snapshot_start.exposure.gdf.index,
+        )
         metric_df = metric_df.reset_index().melt(
             id_vars=DEFAULT_PERIOD_INDEX_NAME,
             var_name=COORD_ID_COL_NAME,


### PR DESCRIPTION
This PR fixes a bug in `calc_eai_gdf` (both for static and interpolated trajectories) where the exposure points coordinates are incorrectly mapped to the corresponding risk value when the exposure `GeoDataFrame` index is discontinuous.

The suggested fix directly uses the index, instead of creating it from a range.

### PR Author Checklist

- [x] Read the [Contribution Guide][contrib]
- [x] Correct target branch selected (if unsure, select `develop`)
- [x] Descriptive pull request title added
- [x] Source branch up-to-date with target branch
- [x] [Documentation](https://climada-python.readthedocs.io/en/latest/guide/Guide_PythonDos-n-Donts.html#2.--Commenting-&-Documenting) updated
- [x] [Tests][testing] updated
- [x] [Tests][testing] passing
- [X] No new [linter issues][linter]
- [ ] [Changelog](https://github.com/CLIMADA-project/climada_python/blob/main/CHANGELOG.md) updated

### PR Reviewer Checklist

- [ ] Read the [Contribution Guide][contrib]
- [ ] [CLIMADA Reviewer Checklist](https://climada-python.readthedocs.io/en/latest/development/Guide_Review.html) passed
- [ ] [Tests][testing] passing
- [ ] No new [linter issues][linter]

[contrib]: https://github.com/CLIMADA-project/climada_python/blob/main/CONTRIBUTING.md
[testing]: https://climada-python.readthedocs.io/en/latest/development/Guide_continuous_integration_GitHub_actions.html
[linter]: https://climada-python.readthedocs.io/en/latest/development/Guide_continuous_integration_GitHub_actions.html#static-code-analysis
