### PR TITLE
Preserve mapped dates in HazardForecast.from_xarray_raster

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -37,3 +37,4 @@
 * Samuel Juhel
 * Valentin Gebhart
 * Dahyann Araya
+* Giovanni Cozzolongo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Code freeze date: YYYY-MM-DD
 
 ### Fixed
 
+- Preserve explicitly mapped dates in `HazardForecast.from_xarray_raster` [#1305](https://github.com/CLIMADA-project/climada_python/issues/1305).
 - Fixed asset count in impact logging message [#1195](https://github.com/CLIMADA-project/climada_python/pull/1195).
 - `Hazard.from_raster_xarray` now returns a sparse matrix instead of a sparse array [#1261](https://github.com/CLIMADA-project/climada_python/pull/1261).
 - Fix TCTracks.from_FAST duplicate loading from year loop [#1269](github.com/CLIMADA-project/climada_python/pull/1269)

--- a/climada/hazard/forecast.py
+++ b/climada/hazard/forecast.py
@@ -443,7 +443,8 @@ class HazardForecast(ForecastMixin, Hazard):
         data_vars : dict(str, str), optional
             Mapping from default variable names to variable names used in the data
             to read. See :py:meth:`~climada.hazard.io.HazardIO.from_xarray_raster` for
-            details.
+            details. To load forecast dates, map ``date`` to the corresponding
+            variable. Dates default to 0 when no date mapping is provided.
         crs : str, optional
             Coordinate reference system identifier. Defaults to "EPSG:4326".
         rechunk : bool, optional
@@ -537,7 +538,8 @@ class HazardForecast(ForecastMixin, Hazard):
             f"lt_{lt / np.timedelta64(1, 'h'):.0f}h_m_{m}"
             for lt, m in zip(kwargs["lead_time"], kwargs["member"])
         ]
-        kwargs["date"] = np.zeros_like(kwargs["date"], dtype=int)
+        if not (data_vars or {}).get("date"):
+            kwargs["date"] = np.zeros_like(kwargs["date"], dtype=int)
 
         # Convert to HazardForecast with forecast attributes
         return cls(**Hazard._check_and_cast_attrs(kwargs))

--- a/climada/hazard/test/test_forecast.py
+++ b/climada/hazard/test/test_forecast.py
@@ -187,6 +187,7 @@ class TestXarrayReader:
             "n_lat": n_lat,
             "n_lon": n_lon,
             "eps": eps,
+            "ref_time": ref_time[0],
             "lead_time": lead_time_vals,
             "lon": lon,
             "lat": lat,
@@ -263,9 +264,10 @@ class TestXarrayReader:
         ]
         npt.assert_array_equal(haz_fc.event_name, event_names_expected)
 
+    @pytest.mark.parametrize("data_vars", [None, {"date": ""}])
     @xarray_leadtime
-    def test_from_xarray_raster_dates(self, forecast_netcdf_file):
-        """Test that dates are set to 0 for forecast events"""
+    def test_from_xarray_raster_dates(self, forecast_netcdf_file, data_vars):
+        """Test that dates default to 0 when no date coordinate is mapped"""
         haz_fc = HazardForecast.from_xarray_raster(
             forecast_netcdf_file["path"],
             hazard_type="PR",
@@ -276,6 +278,7 @@ class TestXarrayReader:
                 "lead_time": "lead_time",
                 "member": "eps",
             },
+            data_vars=data_vars,
             crs=forecast_netcdf_file["crs"],
         )
 
@@ -284,6 +287,29 @@ class TestXarrayReader:
             forecast_netcdf_file["n_eps"] * forecast_netcdf_file["n_lead_time"]
         )
         npt.assert_array_equal(haz_fc.date, np.zeros(expected_n_events, dtype=int))
+
+    @xarray_leadtime
+    def test_from_xarray_raster_dates_from_data(self, forecast_netcdf_file):
+        """Test that an explicitly mapped date coordinate is preserved"""
+        haz_fc = HazardForecast.from_xarray_raster(
+            forecast_netcdf_file["path"],
+            hazard_type="PR",
+            intensity_unit="mm/h",
+            coordinate_vars={
+                "longitude": "lon",
+                "latitude": "lat",
+                "lead_time": "lead_time",
+                "member": "eps",
+            },
+            data_vars={"date": "valid_time"},
+            crs=forecast_netcdf_file["crs"],
+        )
+
+        expected_dates = [
+            pd.Timestamp(forecast_netcdf_file["ref_time"] + lead_time).toordinal()
+            for lead_time in haz_fc.lead_time
+        ]
+        npt.assert_array_equal(haz_fc.date, expected_dates)
 
 
 class TestSelect:


### PR DESCRIPTION
Changes proposed in this PR:
- Preserve dates loaded from an explicit `date` entry in `data_vars`.
- Keep zero-valued forecast dates when no date mapping is supplied, with regression coverage for both paths.

This PR fixes #1305

Tests:
- `python -m pytest -q climada/hazard/test/test_forecast.py` (56 passed)
- `python -m pytest -q climada/hazard/test/test_xarray.py climada/hazard/test/test_io.py` (18 passed)
- `pre-commit run --files AUTHORS.md CHANGELOG.md climada/hazard/forecast.py climada/hazard/test/test_forecast.py`
- `pylint climada/hazard/forecast.py climada/hazard/test/test_forecast.py` (9.35/10, unchanged)

### PR Author Checklist

- [x] Read the [Contribution Guide][contrib]
- [x] Correct target branch selected (if unsure, select `develop`)
- [x] Descriptive pull request title added
- [x] Source branch up-to-date with target branch
- [x] [Documentation](https://climada-python.readthedocs.io/en/latest/guide/Guide_PythonDos-n-Donts.html#2.--Commenting-&-Documenting) updated
- [x] [Tests][testing] updated
- [x] [Tests][testing] passing
- [x] No new [linter issues][linter]
- [x] [Changelog](https://github.com/CLIMADA-project/climada_python/blob/main/CHANGELOG.md) updated

### PR Reviewer Checklist

- [ ] Read the [Contribution Guide][contrib]
- [ ] [CLIMADA Reviewer Checklist](https://climada-python.readthedocs.io/en/latest/development/Guide_Review.html) passed
- [ ] [Tests][testing] passing
- [ ] No new [linter issues][linter]

[contrib]: https://github.com/CLIMADA-project/climada_python/blob/main/CONTRIBUTING.md
[testing]: https://climada-python.readthedocs.io/en/latest/development/Guide_continuous_integration_GitHub_actions.html
[linter]: https://climada-python.readthedocs.io/en/latest/development/Guide_continuous_integration_GitHub_actions.html#static-code-analysis