### PR TITLE
Use Zenodo to host distance to coastline dataset

### DIFF
--- a/climada/conf/climada.conf
+++ b/climada/conf/climada.conf
@@ -52,7 +52,7 @@
     },
     "util": {
         "coordinates": {
-            "dist_to_coast_nasa_url": "https://oceancolor.gsfc.nasa.gov/docs/distfromcoast/GMT_intermediate_coast_distance_01d.zip",
+            "dist_to_coast_nasa_url": "https://zenodo.org/records/21130975/files/GMT_intermediate_coast_distance_01d.zip?download=1",
             "dist_to_coast_nasa_tif": "GMT_intermediate_coast_distance_01d.tif"
         }
     },


### PR DESCRIPTION
Changes proposed in this PR:
- Use Zenodo archive (https://zenodo.org/records/21130975) to download distance to coast dataset

This PR fixes #1299 

### PR Author Checklist

- [x] Read the [Contribution Guide][contrib]
- [x] Correct target branch selected (if unsure, select `develop`)
- [x] Descriptive pull request title added
- [x] Source branch up-to-date with target branch
- [ ] [Documentation](https://climada-python.readthedocs.io/en/latest/guide/Guide_PythonDos-n-Donts.html#2.--Commenting-&-Documenting) updated
- [ ] [Tests][testing] updated
- [x] [Tests][testing] passing
- [x] No new [linter issues][linter]
- [ ] [Changelog](https://github.com/CLIMADA-project/climada_python/blob/main/CHANGELOG.md) updated

### PR Reviewer Checklist

- [ ] Read the [Contribution Guide][contrib]
- [ ] [CLIMADA Reviewer Checklist](https://climada-python.readthedocs.io/en/latest/development/Guide_Review.html) passed
- [ ] [Tests][testing] passing
- [ ] No new [linter issues][linter]

[contrib]: https://github.com/CLIMADA-project/climada_python/blob/main/CONTRIBUTING.md
[testing]: https://climada-python.readthedocs.io/en/latest/development/Guide_continuous_integration_GitHub_actions.html
[linter]: https://climada-python.readthedocs.io/en/latest/development/Guide_continuous_integration_GitHub_actions.html#static-code-analysis
