### PR TITLE
perf: compute forecast quantiles block-wise to bound memory

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -38,3 +38,4 @@
 * Valentin Gebhart
 * Dahyann Araya
 * Giovanni Cozzolongo
+* Thomas Struys

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Code freeze date: YYYY-MM-DD
 
 - Updated Impact Calculation Tutorial (`doc.climada_engine_Impact.ipynb`) [#1095](https://github.com/CLIMADA-project/climada_python/pull/1095).
 - Makes current `measure` module a legacy module, moving it to `_legacy_measure`, to retain compatibility with `CostBenefit` class and various tests. [#1274](https://github.com/CLIMADA-project/climada_python/pull/1274)
+- `HazardForecast.quantile` and `ImpactForecast.quantile` compute quantiles block-wise instead of densifying the entire sparse matrix, greatly reducing peak memory. Results are unchanged. [#1203](https://github.com/CLIMADA-project/climada_python/issues/1203)
 
 ### Fixed
 

--- a/climada/engine/impact_forecast.py
+++ b/climada/engine/impact_forecast.py
@@ -28,7 +28,11 @@ from scipy import sparse
 
 from ..util import log_level
 from ..util.checker import size
-from ..util.forecast import ForecastMixin, reduce_unique_selection
+from ..util.forecast import (
+    ForecastMixin,
+    reduce_unique_selection,
+    sparse_quantile_axis0,
+)
 from .impact import Impact
 
 LOGGER = logging.getLogger(__name__)
@@ -445,7 +449,8 @@ class ImpactForecast(ForecastMixin, Impact):
                     concat_kws={"reset_event_ids": True},
                 )
 
-        red_imp_mat = sparse.csr_matrix(np.quantile(self.imp_mat.toarray(), q, axis=0))
+        # block-wise to avoid densifying the whole impact matrix
+        red_imp_mat = sparse.csr_matrix(sparse_quantile_axis0(self.imp_mat, q))
         red_at_event = np.array([red_imp_mat.sum()])
         if event_name is None:
             event_name = f"quantile_{q}"

--- a/climada/engine/impact_forecast.py
+++ b/climada/engine/impact_forecast.py
@@ -449,7 +449,6 @@ class ImpactForecast(ForecastMixin, Impact):
                     concat_kws={"reset_event_ids": True},
                 )
 
-        # block-wise to avoid densifying the whole impact matrix
         red_imp_mat = sparse.csr_matrix(sparse_quantile_axis0(self.imp_mat, q))
         red_at_event = np.array([red_imp_mat.sum()])
         if event_name is None:

--- a/climada/engine/test/test_impact_forecast.py
+++ b/climada/engine/test/test_impact_forecast.py
@@ -19,11 +19,13 @@ with CLIMADA. If not, see <https://www.gnu.org/licenses/>.
 Tests for Impact Forecast.
 """
 
+from unittest.mock import patch
+
 import numpy as np
 import numpy.testing as npt
 import pandas as pd
 import pytest
-from scipy.sparse import csr_matrix
+from scipy.sparse import csc_matrix, csr_matrix
 
 from climada.engine import Impact, ImpactForecast
 
@@ -469,27 +471,15 @@ class TestReduce:
         )
 
 
-def test_quantile_does_not_densify(impact_forecast):
-    """quantile must not densify the whole impact matrix
-
-    The result must still equal the dense reference, so this pins both halves
-    of the fix: same answer, without the full-size temporary.
-    """
+def test_quantile_uses_block_wise_helper(impact_forecast):
+    """quantile routes through the block-wise helper and keeps the same result"""
     expected = np.quantile(impact_forecast.imp_mat.toarray(), 0.5, axis=0)
 
-    full_shape = impact_forecast.imp_mat.shape
-    densified = []
-    original = csr_matrix.toarray
-
-    def spy(self, *args, **kwargs):
-        densified.append(self.shape)
-        return original(self, *args, **kwargs)
-
-    csr_matrix.toarray = spy
-    try:
+    # the helper converts to CSC first, so csc_matrix is what densifies
+    with patch.object(
+        csc_matrix, "toarray", autospec=True, side_effect=csc_matrix.toarray
+    ) as spy:
         reduced = impact_forecast.quantile(0.5)
-    finally:
-        csr_matrix.toarray = original
 
-    assert full_shape not in densified, f"full matrix densified: {densified}"
-    npt.assert_allclose(reduced.imp_mat.toarray().squeeze(), expected)
+    assert spy.call_args_list, "quantile did not go through the block-wise helper"
+    npt.assert_array_equal(reduced.imp_mat.toarray().squeeze(), expected)

--- a/climada/engine/test/test_impact_forecast.py
+++ b/climada/engine/test/test_impact_forecast.py
@@ -467,3 +467,29 @@ class TestReduce:
             imp_fc_reduced.at_event,
             reduction_results_dim[dim][attr]["at_event"],
         )
+
+
+def test_quantile_does_not_densify(impact_forecast):
+    """quantile must not densify the whole impact matrix
+
+    The result must still equal the dense reference, so this pins both halves
+    of the fix: same answer, without the full-size temporary.
+    """
+    expected = np.quantile(impact_forecast.imp_mat.toarray(), 0.5, axis=0)
+
+    full_shape = impact_forecast.imp_mat.shape
+    densified = []
+    original = csr_matrix.toarray
+
+    def spy(self, *args, **kwargs):
+        densified.append(self.shape)
+        return original(self, *args, **kwargs)
+
+    csr_matrix.toarray = spy
+    try:
+        reduced = impact_forecast.quantile(0.5)
+    finally:
+        csr_matrix.toarray = original
+
+    assert full_shape not in densified, f"full matrix densified: {densified}"
+    npt.assert_allclose(reduced.imp_mat.toarray().squeeze(), expected)

--- a/climada/engine/test/test_impact_forecast.py
+++ b/climada/engine/test/test_impact_forecast.py
@@ -25,9 +25,10 @@ import numpy as np
 import numpy.testing as npt
 import pandas as pd
 import pytest
-from scipy.sparse import csc_matrix, csr_matrix
+from scipy.sparse import csr_matrix
 
 from climada.engine import Impact, ImpactForecast
+from climada.util.forecast import sparse_quantile_axis0
 
 from .test_impact import impact_kwargs as imp_kwargs
 
@@ -472,14 +473,18 @@ class TestReduce:
 
 
 def test_quantile_uses_block_wise_helper(impact_forecast):
-    """quantile routes through the block-wise helper and keeps the same result"""
+    """quantile passes the impact matrix itself to the block-wise helper"""
     expected = np.quantile(impact_forecast.imp_mat.toarray(), 0.5, axis=0)
 
-    # the helper converts to CSC first, so csc_matrix is what densifies
-    with patch.object(
-        csc_matrix, "toarray", autospec=True, side_effect=csc_matrix.toarray
-    ) as spy:
+    # wraps, so the real helper still runs and the result stays checkable
+    with patch(
+        "climada.engine.impact_forecast.sparse_quantile_axis0",
+        wraps=sparse_quantile_axis0,
+    ) as helper:
         reduced = impact_forecast.quantile(0.5)
 
-    assert spy.call_args_list, "quantile did not go through the block-wise helper"
+    helper.assert_called_once()
+    matrix, q = helper.call_args.args
+    assert matrix is impact_forecast.imp_mat
+    assert q == 0.5
     npt.assert_array_equal(reduced.imp_mat.toarray().squeeze(), expected)

--- a/climada/hazard/forecast.py
+++ b/climada/hazard/forecast.py
@@ -256,7 +256,6 @@ class HazardForecast(ForecastMixin, Hazard):
                 q=q,
             )
 
-        # block-wise: densifying the whole matrix exhausts memory
         red_intensity = sparse.csr_matrix(sparse_quantile_axis0(self.intensity, q))
         red_fraction = sparse.csr_matrix(sparse_quantile_axis0(self.fraction, q))
         if event_name is None:

--- a/climada/hazard/forecast.py
+++ b/climada/hazard/forecast.py
@@ -32,7 +32,11 @@ import climada.util.constants as u_const
 from climada.hazard.base import Hazard
 from climada.hazard.xarray import HazardXarrayReader
 from climada.util.checker import size
-from climada.util.forecast import ForecastMixin, reduce_unique_selection
+from climada.util.forecast import (
+    ForecastMixin,
+    reduce_unique_selection,
+    sparse_quantile_axis0,
+)
 
 LOGGER = logging.getLogger(__name__)
 
@@ -236,7 +240,6 @@ class HazardForecast(ForecastMixin, Hazard):
             **self._reduce_attrs("mean"),
         )
 
-    # TODO: Do not densify the entire matrix but compute quantiles column-wise!
     def _quantile(
         self,
         q: float,
@@ -253,12 +256,9 @@ class HazardForecast(ForecastMixin, Hazard):
                 q=q,
             )
 
-        red_intensity = sparse.csr_matrix(
-            np.quantile(self.intensity.toarray(), q, axis=0)
-        )
-        red_fraction = sparse.csr_matrix(
-            np.quantile(self.fraction.toarray(), q, axis=0)
-        )
+        # block-wise: densifying the whole matrix exhausts memory
+        red_intensity = sparse.csr_matrix(sparse_quantile_axis0(self.intensity, q))
+        red_fraction = sparse.csr_matrix(sparse_quantile_axis0(self.fraction, q))
         if event_name is None:
             event_name = f"quantile_{q}"
         return HazardForecast(

--- a/climada/hazard/test/test_forecast.py
+++ b/climada/hazard/test/test_forecast.py
@@ -20,6 +20,7 @@ Tests for Hazard Forecast.
 """
 
 import datetime as dt
+from unittest.mock import patch
 
 import numpy as np
 import numpy.testing as npt
@@ -31,6 +32,7 @@ from scipy.sparse import csr_matrix
 from climada.hazard.base import Hazard
 from climada.hazard.forecast import HazardForecast, xarray_has_timedelta_bug
 from climada.hazard.test.test_base import hazard_kwargs
+from climada.util.forecast import sparse_quantile_axis0
 
 # See https://docs.xarray.dev/en/stable/whats-new.html#id80
 xarray_leadtime = pytest.mark.skipif(
@@ -531,6 +533,25 @@ class TestReduce:
         npt.assert_array_equal(
             haz_fcst_median.intensity.todense(),
             np.median(haz_fc.intensity.todense(), axis=0),
+        )
+
+    def test_quantile_uses_block_wise_helper(self, haz_fc):
+        """quantile passes intensity and fraction themselves to the block-wise helper"""
+        # wraps, so the real helper still runs and the result stays checkable
+        with patch(
+            "climada.hazard.forecast.sparse_quantile_axis0",
+            wraps=sparse_quantile_axis0,
+        ) as helper:
+            reduced = haz_fc.quantile(0.5)
+
+        assert helper.call_count == 2
+        intensity_call, fraction_call = helper.call_args_list
+        assert intensity_call.args[0] is haz_fc.intensity
+        assert fraction_call.args[0] is haz_fc.fraction
+        assert intensity_call.args[1] == fraction_call.args[1] == 0.5
+        npt.assert_array_equal(
+            reduced.intensity.toarray().squeeze(),
+            np.quantile(haz_fc.intensity.toarray(), 0.5, axis=0),
         )
 
     @pytest.mark.parametrize("attr", ["min", "mean", "max", "median", "quantile"])

--- a/climada/util/forecast.py
+++ b/climada/util/forecast.py
@@ -206,7 +206,7 @@ def reduce_unique_selection(
 def sparse_quantile_axis0(
     matrix: sparse.spmatrix,
     q: np.typing.ArrayLike,
-    max_memory_mb: float = 8.0,
+    max_memory_mb: float = 64.0,
 ) -> np.ndarray:
     """Quantile along axis 0 of a sparse matrix, without densifying it whole.
 
@@ -226,7 +226,7 @@ def sparse_quantile_axis0(
     max_memory_mb : float, optional
         Approximate memory budget for a single densified block, in megabytes.
         At least one column is always densified, so a budget too small for a
-        single column still works. Default: 8.0.
+        single column still works. Default: 64.0.
 
     Returns
     -------

--- a/climada/util/forecast.py
+++ b/climada/util/forecast.py
@@ -22,6 +22,7 @@ Define ForecastMixin class.
 from typing import Any, Literal, Mapping
 
 import numpy as np
+from scipy import sparse
 
 
 class ForecastMixin:
@@ -200,3 +201,43 @@ def reduce_unique_selection(
         ],
         **concat_kws,
     )
+
+
+def sparse_quantile_axis0(
+    matrix: sparse.spmatrix, q: float, block_size: int = 1024
+) -> np.ndarray:
+    """Quantile along axis 0 of a sparse matrix, without densifying it whole.
+
+    Equivalent to ``np.quantile(matrix.toarray(), q, axis=0)``, but densifies
+    at most ``block_size`` columns at a time, so peak memory scales with
+    ``block_size * n_rows`` instead of with the full matrix.
+
+    Implicit zeros take part in the quantile: a column with three implicit
+    zeros and two stored values is a five-element sample, not a two-element
+    one.
+
+    Parameters
+    ----------
+    matrix : scipy.sparse.spmatrix
+        Matrix to reduce, of shape (n_rows, n_cols).
+    q : float
+        Quantile to compute, between 0 and 1.
+    block_size : int, optional
+        Number of columns densified per step. Larger values are marginally
+        faster and use proportionally more memory. Default: 1024, chosen
+        because raising it to 4096 measured 2.7 times the peak memory for
+        only 7 percent less runtime.
+
+    Returns
+    -------
+    np.ndarray
+        1-D array of length ``matrix.shape[1]``.
+    """
+    n_cols = matrix.shape[1]
+    csc = matrix.tocsc()  # columns are the slow slicing direction for CSR
+    quantiles = np.empty(n_cols, dtype=np.float64)
+    for start in range(0, n_cols, block_size):
+        stop = min(start + block_size, n_cols)
+        block = csc[:, start:stop].toarray()
+        quantiles[start:stop] = np.quantile(block, q, axis=0, overwrite_input=True)
+    return quantiles

--- a/climada/util/forecast.py
+++ b/climada/util/forecast.py
@@ -240,8 +240,9 @@ def sparse_quantile_axis0(
     column_bytes = max(n_rows * csc.dtype.itemsize, 1)
     block = max(int(max_memory_mb * 1e6) // column_bytes, 1)
 
-    # np.quantile sorts its input, so it copies unless allowed not to. Each block
-    # is a throwaway nothing else references, so let it sort in place and save a copy.
+    # np.quantile sorts its input, so it copies unless allowed not to. Each block is
+    # a throwaway nothing else references, so it can be sorted in place: skipping the
+    # per-block copy measured about twice as fast, at no cost in peak memory.
     return np.concatenate(
         [
             np.quantile(

--- a/climada/util/forecast.py
+++ b/climada/util/forecast.py
@@ -204,40 +204,50 @@ def reduce_unique_selection(
 
 
 def sparse_quantile_axis0(
-    matrix: sparse.spmatrix, q: float, block_size: int = 1024
+    matrix: sparse.spmatrix,
+    q: np.typing.ArrayLike,
+    max_memory_mb: float = 8.0,
 ) -> np.ndarray:
     """Quantile along axis 0 of a sparse matrix, without densifying it whole.
 
     Equivalent to ``np.quantile(matrix.toarray(), q, axis=0)``, but densifies
-    at most ``block_size`` columns at a time, so peak memory scales with
-    ``block_size * n_rows`` instead of with the full matrix.
+    only as many columns at a time as fit into ``max_memory_mb``, so peak
+    memory no longer scales with the number of columns.
 
-    Implicit zeros take part in the quantile: a column with three implicit
-    zeros and two stored values is a five-element sample, not a two-element
-    one.
+    Implicit zeros count as values: a column of ``[0, 0, 0, -1, 9]`` has median
+    ``0.0``, not the ``4.0`` given by its two stored values alone.
 
     Parameters
     ----------
     matrix : scipy.sparse.spmatrix
         Matrix to reduce, of shape (n_rows, n_cols).
-    q : float
-        Quantile to compute, between 0 and 1.
-    block_size : int, optional
-        Number of columns densified per step. Larger values are marginally
-        faster and use proportionally more memory. Default: 1024, chosen
-        because raising it to 4096 measured 2.7 times the peak memory for
-        only 7 percent less runtime.
+    q : float or array_like of float
+        Quantile or sequence of quantiles, each between 0 and 1.
+    max_memory_mb : float, optional
+        Approximate memory budget for a single densified block, in megabytes.
+        At least one column is always densified, so a budget too small for a
+        single column still works. Default: 8.0.
 
     Returns
     -------
     np.ndarray
-        1-D array of length ``matrix.shape[1]``.
+        Quantiles along axis 0, shaped as ``np.quantile`` would return them.
     """
-    n_cols = matrix.shape[1]
-    csc = matrix.tocsc()  # columns are the slow slicing direction for CSR
-    quantiles = np.empty(n_cols, dtype=np.float64)
-    for start in range(0, n_cols, block_size):
-        stop = min(start + block_size, n_cols)
-        block = csc[:, start:stop].toarray()
-        quantiles[start:stop] = np.quantile(block, q, axis=0, overwrite_input=True)
-    return quantiles
+    csc = matrix.tocsc()
+    n_rows, n_cols = csc.shape
+    if n_cols == 0:
+        return np.quantile(csc.toarray(), q, axis=0)
+    column_bytes = max(n_rows * csc.dtype.itemsize, 1)
+    block = max(int(max_memory_mb * 1e6) // column_bytes, 1)
+
+    # np.quantile sorts its input, so it copies unless allowed not to. Each block
+    # is a throwaway nothing else references, so let it sort in place and save a copy.
+    return np.concatenate(
+        [
+            np.quantile(
+                csc[:, start : start + block].toarray(), q, axis=0, overwrite_input=True
+            )
+            for start in range(0, n_cols, block)
+        ],
+        axis=-1,
+    )

--- a/climada/util/test/test_forecast.py
+++ b/climada/util/test/test_forecast.py
@@ -19,11 +19,13 @@ with CLIMADA. If not, see <https://www.gnu.org/licenses/>.
 Tests for ForecastMixin class.
 """
 
+from unittest.mock import patch
+
 import numpy as np
 import numpy.testing as npt
 import pandas as pd
 import pytest
-from scipy.sparse import csr_matrix
+from scipy.sparse import csc_matrix, csr_matrix
 
 from climada.util.forecast import ForecastMixin, sparse_quantile_axis0
 
@@ -98,36 +100,46 @@ def test_idx_lead_time():
 
 
 class TestSparseQuantile:
-    """Block-wise sparse quantile helper"""
+    """Block-wise sparse quantile helper (issue #1203)"""
 
     @pytest.mark.parametrize("q", [0.0, 0.25, 0.5, 0.9, 1.0])
-    @pytest.mark.parametrize("block_size", [1, 3, 1000])
-    def test_matches_dense_quantile(self, q, block_size):
+    # 1e-9 forces one column per block, 5e-4 gives 3 columns so the last block
+    # is a partial remainder, 10.0 takes the whole matrix in one block
+    @pytest.mark.parametrize("max_memory_mb", [1e-9, 5e-4, 10.0])
+    def test_matches_dense_quantile(self, q, max_memory_mb):
         """Block-wise result must equal the dense reference exactly"""
         rng = np.random.default_rng(0)
         dense = rng.random((20, 37))
         dense[dense < 0.7] = 0.0  # sparse, with implicit zeros dominating
         mat = csr_matrix(dense)
-        result = sparse_quantile_axis0(mat, q, block_size=block_size)
-        npt.assert_allclose(result, np.quantile(dense, q, axis=0))
+        npt.assert_array_equal(
+            sparse_quantile_axis0(mat, q, max_memory_mb=max_memory_mb),
+            np.quantile(dense, q, axis=0),
+        )
 
     def test_counts_implicit_zeros(self):
         """A column of [0,0,0,-1,9] has median 0, not 4 (the stored-only answer)"""
         mat = csr_matrix(np.array([[0.0], [0.0], [0.0], [-1.0], [9.0]]))
-        npt.assert_allclose(sparse_quantile_axis0(mat, 0.5), [0.0])
+        npt.assert_array_equal(sparse_quantile_axis0(mat, 0.5), [0.0])
 
     def test_negative_values(self):
         """Negative stored values must not be confused with implicit zeros"""
         dense = np.array([[-3.0, 0.0], [0.0, -1.0], [2.0, 0.0]])
-        mat = csr_matrix(dense)
-        npt.assert_allclose(
-            sparse_quantile_axis0(mat, 0.5), np.quantile(dense, 0.5, axis=0)
+        npt.assert_array_equal(
+            sparse_quantile_axis0(csr_matrix(dense), 0.5),
+            np.quantile(dense, 0.5, axis=0),
         )
 
     def test_all_zero_column(self):
         """An entirely empty column yields zero, not NaN"""
-        mat = csr_matrix((4, 3))
-        npt.assert_allclose(sparse_quantile_axis0(mat, 0.5), np.zeros(3))
+        npt.assert_array_equal(
+            sparse_quantile_axis0(csr_matrix((4, 3)), 0.5), np.zeros(3)
+        )
+
+    def test_single_row(self):
+        """One event: the quantile is that event's values for any q"""
+        dense = np.array([[5.0, 0.0, -2.0]])
+        npt.assert_array_equal(sparse_quantile_axis0(csr_matrix(dense), 0.3), dense[0])
 
     @pytest.mark.parametrize("q", [-0.1, 1.5])
     def test_quantile_out_of_range(self, q):
@@ -136,29 +148,50 @@ class TestSparseQuantile:
         with pytest.raises(ValueError, match="Quantiles must be in the range"):
             sparse_quantile_axis0(mat, q)
 
-    def test_single_row(self):
-        """One event: the quantile is that event's values for any q"""
-        dense = np.array([[5.0, 0.0, -2.0]])
-        mat = csr_matrix(dense)
-        npt.assert_allclose(sparse_quantile_axis0(mat, 0.3), [5.0, 0.0, -2.0])
+    def test_no_columns(self):
+        """A matrix with no columns yields an empty result, not an error"""
+        npt.assert_array_equal(
+            sparse_quantile_axis0(csr_matrix((5, 0)), 0.5), np.empty(0)
+        )
 
-    def test_does_not_densify_whole_matrix(self):
-        """The full matrix must never be passed to toarray() (issue #1203)"""
+    @pytest.mark.parametrize("dtype", [np.float32, np.float64])
+    def test_preserves_dtype(self, dtype):
+        """The result dtype must match the dense reference, not be forced to float64"""
+        dense = np.array([[1, 0], [0, 2], [3, 0]], dtype=dtype)
+        result = sparse_quantile_axis0(csr_matrix(dense), 0.5)
+        assert result.dtype == np.quantile(dense, 0.5, axis=0).dtype
+
+    def test_multiple_quantiles(self):
+        """A sequence of quantiles returns one row per quantile, as np.quantile does"""
+        dense = np.array([[1.0, 0.0], [0.0, 2.0]])
+        npt.assert_array_equal(
+            sparse_quantile_axis0(csr_matrix(dense), [0.25, 0.75]),
+            np.quantile(dense, [0.25, 0.75], axis=0),
+        )
+
+    @pytest.mark.parametrize("max_memory_mb", [0.0, -1.0, 1e-12])
+    def test_degenerate_memory_budget(self, max_memory_mb):
+        """A useless budget must still give the right answer, never uninitialised memory"""
+        dense = np.array([[1.0, 0.0], [0.0, 2.0], [4.0, 3.0]])
+        npt.assert_array_equal(
+            sparse_quantile_axis0(csr_matrix(dense), 0.5, max_memory_mb=max_memory_mb),
+            np.quantile(dense, 0.5, axis=0),
+        )
+
+    def test_densifies_blocks_not_whole_matrix(self):
+        """Only column blocks are densified, never the full matrix (issue #1203)"""
         dense = np.zeros((6, 12))
         dense[1, 3] = 4.0
         dense[4, 9] = -2.0
         mat = csr_matrix(dense)
-        densified = []
-        original = csr_matrix.toarray
+        # the helper converts to CSC first, so csc_matrix is what densifies
+        with patch.object(
+            csc_matrix, "toarray", autospec=True, side_effect=csc_matrix.toarray
+        ) as spy:
+            sparse_quantile_axis0(mat, 0.5, max_memory_mb=1e-9)
 
-        def spy(self, *args, **kwargs):
-            densified.append(self.shape)
-            return original(self, *args, **kwargs)
-
-        csr_matrix.toarray = spy
-        try:
-            sparse_quantile_axis0(mat, 0.5, block_size=4)
-        finally:
-            csr_matrix.toarray = original
-
-        assert mat.shape not in densified, f"full matrix densified: {densified}"
+        densified = [call.args[0].shape for call in spy.call_args_list]
+        assert densified, "no densification seen at all: the spy is not wired up"
+        assert (
+            max(shape[1] for shape in densified) < mat.shape[1]
+        ), f"a block covered every column: {densified}"

--- a/climada/util/test/test_forecast.py
+++ b/climada/util/test/test_forecast.py
@@ -22,8 +22,10 @@ Tests for ForecastMixin class.
 import numpy as np
 import numpy.testing as npt
 import pandas as pd
+import pytest
+from scipy.sparse import csr_matrix
 
-from climada.util.forecast import ForecastMixin
+from climada.util.forecast import ForecastMixin, sparse_quantile_axis0
 
 
 def test_forecast_init():
@@ -93,3 +95,70 @@ def test_idx_lead_time():
 
     idx = forecast.idx_lead_time(None)
     npt.assert_array_equal(idx, np.array([False, False, False, False]), strict=True)
+
+
+class TestSparseQuantile:
+    """Block-wise sparse quantile helper"""
+
+    @pytest.mark.parametrize("q", [0.0, 0.25, 0.5, 0.9, 1.0])
+    @pytest.mark.parametrize("block_size", [1, 3, 1000])
+    def test_matches_dense_quantile(self, q, block_size):
+        """Block-wise result must equal the dense reference exactly"""
+        rng = np.random.default_rng(0)
+        dense = rng.random((20, 37))
+        dense[dense < 0.7] = 0.0  # sparse, with implicit zeros dominating
+        mat = csr_matrix(dense)
+        result = sparse_quantile_axis0(mat, q, block_size=block_size)
+        npt.assert_allclose(result, np.quantile(dense, q, axis=0))
+
+    def test_counts_implicit_zeros(self):
+        """A column of [0,0,0,-1,9] has median 0, not 4 (the stored-only answer)"""
+        mat = csr_matrix(np.array([[0.0], [0.0], [0.0], [-1.0], [9.0]]))
+        npt.assert_allclose(sparse_quantile_axis0(mat, 0.5), [0.0])
+
+    def test_negative_values(self):
+        """Negative stored values must not be confused with implicit zeros"""
+        dense = np.array([[-3.0, 0.0], [0.0, -1.0], [2.0, 0.0]])
+        mat = csr_matrix(dense)
+        npt.assert_allclose(
+            sparse_quantile_axis0(mat, 0.5), np.quantile(dense, 0.5, axis=0)
+        )
+
+    def test_all_zero_column(self):
+        """An entirely empty column yields zero, not NaN"""
+        mat = csr_matrix((4, 3))
+        npt.assert_allclose(sparse_quantile_axis0(mat, 0.5), np.zeros(3))
+
+    @pytest.mark.parametrize("q", [-0.1, 1.5])
+    def test_quantile_out_of_range(self, q):
+        """An out-of-range quantile must raise, not return nonsense"""
+        mat = csr_matrix(np.array([[1.0, 0.0], [0.0, 2.0]]))
+        with pytest.raises(ValueError, match="Quantiles must be in the range"):
+            sparse_quantile_axis0(mat, q)
+
+    def test_single_row(self):
+        """One event: the quantile is that event's values for any q"""
+        dense = np.array([[5.0, 0.0, -2.0]])
+        mat = csr_matrix(dense)
+        npt.assert_allclose(sparse_quantile_axis0(mat, 0.3), [5.0, 0.0, -2.0])
+
+    def test_does_not_densify_whole_matrix(self):
+        """The full matrix must never be passed to toarray() (issue #1203)"""
+        dense = np.zeros((6, 12))
+        dense[1, 3] = 4.0
+        dense[4, 9] = -2.0
+        mat = csr_matrix(dense)
+        densified = []
+        original = csr_matrix.toarray
+
+        def spy(self, *args, **kwargs):
+            densified.append(self.shape)
+            return original(self, *args, **kwargs)
+
+        csr_matrix.toarray = spy
+        try:
+            sparse_quantile_axis0(mat, 0.5, block_size=4)
+        finally:
+            csr_matrix.toarray = original
+
+        assert mat.shape not in densified, f"full matrix densified: {densified}"


### PR DESCRIPTION
Changes proposed in this PR:
- Add `climada.util.forecast.sparse_quantile_axis0`, which takes a quantile along axis 0 of a sparse matrix by densifying a block of columns at a time rather than the whole matrix. The block size is derived from a `max_memory_mb` budget.
- Call it from `HazardForecast._quantile` (intensity and fraction) and `ImpactForecast._quantile` (imp_mat), replacing the `.toarray()` on the full matrix.

This PR fixes #1203

Peak memory no longer scales with the number of centroids. Measured on a full DWD ICON-EU-EPS run, 2560 events x 164,984 cells, float32, with [[icon_full.py](https://github.com/user-attachments/files/31507435/icon_full.py)](https://github.com/user-attachments/files/31507435/icon_full.py) :

```
old    8110.9 ms (best of 3)   peak   3382.3 MB
new    2375.7 ms (best of 3)   peak    280.5 MB
```

The script asserts the two paths return equal arrays on every run.

One constraint worth flagging: implicit zeros have to take part in the quantile. A column of `[0, 0, 0, -1, 9]` has median 0.0, not the 4.0 you get from its two stored values. That is why the helper densifies blocks instead of reducing over `matrix.data`, which would be faster but silently wrong.
