### PR TITLE
Handle 0-dim arrays being passed to ordinal converter

### DIFF
--- a/climada/hazard/xarray.py
+++ b/climada/hazard/xarray.py
@@ -94,7 +94,10 @@ def _date_to_ordinal_accessor(array: xr.DataArray, strict: bool = True) -> np.nd
             return _strict_positive_int_accessor(array)
 
         # Try transforming to ordinals
-        return np.array(u_dt.datetime64_to_ordinal(array.to_numpy()))
+        arr = array.to_numpy()
+        if arr.ndim == 0:
+            arr = np.array([arr])
+        return np.array(u_dt.datetime64_to_ordinal(arr))
 
     # Handle access errors
     except (ValueError, TypeError, AttributeError) as err:


### PR DESCRIPTION
Changes proposed in this PR:
- Explicitly cast scalar array to a 1-dim array before passing it to the datetime to ordinal converter function

I don't think this requires a test.

This resolves an issue that occurs in the GloFAS river flood module (https://github.com/CLIMADA-project/climada_petals/pull/167).

### PR Author Checklist

- [x] Read the [Contribution Guide][contrib]
- [x] Correct target branch selected (if unsure, select `develop`)
- [x] Descriptive pull request title added
- [x] Source branch up-to-date with target branch
- [ ] [Documentation](https://climada-python.readthedocs.io/en/latest/guide/Guide_PythonDos-n-Donts.html#2.--Commenting-&-Documenting) updated
- [ ] [Tests][testing] updated
- [ ] [Tests][testing] passing
- [ ] No new [linter issues][linter]
- [ ] [Changelog](https://github.com/CLIMADA-project/climada_python/blob/main/CHANGELOG.md) updated

### PR Reviewer Checklist

- [ ] Read the [Contribution Guide][contrib]
- [ ] [CLIMADA Reviewer Checklist](https://climada-python.readthedocs.io/en/latest/development/Guide_Review.html) passed
- [ ] [Tests][testing] passing
- [ ] No new [linter issues][linter]

[contrib]: https://github.com/CLIMADA-project/climada_python/blob/main/CONTRIBUTING.md
[testing]: https://climada-python.readthedocs.io/en/latest/development/Guide_continuous_integration_GitHub_actions.html
[linter]: https://climada-python.readthedocs.io/en/latest/development/Guide_continuous_integration_GitHub_actions.html#static-code-analysis
