### PR TITLE
Fix exposure coordinate extraction for `CalcDeltaImpact`

### DIFF
--- a/climada/engine/unsequa/calc_delta_climate.py
+++ b/climada/engine/unsequa/calc_delta_climate.py
@@ -281,7 +281,9 @@ class CalcDeltaImpact(Calc):
 
         if calc_eai_exp:
             exp = self.exp_final_input_var.evaluate()
-            coord_df = exp.gdf[["latitude", "longitude"]]
+            coord_df = pd.DataFrame.from_dict(
+                {"latitude": exp.latitude, "longitude": exp.longitude}
+            )
         else:
             coord_df = pd.DataFrame([])
 

--- a/climada/engine/unsequa/calc_delta_climate.py
+++ b/climada/engine/unsequa/calc_delta_climate.py
@@ -280,7 +280,7 @@ class CalcDeltaImpact(Calc):
         at_event_unc_df = pd.DataFrame(at_event_list)
 
         if calc_eai_exp:
-            exp = self.exp_input_var.evaluate()
+            exp = self.exp_final_input_var.evaluate()
             coord_df = exp.gdf[["latitude", "longitude"]]
         else:
             coord_df = pd.DataFrame([])


### PR DESCRIPTION
Changes proposed in this PR:
- Use the correct attribute for extracting the exposure coordinates in `CalcDeltaImpact`. Apparently, this is not covered by a test. I did **not** add one.


### PR Author Checklist

- [x] Read the [Contribution Guide][contrib]
- [x] Correct target branch selected (if unsure, select `develop`)
- [x] Descriptive pull request title added
- [x] Source branch up-to-date with target branch
- [ ] [Documentation](https://climada-python.readthedocs.io/en/latest/guide/Guide_PythonDos-n-Donts.html#2.--Commenting-&-Documenting) updated
- [ ] [Tests][testing] updated
- [ ] [Tests][testing] passing
- [ ] No new [linter issues][linter]
- [ ] [Changelog](https://github.com/CLIMADA-project/climada_python/blob/main/CHANGELOG.md) updated

### PR Reviewer Checklist

- [ ] Read the [Contribution Guide][contrib]
- [ ] [CLIMADA Reviewer Checklist](https://climada-python.readthedocs.io/en/latest/development/Guide_Review.html) passed
- [ ] [Tests][testing] passing
- [ ] No new [linter issues][linter]

[contrib]: https://github.com/CLIMADA-project/climada_python/blob/main/CONTRIBUTING.md
[testing]: https://climada-python.readthedocs.io/en/latest/development/Guide_continuous_integration_GitHub_actions.html
[linter]: https://climada-python.readthedocs.io/en/latest/development/Guide_continuous_integration_GitHub_actions.html#static-code-analysis
